### PR TITLE
Render table of contents natively on the purchase page

### DIFF
--- a/components/content-page-navigator.tsx
+++ b/components/content-page-navigator.tsx
@@ -1,0 +1,89 @@
+import { LineIcon } from "@/components/icon";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/utils";
+import { type ComponentProps, useState } from "react";
+import { FlatList, Pressable, View } from "react-native";
+
+export type ContentPage = {
+  id: string;
+  title: string;
+  icon: string;
+};
+
+export const ContentPageNavigator = ({
+  pages,
+  activeIndex,
+  onPageChange,
+}: {
+  pages: ContentPage[];
+  activeIndex: number;
+  onPageChange: (index: number) => void;
+}) => {
+  const [isTocOpen, setIsTocOpen] = useState(false);
+  const hasPreviousPage = activeIndex > 0;
+  const hasNextPage = activeIndex < pages.length - 1;
+
+  return (
+    <>
+      <View className="flex-row items-center gap-2 border-t border-border bg-background px-3 py-2">
+        <Button variant="outline" size="icon" onPress={() => setIsTocOpen(true)}>
+          <LineIcon name="list-ul" size={20} className="text-foreground" />
+        </Button>
+        <Button
+          variant="outline"
+          className="flex-1"
+          disabled={!hasPreviousPage}
+          onPress={() => onPageChange(activeIndex - 1)}
+        >
+          <LineIcon name="left-arrow-alt" size={20} className="text-foreground" />
+          <Text>Previous</Text>
+        </Button>
+        <Button
+          variant="outline"
+          className="flex-1"
+          disabled={!hasNextPage}
+          onPress={() => onPageChange(activeIndex + 1)}
+        >
+          <Text>Next</Text>
+          <LineIcon name="right-arrow-alt" size={20} className="text-foreground" />
+        </Button>
+      </View>
+
+      <Sheet open={isTocOpen} onOpenChange={setIsTocOpen}>
+        <SheetHeader onClose={() => setIsTocOpen(false)}>
+          <SheetTitle>Table of contents</SheetTitle>
+        </SheetHeader>
+        <SheetContent>
+          <FlatList
+            data={pages}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item, index }) => {
+              const isActive = index === activeIndex;
+              return (
+                <Pressable
+                  onPress={() => {
+                    onPageChange(index);
+                    setIsTocOpen(false);
+                  }}
+                  className={cn("flex-row items-center gap-3 border-b border-border px-4 py-4", isActive && "bg-muted")}
+                >
+                  <LineIcon
+                    name={item.icon as ComponentProps<typeof LineIcon>["name"]}
+                    size={18}
+                    className="text-muted-foreground"
+                  />
+                  <Text className={cn("flex-1", isActive && "font-bold")} numberOfLines={2}>
+                    {item.title}
+                  </Text>
+                  {isActive ? <LineIcon name="check" size={18} className="text-primary" /> : null}
+                </Pressable>
+              );
+            }}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 18.0.1",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/tests/components/content-page-navigator.test.tsx
+++ b/tests/components/content-page-navigator.test.tsx
@@ -1,0 +1,98 @@
+import { ContentPage, ContentPageNavigator } from "@/components/content-page-navigator";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+const pages: ContentPage[] = [
+  { id: "page-1", title: "Introduction", icon: "file" },
+  { id: "page-2", title: "Chapter 1", icon: "music" },
+  { id: "page-3", title: "Chapter 2", icon: "video" },
+];
+
+const getTocButton = () => screen.getAllByRole("button")[0];
+
+describe("ContentPageNavigator", () => {
+  it("renders previous and next buttons", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={1} onPageChange={onPageChange} />);
+
+    expect(screen.getByText("Previous")).toBeTruthy();
+    expect(screen.getByText("Next")).toBeTruthy();
+  });
+
+  it("does not call onPageChange when pressing previous on first page", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={0} onPageChange={onPageChange} />);
+
+    fireEvent.press(screen.getByText("Previous"));
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onPageChange when pressing next on last page", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={2} onPageChange={onPageChange} />);
+
+    fireEvent.press(screen.getByText("Next"));
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("calls onPageChange with previous index when pressing previous", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={1} onPageChange={onPageChange} />);
+
+    fireEvent.press(screen.getByText("Previous"));
+    expect(onPageChange).toHaveBeenCalledWith(0);
+  });
+
+  it("calls onPageChange with next index when pressing next", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={1} onPageChange={onPageChange} />);
+
+    fireEvent.press(screen.getByText("Next"));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it("opens the TOC sheet and displays all page titles", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={0} onPageChange={onPageChange} />);
+
+    fireEvent.press(getTocButton());
+
+    expect(screen.getByText("Table of contents")).toBeTruthy();
+    expect(screen.getByText("Introduction")).toBeTruthy();
+    expect(screen.getByText("Chapter 1")).toBeTruthy();
+    expect(screen.getByText("Chapter 2")).toBeTruthy();
+  });
+
+  it("marks the active page with a distinct style in the TOC sheet", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={1} onPageChange={onPageChange} />);
+
+    fireEvent.press(getTocButton());
+
+    const activeText = screen.getByText("Chapter 1");
+    const inactiveText = screen.getByText("Introduction");
+    expect(activeText.props.className).toContain("font-bold");
+    expect(inactiveText.props.className).not.toContain("font-bold");
+  });
+
+  it("calls onPageChange when selecting a page from the TOC", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={0} onPageChange={onPageChange} />);
+
+    fireEvent.press(getTocButton());
+    fireEvent.press(screen.getByText("Chapter 2"));
+
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it("closes the TOC sheet after selecting a page", () => {
+    const onPageChange = jest.fn();
+    render(<ContentPageNavigator pages={pages} activeIndex={0} onPageChange={onPageChange} />);
+
+    fireEvent.press(getTocButton());
+    expect(screen.getByText("Table of contents")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Chapter 1"));
+
+    expect(screen.queryByText("Table of contents")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a native `ContentPageNavigator` component with Previous/Next buttons and a bottom-sheet table of contents
- Receives page list from web via `postMessage` bridge; navigates pages via `injectJavaScript` (cross-platform iOS/Android)
- Renders per-page icons from the web in the TOC sheet
- 9 unit tests covering navigation buttons, sheet open/close, page selection, and active-page styling

Closes #27

**Note:** Requires companion PR in the main gumroad web repo to add the `pageList` message bridge in `WithContent.tsx`.

## Test plan
- [ ] Open a multi-page product purchase → TOC bar appears with Previous/Next
- [ ] Tap TOC button → sheet opens listing all pages with correct icons
- [ ] Tap a page in the sheet → navigates to that page, sheet closes
- [ ] Previous/Next buttons disabled at boundaries
- [ ] `npx tsc --noEmit` passes
- [ ] `npx jest` — 59 tests pass (9 in content-page-navigator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)