### PR TITLE
feat: Replace browser login with native email/password form (#24)

### DIFF
--- a/.maestro/login-screen.yaml
+++ b/.maestro/login-screen.yaml
@@ -2,24 +2,9 @@ appId: ${APP_ID}
 ---
 - runFlow:
     file: utils/launch.yaml
-- tapOn: Sign in with Gumroad
-# Tap through the iOS "Sign in with gumroad.dev?" prompt
-- runFlow:
-    when:
-      visible: Continue
-    commands:
-      - tapOn: Continue
-# The browser state isn't cleared when the app cache is cleared, so we may still be logged in from a previous session
-- runFlow:
-    when:
-      visible: Logout
-    commands:
-      - tapOn: Logout
-- scrollUntilVisible:
-    element: Login
 - tapOn: Email
 - inputText: mobile_buyer_do_not_edit@gumroad.com
-- pressKey: enter # Form validation auto-focuses the password field
+- pressKey: enter
 - inputText: password
 - pressKey: enter
 # Tap through the iOS password manager prompt
@@ -28,12 +13,4 @@ appId: ${APP_ID}
       visible: Not Now
     commands:
       - tapOn: Not Now
-# 2FA prompt will trigger if it hasn't already been completed
-- runFlow:
-    when:
-      visible: Authentication Token
-    commands:
-      - tapOn: Login
-- assertVisible: Authorize
-- tapOn: Authorize
 - assertVisible: Library

--- a/.maestro/utils/launch.yaml
+++ b/.maestro/utils/launch.yaml
@@ -28,4 +28,4 @@ appId: ${APP_ID}
     commands:
       - tapOn:
           point: 50%,10%
-- assertVisible: "Sign in with Gumroad"
+- assertVisible: "Log in"

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,38 +1,107 @@
+import { LineIcon } from "@/components/icon";
+import { StyledImage } from "@/components/styled";
+import { Alert, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
+import { env } from "@/lib/env";
 import { Redirect } from "expo-router";
 import * as WebBrowser from "expo-web-browser";
-import { useEffect } from "react";
-import { View } from "react-native";
-import { useUniwind } from "uniwind";
+import { useRef, useState } from "react";
+import { KeyboardAvoidingView, Platform, TextInput, View } from "react-native";
+import { useCSSVariable, useUniwind } from "uniwind";
 import logoDark from "../assets/images/logo-dark.svg";
 import logoLight from "../assets/images/logo.svg";
-import { StyledImage } from "../components/styled";
-import { useAuth } from "../lib/auth-context";
+
+const forgotPasswordUrl = `${env.EXPO_PUBLIC_GUMROAD_URL}/forgot_password`;
 
 export default function LoginScreen() {
   const { isAuthenticated, isLoading, login } = useAuth();
   const { theme } = useUniwind();
+  const mutedColor = useCSSVariable("--color-muted") as string;
 
-  useEffect(() => {
-    // Speeds up opening the browser for the auth flow on Android
-    WebBrowser.warmUpAsync();
-
-    return () => {
-      WebBrowser.coolDownAsync();
-    };
-  }, []);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const passwordRef = useRef<TextInput>(null);
 
   if (isAuthenticated) return <Redirect href="/" />;
 
-  return (
-    <View className="flex-1 items-center justify-center gap-12 bg-background px-6">
-      <StyledImage source={theme === "dark" ? logoDark : logoLight} className="aspect-158/22 w-50" />
+  const handleLogin = async () => {
+    if (!email.trim() || !password) return;
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await login(email.trim(), password);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Login failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
-      <Button variant="accent" onPress={login} disabled={isLoading}>
-        {isLoading ? <LoadingSpinner size="small" /> : <Text>Sign in with Gumroad</Text>}
-      </Button>
-    </View>
+  const isDisabled = isLoading || isSubmitting;
+
+  return (
+    <KeyboardAvoidingView className="flex-1 bg-background" behavior={Platform.OS === "ios" ? "padding" : "height"}>
+      <View className="flex-1 items-center justify-center gap-8 px-6">
+        <StyledImage source={theme === "dark" ? logoDark : logoLight} className="aspect-158/22 w-50" />
+
+        <View className="w-full max-w-sm gap-4">
+          {error && (
+            <Alert variant="destructive" icon={<LineIcon name="error" size={20} className="text-destructive" />}>
+              <AlertTitle>{error}</AlertTitle>
+            </Alert>
+          )}
+
+          <View className="rounded border border-border bg-background px-3 py-2">
+            <TextInput
+              className="font-sans text-base text-foreground"
+              placeholder="Email"
+              placeholderTextColor={mutedColor}
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="email-address"
+              textContentType="emailAddress"
+              autoComplete="email"
+              returnKeyType="next"
+              onSubmitEditing={() => passwordRef.current?.focus()}
+              editable={!isDisabled}
+              testID="email-input"
+            />
+          </View>
+
+          <View className="rounded border border-border bg-background px-3 py-2">
+            <TextInput
+              ref={passwordRef}
+              className="font-sans text-base text-foreground"
+              placeholder="Password"
+              placeholderTextColor={mutedColor}
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              textContentType="password"
+              autoComplete="password"
+              returnKeyType="go"
+              onSubmitEditing={handleLogin}
+              editable={!isDisabled}
+              testID="password-input"
+            />
+          </View>
+
+          <Button variant="accent" onPress={handleLogin} disabled={isDisabled || !email.trim() || !password}>
+            {isSubmitting ? <LoadingSpinner size="small" /> : <Text>Log in</Text>}
+          </Button>
+
+          <Button variant="link" onPress={() => WebBrowser.openBrowserAsync(forgotPasswordUrl)} disabled={isDisabled}>
+            <Text>Forgot password?</Text>
+          </Button>
+        </View>
+      </View>
+    </KeyboardAvoidingView>
   );
 }

--- a/tests/app/login.test.tsx
+++ b/tests/app/login.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { act } from "react";
+
+jest.mock("react-native-webview", () => ({ WebView: "WebView" }));
+
+const mockLogin = jest.fn();
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    login: mockLogin,
+  }),
+}));
+
+jest.mock("expo-router", () => ({
+  Redirect: () => null,
+}));
+
+jest.mock("expo-web-browser", () => ({
+  openBrowserAsync: jest.fn(),
+}));
+
+jest.mock("uniwind", () => ({
+  useUniwind: () => ({ theme: "light" }),
+  useCSSVariable: () => "#8a8a8a",
+  withUniwind: (component: unknown) => component,
+}));
+
+import LoginScreen from "@/app/login";
+
+describe("LoginScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogin.mockResolvedValue(undefined);
+  });
+
+  it("renders email and password inputs", () => {
+    render(<LoginScreen />);
+    expect(screen.getByPlaceholderText("Email")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Password")).toBeTruthy();
+  });
+
+  it("renders the login button", () => {
+    render(<LoginScreen />);
+    expect(screen.getByText("Log in")).toBeTruthy();
+  });
+
+  it("calls login with email and password on submit", async () => {
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Email"), "user@example.com");
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "password123");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(mockLogin).toHaveBeenCalledWith("user@example.com", "password123");
+  });
+
+  it("does not call login when email is empty", async () => {
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "password123");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it("does not call login when password is empty", async () => {
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Email"), "user@example.com");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it("displays error message when login fails", async () => {
+    mockLogin.mockRejectedValue(new Error("Invalid email or password"));
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Email"), "user@example.com");
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "wrong");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(screen.getByText("Invalid email or password")).toBeTruthy();
+  });
+
+  it("clears error on next submission attempt", async () => {
+    mockLogin.mockRejectedValueOnce(new Error("Invalid email or password")).mockResolvedValueOnce(undefined);
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Email"), "user@example.com");
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "wrong");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(screen.getByText("Invalid email or password")).toBeTruthy();
+
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "correct");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(screen.queryByText("Invalid email or password")).toBeNull();
+  });
+
+  it("opens forgot password page in browser", () => {
+    const WebBrowser = require("expo-web-browser");
+    render(<LoginScreen />);
+    fireEvent.press(screen.getByText("Forgot password?"));
+    expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(expect.stringContaining("/forgot_password"));
+  });
+
+  it("trims whitespace from email before login", async () => {
+    render(<LoginScreen />);
+    fireEvent.changeText(screen.getByPlaceholderText("Email"), "  user@example.com  ");
+    fireEvent.changeText(screen.getByPlaceholderText("Password"), "password");
+    await act(async () => {
+      fireEvent.press(screen.getByText("Log in"));
+    });
+    expect(mockLogin).toHaveBeenCalledWith("user@example.com", "password");
+  });
+});

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import React from "react";
+
+const mockSetItemAsync = jest.fn();
+const mockGetItemAsync = jest.fn();
+const mockDeleteItemAsync = jest.fn();
+jest.mock("expo-secure-store", () => ({
+  setItemAsync: (...args: unknown[]) => mockSetItemAsync(...args),
+  getItemAsync: (...args: unknown[]) => mockGetItemAsync(...args),
+  deleteItemAsync: (...args: unknown[]) => mockDeleteItemAsync(...args),
+}));
+
+const mockReplace = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+const mockRequest = jest.fn();
+jest.mock("@/lib/request", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+import { AuthProvider, useAuth } from "@/lib/auth-context";
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(AuthProvider, null, children);
+
+describe("login", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItemAsync.mockResolvedValue(null);
+    mockRequest.mockResolvedValue({ products: [] });
+  });
+
+  it("exchanges email and password for tokens and stores them", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: "new-token", refresh_token: "new-refresh" }),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login("user@example.com", "password123");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/oauth/token"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"grant_type":"password"'),
+      }),
+    );
+    expect(mockSetItemAsync).toHaveBeenCalledWith("gumroad_access_token", "new-token");
+    expect(mockSetItemAsync).toHaveBeenCalledWith("gumroad_refresh_token", "new-refresh");
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("checks creator status after login", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: "creator-token" }),
+    });
+    mockRequest.mockResolvedValue({ products: [{ id: "1" }] });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login("creator@example.com", "pass");
+    });
+
+    expect(result.current.isCreator).toBe(true);
+  });
+
+  it("throws a friendly message on invalid credentials", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "invalid_grant", error_description: "The provided authorization grant is invalid." }),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(act(() => result.current.login("user@example.com", "wrong"))).rejects.toThrow(
+      "Invalid email or password",
+    );
+  });
+
+  it("throws a generic message when error response is not JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(act(() => result.current.login("user@example.com", "wrong"))).rejects.toThrow(
+      "Login failed. Please try again.",
+    );
+  });
+
+  it("propagates network errors", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Network request failed"));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(act(() => result.current.login("user@example.com", "pass"))).rejects.toThrow(
+      "Network request failed",
+    );
+  });
+});
+
+describe("stored auth", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequest.mockResolvedValue({ products: [] });
+  });
+
+  it("loads stored token on mount and sets isAuthenticated", async () => {
+    mockGetItemAsync.mockResolvedValue("stored-token");
+    mockRequest.mockResolvedValue({ products: [{ id: "1" }] });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isCreator).toBe(true);
+  });
+
+  it("remains unauthenticated when no stored token exists", async () => {
+    mockGetItemAsync.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});
+
+describe("logout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetItemAsync.mockResolvedValue(null);
+    mockRequest.mockResolvedValue({ products: [] });
+  });
+
+  it("clears tokens and navigates to login", async () => {
+    mockGetItemAsync.mockResolvedValue("stored-token");
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(mockDeleteItemAsync).toHaveBeenCalledWith("gumroad_access_token");
+    expect(mockDeleteItemAsync).toHaveBeenCalledWith("gumroad_refresh_token");
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(mockReplace).toHaveBeenCalledWith("/login");
+  });
+});


### PR DESCRIPTION
Issue: #24

## Problem

Login opens a system browser for the full OAuth flow. Users leave the app, enter credentials on a web page, handle 2FA prompts, tap Authorize, and bounce back. Works, but feels wrong for a native app.

## Solution

Native email/password form using Doorkeeper's `grant_type: password`. POST credentials directly to `/oauth/token`, get tokens back, never leave the app.

Uses raw `fetch` instead of the `request()` helper because we need to parse Doorkeeper's structured error JSON (`{ error: "invalid_grant" }`) for user-friendly messages. Keyboard navigation works properly (return on email focuses password, return on password submits). Inputs disable during submission. "Forgot password?" opens the web reset flow in-app since that's inherently web-based.

Removed `expo-auth-session` entirely. Login signature changed from `login()` to `login(email, password)`. Token storage, creator status, logout, and refresh are untouched.

## 2FA

The password grant skips 2FA since it's handled in the web session layer (cookies, IP trust, email OTP). The `resource_owner_from_credentials` block returns tokens once the password is valid.

Native 2FA would need a backend endpoint. All the pieces exist in the codebase (`two_factor_authentication.rb`, `send_authentication_token!`, `token_authenticated?`), they just need wiring into a mobile-friendly endpoint. Happy to open that as a follow-up. Roughly:

```ruby
class Api::Mobile::AuthController < Api::Mobile::BaseController
  skip_before_action :doorkeeper_authorize!

  def login
    user = User.alive.where("username = ? OR email = ?", params[:email], params[:email]).first
    return render json: { error: "invalid_credentials" }, status: :unauthorized unless user&.valid_password?(params[:password])

    if user.two_factor_authentication_enabled && !user.skip_two_factor_authentication?(request)
      if params[:otp].present?
        return render json: { error: "invalid_otp" }, status: :unauthorized unless user.token_authenticated?(params[:otp])
      else
        user.send_authentication_token!
        return render json: { two_factor_required: true }
      end
    end

    token = Doorkeeper::AccessToken.create!(resource_owner_id: user.id, scopes: "mobile_api creator_api", use_refresh_token: true)
    render json: { access_token: token.token, refresh_token: token.refresh_token }
  end
end
```

On the mobile side, detect `{ two_factor_required: true }`, show a native OTP screen, resubmit with the code.

## Biometric integration

Pairs with #32 naturally. Biometric login uses `refreshToken()` which is untouched here. Only change needed in that PR: update the login call from `login()` to `login(email, password)` and keep the biometric button alongside the form. Native form for new sessions, biometrics for fast return. No conflicts.

## Changes

**Modified (4):** `lib/auth-context.tsx` (password grant via fetch), `app/login.tsx` (native form), `.maestro/login-screen.yaml` (simplified E2E), `.maestro/utils/launch.yaml` (button text assertion)

**Created (2):** `tests/lib/auth-context.test.tsx` (8 tests), `tests/app/login.test.tsx` (9 tests)

## Demo                                     
                                          
  ### Before (browser popup)
                                                                                                                                                                                                   
  **Light**
                                                                                                                                                                                                   
  https://github.com/user-attachments/assets/9820d679-dc1c-4a35-ba77-543fdb2a62ba           

  **Dark**

  https://github.com/user-attachments/assets/fd19f5a6-db93-433d-8d0d-ce952b70f543

  ### After (native form)

  **Light**

  https://github.com/user-attachments/assets/083b1b60-9ec4-4c41-bfa6-538a7cf5ffaa

  **Dark**

  https://github.com/user-attachments/assets/83cb9000-5031-40eb-829c-17762b8e6926


## Test results

6 suites, 67 tests, all passing.

<img width="1549" height="984" alt="Screenshot 2026-02-19 at 9 09 08 PM" src="https://github.com/user-attachments/assets/e2cdcb18-4039-43cf-8f9a-bd41680360de" />


## Checklist

- [x] I have read the contributing guidelines
- [x] I have performed a self-review
- [x] I have added/updated tests for my changes
- [x] Screenshots attached

## AI disclosure

Model: Claude Opus 4.6 via Claude Code CLI

Used for: analyzing the auth context and Doorkeeper config, running tests and type checks, researching the 2FA architecture.

Architecture and implementation decisions were mine. All code reviewed before committing.
