### PR TITLE
Feat : Update to Boxicons v3

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -81,7 +81,7 @@ const SettingsSheet = () => {
           <Text className="mb-4 text-sm text-muted-foreground">This will log you out of your Gumroad account.</Text>
           <Button onPress={handleLogout}>
             <Text>Logout</Text>
-            <LineIcon name="log-out" size={20} className="text-primary-foreground" />
+            <LineIcon name="door-open" size={20} className="text-primary-foreground" />
           </Button>
         </View>
         <View className="border-b border-border p-4">
@@ -92,7 +92,7 @@ const SettingsSheet = () => {
           </Text>
           <Button variant="destructive" onPress={handleDeleteAccount}>
             <Text>Go to account deletion page</Text>
-            <LineIcon name="right-arrow-alt" size={20} className="text-destructive-foreground" />
+            <LineIcon name="arrow-right-stroke" size={20} className="text-destructive-foreground" />
           </Button>
         </View>
       </SheetContent>
@@ -166,7 +166,7 @@ export default function TabsLayout() {
               title: "Analytics",
               headerLeft: () => <LogoIcon />,
               headerRight: () => <LibraryHeaderRight />,
-              tabBarIcon: ({ color, size }) => <SolidIcon name="bar-chart-alt-2" size={size} color={color} />,
+              tabBarIcon: ({ color, size }) => <SolidIcon name="bar-chart-big" size={size} color={color} />,
               href: isCreator ? undefined : null,
             }}
           />

--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -81,7 +81,7 @@ export default function PdfViewerScreen() {
                 {viewMode === "continuous" ? (
                   <LineIcon name="move-vertical" size={24} className="text-accent" />
                 ) : (
-                  <SolidIcon name="carousel" size={24} className="text-accent" />
+                  <SolidIcon name="gallery-horizontal" size={24} className="text-accent" />
                 )}
               </TouchableOpacity>
             </View>
@@ -147,7 +147,7 @@ export default function PdfViewerScreen() {
             className="flex-row items-center justify-between border-b border-border py-4"
           >
             <View className="flex-row items-center gap-3">
-              <SolidIcon name="carousel" size={24} className="text-foreground" />
+              <SolidIcon name="gallery-horizontal" size={24} className="text-foreground" />
               <Text className="text-base text-foreground">Single Page</Text>
             </View>
             {viewMode === "single" && <LineIcon name="check" size={24} className="text-accent" />}

--- a/components/analytics/chart-container.tsx
+++ b/components/analytics/chart-container.tsx
@@ -25,7 +25,7 @@ export const ChartContainer = ({
       children
     ) : (
       <View className="h-38 flex-row items-center justify-center gap-2">
-        <SolidIcon name="bar-chart-alt-2" className="text-muted" size={16} />
+        <SolidIcon name="bar-chart-big" className="text-muted" size={16} />
         <Text className="text-muted">{emptyMessage}</Text>
       </View>
     )}

--- a/components/icon.tsx
+++ b/components/icon.tsx
@@ -1,12 +1,61 @@
-import createIconSet from "@expo/vector-icons/build/createIconSet";
-import fontAsset from "boxicons/fonts/boxicons.ttf";
+import { type ComponentType, forwardRef } from "react";
+import { StyleSheet, type StyleProp, type TextStyle, type ViewStyle } from "react-native";
+import Svg, { Path, Rect } from "react-native-svg";
 import { withUniwind } from "uniwind";
-import { lineGlyphMap, logoGlyphMap, solidGlyphMap } from "./icons-generated";
+import { type IconPack, iconData } from "./icons-generated";
 
-const BaseLineIcon = createIconSet(lineGlyphMap, "boxicons", fontAsset);
-const BaseSolidIcon = createIconSet(solidGlyphMap, "boxicons", fontAsset);
-const BaseLogoIcon = createIconSet(logoGlyphMap, "boxicons", fontAsset);
+interface IconProps {
+  name: string;
+  size?: number;
+  color?: string;
+  style?: StyleProp<TextStyle>;
+}
 
-export const LineIcon = withUniwind(BaseLineIcon);
-export const SolidIcon = withUniwind(BaseSolidIcon);
-export const LogoIcon = withUniwind(BaseLogoIcon);
+const svgComponents: Record<string, ComponentType<Record<string, unknown>>> = {
+  path: Path as ComponentType<Record<string, unknown>>,
+  rect: Rect as ComponentType<Record<string, unknown>>,
+};
+
+const kebabToCamel = (s: string) =>
+  s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+
+const BaseIcon = forwardRef<Svg, IconProps & { pack: IconPack }>(
+  ({ name, pack, size = 24, color, style, ...props }, ref) => {
+    const icon = iconData[name]?.[pack];
+    if (!icon) return null;
+
+    const flatStyle = StyleSheet.flatten(style);
+    const fill = color ?? flatStyle?.color ?? "black";
+
+    return (
+      <Svg
+        ref={ref}
+        viewBox={icon.viewBox}
+        width={size}
+        height={size}
+        style={style as StyleProp<ViewStyle>}
+        {...props}
+      >
+        {icon.elements.map((el, i) => {
+          const Component = svgComponents[el.tag];
+          if (!Component) return null;
+          const rnProps = Object.fromEntries(
+            Object.entries(el.attrs).map(([k, v]) => [kebabToCamel(k), v]),
+          );
+          return <Component key={i} fill={fill} {...rnProps} />;
+        })}
+      </Svg>
+    );
+  },
+);
+
+const createPackIcon = (pack: IconPack) => {
+  const PackIcon = forwardRef<Svg, IconProps>((props, ref) => (
+    <BaseIcon ref={ref} pack={pack} {...props} />
+  ));
+  return withUniwind(PackIcon);
+};
+
+export const LineIcon = createPackIcon("basic");
+export const SolidIcon = createPackIcon("filled");
+export const LogoIcon = createPackIcon("brands");

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@rn-primitives/select": "^1.2.0",
         "@rn-primitives/slot": "^1.2.0",
         "@tanstack/react-query": "^5.90.16",
-        "boxicons": "^2.1.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "expo": "~54.0.30",
@@ -64,6 +63,7 @@
         "uniwind": "^1.2.4"
       },
       "devDependencies": {
+        "@boxicons/react": "^1.0.3",
         "@tailwindcss/postcss": "^4.1.18",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29",
@@ -1590,6 +1590,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@boxicons/react": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@boxicons/react/-/react-1.0.3.tgz",
+      "integrity": "sha512-NASJNbk4X6Xi24CIa/Anx7KhMH1KPiBuaq0RJq3HJiFg65Ct9mhIB6j/a/Ciz/ZOTGaGzisWYmbU4jdKKK/YYA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -5527,12 +5537,6 @@
         "@urql/core": "^5.0.0"
       }
     },
-    "node_modules/@webcomponents/webcomponentsjs": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.8.0.tgz",
-      "integrity": "sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -6250,59 +6254,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
-    },
-    "node_modules/boxicons": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/boxicons/-/boxicons-2.1.4.tgz",
-      "integrity": "sha512-BvJNfYfnE4g9WQ7GL91fftxMOTwAleWlPFwvQJPYb/Ju7aLjlQ/Eu55AH9JLNk/OR82z+ZSq4TbKzbV/e5Rr0A==",
-      "license": "(CC-BY-4.0 OR OFL-1.1 OR MIT)",
-      "dependencies": {
-        "@webcomponents/webcomponentsjs": "^2.0.2",
-        "prop-types": "^15.6.0",
-        "react": "^16.0.0",
-        "react-dom": "^16.0.0",
-        "react-interactive": "^0.8.1",
-        "react-router-dom": "^4.2.2"
-      }
-    },
-    "node_modules/boxicons/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/boxicons/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/boxicons/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
@@ -7332,24 +7283,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/detect-hover": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-hover/-/detect-hover-1.0.3.tgz",
-      "integrity": "sha512-HtLoY+tClgYucJNiovNICGWFp9nOGVmHY44s7L62iPqORXM9vujeWFaVcqtA7XRvp/2Y+4RBUfHbDKFGN+xxZQ==",
-      "license": "MIT"
-    },
-    "node_modules/detect-it": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/detect-it/-/detect-it-3.0.7.tgz",
-      "integrity": "sha512-RxpgcdbatUX6epJE09K16iJqF7x6iEcEdoL18FR2zpBO4JhnL7aMOAUoUEyexdtbWOSfTmoDWmeD6mwRBQyRXg==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-hover": "^1.0.3",
-        "detect-passive-events": "^1.0.5",
-        "detect-pointer": "^1.0.3",
-        "detect-touch-events": "^2.0.2"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7373,24 +7306,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
-      "license": "MIT"
-    },
-    "node_modules/detect-passive-events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/detect-passive-events/-/detect-passive-events-1.0.5.tgz",
-      "integrity": "sha512-foW7Q35wwOCxVzW0xLf5XeB5Fhe7oyRgvkBYdiP9IWgLMzjqUqTvsJv9ymuEWGjY6AoDXD3OC294+Z9iuOw0QA==",
-      "license": "MIT"
-    },
-    "node_modules/detect-pointer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-pointer/-/detect-pointer-1.0.3.tgz",
-      "integrity": "sha512-d0o/Puo3fiGSCXy6H039h9Kwz+mmYCGKZ/qtPFnpN3WfsumjC1C9b5KKvRu+aYnfdI8peqN/iAe7dPd85qIt2g==",
-      "license": "MIT"
-    },
-    "node_modules/detect-touch-events": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/detect-touch-events/-/detect-touch-events-2.0.2.tgz",
-      "integrity": "sha512-g8GWBkJLiIDRJfRXEdrd1wMXpNyGId2DkbfuwFahSb4OCvn717hyRJtAcEDISfp3zkwEhZ4Y4woHPA6DeyB3Fw==",
       "license": "MIT"
     },
     "node_modules/diff-sequences": {
@@ -9938,20 +9853,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.29.1"
-      }
-    },
-    "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -13808,21 +13709,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
-      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/path-to-regexp/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14356,20 +14242,6 @@
         "react": ">=17.0.0"
       }
     },
-    "node_modules/react-interactive": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/react-interactive/-/react-interactive-0.8.3.tgz",
-      "integrity": "sha512-mmRvA9aKP7zu9kVfP1AX1egX8tFlnE3DDXq92z0JTZezfOpmeQBzr77O1+mTV54OOmn+M2t6c5kFD5VnuFoM7A==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-it": "^3.0.3",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
     "node_modules/react-is": {
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
@@ -14875,47 +14747,6 @@
         }
       }
     },
-    "node_modules/react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
-      "license": "MIT",
-      "dependencies": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
-      "license": "MIT",
-      "dependencies": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/react-router/node_modules/hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -15169,12 +15000,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -16337,18 +16162,6 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "license": "MIT"
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "license": "MIT"
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -17203,12 +17016,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "license": "MIT"
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -17441,15 +17248,6 @@
       "resolved": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
       "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
       "license": "MIT"
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@rn-primitives/select": "^1.2.0",
     "@rn-primitives/slot": "^1.2.0",
     "@tanstack/react-query": "^5.90.16",
-    "boxicons": "^2.1.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "expo": "~54.0.30",
@@ -88,6 +87,7 @@
     "uniwind": "^1.2.4"
   },
   "devDependencies": {
+    "@boxicons/react": "^1.0.3",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29",

--- a/scripts/generate-boxicons.ts
+++ b/scripts/generate-boxicons.ts
@@ -1,42 +1,129 @@
 import * as fs from "fs";
 import * as path from "path";
 
-const cssPath = path.join(__dirname, "../node_modules/boxicons/css/boxicons.css");
+type Pack = "basic" | "filled" | "brands";
+
+interface SvgElement {
+  tag: string;
+  attrs: Record<string, string>;
+}
+
+interface PackData {
+  viewBox: string;
+  elements: SvgElement[];
+}
+
+type IconEntry = Partial<Record<Pack, PackData>>;
+
+const iconsDir = path.join(
+  __dirname,
+  "../node_modules/@boxicons/react/dist/esm/icons",
+);
 const outputPath = path.join(__dirname, "../components/icons-generated.ts");
 
-const cssContent = fs.readFileSync(cssPath, "utf-8");
+const iconFiles = fs
+  .readdirSync(iconsDir)
+  .filter((f) => f.endsWith(".js") && f !== "index.js");
 
-const lineGlyphs: Record<string, number> = {};
-const solidGlyphs: Record<string, number> = {};
-const logoGlyphs: Record<string, number> = {};
+const pathsObjRegex = /const paths = \{([\s\S]*?)\};\s*\nconst /;
+const packEntryRegex =
+  /(\w+):\s*\{\s*viewBox:\s*'([^']+)',\s*content:\s*`([^`]+)`\s*\}/g;
+const svgElementRegex = /<(\w+)\s+([^>]*?)\/>/g;
+const attrRegex = /(\w[\w-]*)="([^"]*)"/g;
 
-const regex = /\.(bx[sl]?)-([a-z0-9-]+):before\s*\{\s*content:\s*"\\([a-fA-F0-9]+)"/g;
+const toPack = (raw: string): Pack | null => {
+  if (raw === "basic" || raw === "filled" || raw === "brands") return raw;
+  return null;
+};
 
-let match;
-while ((match = regex.exec(cssContent)) !== null) {
-  const prefix = match[1];
-  const name = match[2];
-  const codePoint = parseInt(match[3], 16);
+const toKebabCase = (name: string): string =>
+  name
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+    .toLowerCase();
 
-  if (prefix === "bx") {
-    lineGlyphs[name] = codePoint;
-  } else if (prefix === "bxs") {
-    solidGlyphs[name] = codePoint;
-  } else if (prefix === "bxl") {
-    logoGlyphs[name] = codePoint;
+const parseSvgElements = (content: string): SvgElement[] => {
+  const results: SvgElement[] = [];
+  let match;
+  while ((match = svgElementRegex.exec(content)) !== null) {
+    const tag = match[1];
+    const attrString = match[2];
+    const attrs: Record<string, string> = {};
+    let attrMatch;
+    while ((attrMatch = attrRegex.exec(attrString)) !== null) {
+      attrs[attrMatch[1]] = attrMatch[2];
+    }
+    if (Object.keys(attrs).length > 0) {
+      results.push({ tag, attrs });
+    }
+  }
+  return results;
+};
+
+const icons: Record<string, IconEntry> = {};
+let skipped = 0;
+
+for (const file of iconFiles) {
+  const componentName = file.replace(".js", "");
+  const kebabName = toKebabCase(componentName);
+  const source = fs.readFileSync(path.join(iconsDir, file), "utf-8");
+
+  const objMatch = pathsObjRegex.exec(source);
+  if (!objMatch) {
+    skipped++;
+    continue;
+  }
+
+  const objBody = objMatch[1];
+  const entry: IconEntry = {};
+  let packMatch;
+  while ((packMatch = packEntryRegex.exec(objBody)) !== null) {
+    const pack = toPack(packMatch[1]);
+    if (!pack) continue;
+    const viewBox = packMatch[2];
+    const content = packMatch[3];
+    svgElementRegex.lastIndex = 0;
+    attrRegex.lastIndex = 0;
+    const elements = parseSvgElements(content);
+    if (elements.length > 0) {
+      entry[pack] = { viewBox, elements };
+    }
+  }
+  packEntryRegex.lastIndex = 0;
+
+  if (Object.keys(entry).length > 0) {
+    icons[kebabName] = entry;
   }
 }
 
-const output = `export const lineGlyphMap = ${JSON.stringify(lineGlyphs, null, 2)};
+const packs: Pack[] = ["basic", "filled", "brands"];
+const counts = Object.fromEntries(
+  packs.map((pack) => [
+    pack,
+    Object.values(icons).filter((e) => e[pack]).length,
+  ]),
+);
 
-export const solidGlyphMap = ${JSON.stringify(solidGlyphs, null, 2)};
+const output = `export type IconPack = "basic" | "filled" | "brands";
 
-export const logoGlyphMap = ${JSON.stringify(logoGlyphs, null, 2)};
+interface SvgElement {
+  tag: string;
+  attrs: Record<string, string>;
+}
+
+interface PackData {
+  viewBox: string;
+  elements: SvgElement[];
+}
+
+export type IconEntry = Partial<Record<IconPack, PackData>>;
+
+export const iconData: Record<string, IconEntry> = ${JSON.stringify(icons)};
 `;
 
 fs.writeFileSync(outputPath, output);
 
 // eslint-disable-next-line no-console
 console.log(
-  `Generated ${Object.keys(lineGlyphs).length} line, ${Object.keys(solidGlyphs).length} solid, ${Object.keys(logoGlyphs).length} logo icons to ${outputPath}`,
+  `Generated ${Object.keys(icons).length} icons (${counts.basic} basic, ${counts.filled} filled, ${counts.brands} brands), skipped ${skipped} to ${outputPath}`,
 );


### PR DESCRIPTION
Issue: #36

# Description

<!-- Briefly describe the problem and your solution -->
Updating to Boxicons v3 from v2

## Problem
We currently use the fully open source v2 of Boxicons, but it's missing a ton of icons we want to use in Gumroad. We should update to v3, but since the font files are no longer published we need to find an alternative approach for including the icons. 

## Solution
Add a script that converts specific icons to use react-native-svg components and writes them to a components/icons directory. 

---

# Before/After

<!-- For UI/CSS changes, include screenshots or videos showing both states -->
<!-- Include: Desktop (light + dark) and Mobile (light + dark) -->
### Before

https://github.com/user-attachments/assets/26fb5af6-786b-469a-93c7-36bdcb439f33



### After

https://github.com/user-attachments/assets/1b8594cd-1814-431d-9b12-070c3d074f2c


---





# Test Results

<!-- Include a screenshot of your test suite passing locally -->
<img width="685" height="104" alt="image" src="https://github.com/user-attachments/assets/ab02d8fe-2bdc-4e2d-8fe3-f28de8e22c24" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

<!-- State whether AI was used and for what purpose, or "No AI was used for any part of this contribution." -->
Claude Opus 4.6 used for working out the approach and for script generation.