### PR TITLE
feat: Paginate library products (#23)

### DIFF
--- a/app/purchase/[id].tsx
+++ b/app/purchase/[id].tsx
@@ -1,4 +1,3 @@
-import { usePurchases } from "@/app/(tabs)/library";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledWebView } from "@/components/styled";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
@@ -7,6 +6,7 @@ import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { buildApiUrl } from "@/lib/request";
+import { usePurchase } from "@/lib/use-purchases";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
@@ -49,12 +49,10 @@ const shareFile = async (uri: string) => {
 export default function DownloadScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [isDownloading, setIsDownloading] = useState(false);
-  const { data: purchases = [] } = usePurchases();
+  const purchase = usePurchase(id);
   const router = useRouter();
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
-
-  const purchase = purchases.find((p) => p.url_redirect_token === id);
   const url = `${env.EXPO_PUBLIC_GUMROAD_URL}/d/${id}?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`;
 
   const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);

--- a/components/use-library-filters.ts
+++ b/components/use-library-filters.ts
@@ -1,4 +1,4 @@
-import { Purchase } from "@/app/(tabs)/library";
+import { Purchase } from "@/lib/use-purchases";
 import { useMemo, useState } from "react";
 
 export type SortOption = "content_updated_at" | "purchased_at";

--- a/lib/use-purchases.ts
+++ b/lib/use-purchases.ts
@@ -1,0 +1,61 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { assertDefined } from "./assert";
+import { useAuth } from "./auth-context";
+import { requestAPI, UnauthorizedError } from "./request";
+
+export interface Purchase {
+  name: string;
+  creator_name: string;
+  creator_username: string;
+  creator_profile_picture_url: string;
+  thumbnail_url: string | null;
+  url_redirect_token: string;
+  purchase_email: string;
+  purchase_id?: string;
+  is_archived?: boolean;
+  content_updated_at?: string;
+  purchased_at?: string;
+  file_data?: {
+    id: string;
+    name: string;
+    filegroup?: string;
+    streaming_url?: string;
+  }[];
+}
+
+interface PurchasesResponse {
+  success: boolean;
+  products: Purchase[];
+  user_id: string;
+}
+
+const PER_PAGE = 24;
+
+export const usePurchases = () => {
+  const { accessToken, logout, isLoading: isAuthLoading } = useAuth();
+
+  const query = useInfiniteQuery<PurchasesResponse, Error, Purchase[], string[], number>({
+    queryKey: ["purchases"],
+    queryFn: ({ pageParam }) =>
+      requestAPI<PurchasesResponse>(`mobile/purchases/index?per_page=${PER_PAGE}&page=${pageParam}`, {
+        accessToken: assertDefined(accessToken),
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) =>
+      lastPage.products.length < PER_PAGE ? undefined : lastPageParam + 1,
+    select: (data) => data.pages.flatMap((page) => page.products),
+    enabled: !!accessToken,
+  });
+
+  useEffect(() => {
+    if ((!isAuthLoading && !accessToken) || query.error instanceof UnauthorizedError) logout();
+  }, [isAuthLoading, accessToken, query.error, logout]);
+
+  return query;
+};
+
+export const usePurchase = (id: string) => {
+  const { data: purchases = [] } = usePurchases();
+  return purchases.find((p) => p.url_redirect_token === id);
+};

--- a/tests/components/use-library-filters.test.ts
+++ b/tests/components/use-library-filters.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from "@testing-library/react-native";
 import { useLibraryFilters } from "@/components/use-library-filters";
-import { Purchase } from "@/app/(tabs)/library";
+import { Purchase } from "@/lib/use-purchases";
 
 const makePurchase = (overrides: Partial<Purchase> = {}): Purchase => ({
   name: "Test Product",

--- a/tests/lib/use-purchases.test.ts
+++ b/tests/lib/use-purchases.test.ts
@@ -1,0 +1,126 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockRequestAPI = jest.fn();
+jest.mock("@/lib/request", () => ({
+  requestAPI: (...args: unknown[]) => mockRequestAPI(...args),
+  UnauthorizedError: class extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "UnauthorizedError";
+    }
+  },
+}));
+
+const mockLogout = jest.fn();
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    accessToken: "test-token",
+    logout: mockLogout,
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/lib/assert", () => ({
+  assertDefined: <T>(value: T) => value,
+}));
+
+import { usePurchases, usePurchase, Purchase } from "@/lib/use-purchases";
+
+const makePurchase = (overrides: Partial<Purchase> = {}): Purchase => ({
+  name: "Test Product",
+  creator_name: "Test Creator",
+  creator_username: "testcreator",
+  creator_profile_picture_url: "https://example.com/pic.jpg",
+  thumbnail_url: null,
+  url_redirect_token: "token123",
+  purchase_email: "test@example.com",
+  ...overrides,
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe("usePurchases", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches the first page of purchases", async () => {
+    const products = [makePurchase({ url_redirect_token: "a" })];
+    mockRequestAPI.mockResolvedValue({ success: true, products, user_id: "u1" });
+
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.data).toHaveLength(1);
+    expect(mockRequestAPI).toHaveBeenCalledWith(
+      expect.stringContaining("per_page=24&page=1"),
+      expect.objectContaining({ accessToken: "test-token" }),
+    );
+  });
+
+  it("has next page when a full page is returned", async () => {
+    const products = Array.from({ length: 24 }, (_, i) =>
+      makePurchase({ url_redirect_token: `token-${i}` }),
+    );
+    mockRequestAPI.mockResolvedValue({ success: true, products, user_id: "u1" });
+
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("has no next page when a partial page is returned", async () => {
+    const products = [makePurchase({ url_redirect_token: "a" })];
+    mockRequestAPI.mockResolvedValue({ success: true, products, user_id: "u1" });
+
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.data).toBeDefined());
+
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("flattens multiple pages into a single array", async () => {
+    const page1 = Array.from({ length: 24 }, (_, i) =>
+      makePurchase({ url_redirect_token: `p1-${i}`, name: `Product ${i}` }),
+    );
+    const page2 = [makePurchase({ url_redirect_token: "p2-0", name: "Last Product" })];
+
+    mockRequestAPI
+      .mockResolvedValueOnce({ success: true, products: page1, user_id: "u1" })
+      .mockResolvedValueOnce({ success: true, products: page2, user_id: "u1" });
+
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.data).toHaveLength(24));
+
+    await result.current.fetchNextPage();
+    await waitFor(() => expect(result.current.data).toHaveLength(25));
+
+    expect(result.current.data![24].name).toBe("Last Product");
+  });
+});
+
+describe("usePurchase", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the purchase matching the given id", async () => {
+    const products = [
+      makePurchase({ url_redirect_token: "aaa", name: "First" }),
+      makePurchase({ url_redirect_token: "bbb", name: "Second" }),
+    ];
+    mockRequestAPI.mockResolvedValue({ success: true, products, user_id: "u1" });
+
+    const { result } = renderHook(() => usePurchase("bbb"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current).toBeDefined());
+
+    expect(result.current?.name).toBe("Second");
+  });
+});


### PR DESCRIPTION
Issue: #23                                  
                                                                                                                                                                                                   
  ## Problem
                                                                                                                                                                                                   
  The library fetches all purchases in a single request with no pagination params. For users with large libraries this blocks the UI and loads excessive data upfront.                           
                                                                                                                                                                                                   
  ## Solution                                                                                                                                                                                      

  Replaced `useQuery` with `useInfiniteQuery` from React Query (already in package.json). The app now hits `mobile/purchases/index?per_page=24&page=N`, loading products in pages of 24 as the user scrolls. A loading spinner appears at the bottom while the next page fetches.

  Extracted `Purchase` type and the hook into `lib/use-purchases.ts` so both the library screen and the purchase detail page share the same paginated cache. The detail page gets a `usePurchase(id)` helper that looks up a single purchase from the flattened pages.

  All filtering, sorting, and search stay client-side on the accumulated pages — `useLibraryFilters` receives the same flat `Purchase[]` as before. Creator filter counts update progressively as pages load. This avoids depending on a new backend endpoint.

  Session expiry handling mirrors `useAPIRequest` exactly — calls `logout()` on 401 or missing token. Pull-to-refresh re-fetches all loaded pages.

  Page size of 24 gives 12 rows per page in the 2-column grid. Good balance of initial load speed vs scroll depth before the next fetch.

  ## Screenshots

  ### Before — light mode (no pagination, all products load at once)


https://github.com/user-attachments/assets/54b36f7d-6071-4b4f-88af-58b428d72f01


  ### Before — dark mode (no pagination, all products load at once)

https://github.com/user-attachments/assets/f70f08cc-6581-4e82-a84a-702c9064c353

  Page size was set to 2 for the after demos to make pagination clearly visible. Production value is 24.

  ### After — light mode (products load in pages as user scrolls)

https://github.com/user-attachments/assets/ca9c5c0b-dbac-44eb-94ef-5800baff4c53


  ### After — dark mode

https://github.com/user-attachments/assets/1d056e2f-2c2b-47d3-8a78-e11d804e2804




  ### Test results
  5 suites, 55 tests (5 new), all passing.
<img width="1792" height="997" alt="Screenshot 2026-02-19 at 2 26 30 PM" src="https://github.com/user-attachments/assets/e4ff3973-c4e3-4246-b60c-c88e6ef52656" />


  ## Checklist

  - [x] I have read the contributing guidelines
  - [x] I have performed a self-review
  - [x] I have added/updated tests for my changes
  - [x] Screenshots attached

  ## AI disclosure

  Model: Claude Opus 4.6 via Claude Code CLI

  Used for:
  - Analyzing the existing request infrastructure and React Query setup
  - Running test suites, type checking
  - Identifying edge cases (session expiry, deep link with empty cache)

  Implementation direction and architectural decisions were my own. Client-side filtering on accumulated pages, `useInfiniteQuery` over custom pagination, page size selection, and the decision to avoid backend dependencies. All code reviewed line-by-line before committing.
