### PR TITLE
Doc: Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@ Issue: #
 
 # Checklist
 
-- [ ] I have read the [contributing guidelines](https://github.com/antiwork/gumroad/blob/main/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
 - [ ] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
 - [ ] I have performed a self-review and left review comments on my PR
 - [ ] I have added/updated tests for my changes


### PR DESCRIPTION
Add PR template, mirroring the existing Gumroad PR template to keep contribution workflows consistent across repositories