### PR TITLE
Improve support for tapping bars in analytics charts

### DIFF
--- a/components/analytics/analytics-bar-chart.ts
+++ b/components/analytics/analytics-bar-chart.ts
@@ -48,6 +48,16 @@ export const formatNumber = (num: number): string => {
   return num.toLocaleString();
 };
 
+export const Y_AXIS_EMPTY_LABEL_WIDTH = 10;
+
+export const getBarIndexFromX = (x: number, barWidth: number, spacing: number, dataLength: number): number | null => {
+  if (dataLength <= 0) return null;
+  const adjustedX = x - Y_AXIS_EMPTY_LABEL_WIDTH;
+  if (adjustedX < 0) return 0;
+  const index = Math.floor(adjustedX / (barWidth + spacing));
+  return Math.max(0, Math.min(index, dataLength - 1));
+};
+
 export const useChartDimensions = (dataLength: number) => {
   const [containerWidth, setContainerWidth] = useState(0);
 

--- a/components/analytics/chart-touch-overlay.tsx
+++ b/components/analytics/chart-touch-overlay.tsx
@@ -1,0 +1,86 @@
+import * as Haptics from "expo-haptics";
+import { ReactNode, useMemo, useRef } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { getBarIndexFromX } from "./analytics-bar-chart";
+
+const ACTIVE_OFFSET = 10;
+
+export const ChartTouchOverlay = ({
+  barWidth,
+  spacing,
+  dataLength,
+  onBarSelect,
+  height,
+  children,
+}: {
+  barWidth: number;
+  spacing: number;
+  dataLength: number;
+  onBarSelect: (index: number) => void;
+  height: number;
+  children: ReactNode;
+}) => {
+  const lastIndexRef = useRef<number | null>(null);
+
+  const tap = useMemo(
+    () =>
+      Gesture.Tap()
+        .runOnJS(true)
+        .onEnd((event) => {
+          const index = getBarIndexFromX(event.x, barWidth, spacing, dataLength);
+          if (index !== null) {
+            Haptics.selectionAsync();
+            onBarSelect(index);
+          }
+        }),
+    [barWidth, spacing, dataLength, onBarSelect],
+  );
+
+  const pan = useMemo(
+    () =>
+      Gesture.Pan()
+        .runOnJS(true)
+        .activeOffsetX([-ACTIVE_OFFSET, ACTIVE_OFFSET])
+        .failOffsetY([-ACTIVE_OFFSET, ACTIVE_OFFSET])
+        .onStart((event) => {
+          const index = getBarIndexFromX(event.x, barWidth, spacing, dataLength);
+          if (index !== null) {
+            lastIndexRef.current = index;
+            Haptics.selectionAsync();
+            onBarSelect(index);
+          }
+        })
+        .onUpdate((event) => {
+          const index = getBarIndexFromX(event.x, barWidth, spacing, dataLength);
+          if (index !== null && index !== lastIndexRef.current) {
+            lastIndexRef.current = index;
+            Haptics.selectionAsync();
+            onBarSelect(index);
+          }
+        })
+        .onFinalize(() => {
+          lastIndexRef.current = null;
+        }),
+    [barWidth, spacing, dataLength, onBarSelect],
+  );
+
+  const composed = useMemo(() => Gesture.Race(pan, tap), [pan, tap]);
+
+  return (
+    <View style={{ position: "relative" }}>
+      {children}
+      <GestureDetector gesture={composed}>
+        <View
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height,
+          }}
+        />
+      </GestureDetector>
+    </View>
+  );
+};

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -5,6 +5,7 @@ import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartTouchOverlay } from "./chart-touch-overlay";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
@@ -35,7 +36,6 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
     values.map((value, index) => ({
       value: value === 0 ? 0 : value,
       frontColor: index === activeIndex ? accentColor : colors.muted,
-      onPress: () => handleBarPress(index),
     }));
 
   const revenueData = createChartData(totals);
@@ -69,7 +69,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               data={revenueData}
               height={120}
@@ -80,6 +86,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               isAnimated={false}
               barBorderTopLeftRadius={4}
               barBorderTopRightRadius={4}
@@ -87,7 +94,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </ChartTouchOverlay>
         </ChartContainer>
 
         <ChartContainer
@@ -104,7 +111,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               data={salesData}
               height={120}
@@ -115,6 +128,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               isAnimated={false}
               barBorderTopLeftRadius={4}
               barBorderTopRightRadius={4}
@@ -122,7 +136,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </ChartTouchOverlay>
         </ChartContainer>
 
         <ChartContainer
@@ -139,7 +153,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               data={viewsData}
               height={120}
@@ -150,6 +170,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               isAnimated={false}
               barBorderTopLeftRadius={4}
               barBorderTopRightRadius={4}
@@ -157,7 +178,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </ChartTouchOverlay>
         </ChartContainer>
       </View>
     </ScrollView>

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -4,6 +4,7 @@ import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartTouchOverlay } from "./chart-touch-overlay";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
 
@@ -141,7 +142,13 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               stackData={revenueChartData}
               height={120}
@@ -152,15 +159,15 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               yAxisThickness={0}
               xAxisThickness={1}
               xAxisColor={colors.border}
               highlightEnabled={activeIndex !== null}
               highlightedBarIndex={activeIndex ?? undefined}
               lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </ChartTouchOverlay>
           <View>
             {revenue.topReferrers.map((name) => (
               <LegendItem
@@ -187,7 +194,13 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               stackData={salesChartData}
               height={120}
@@ -198,15 +211,15 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               yAxisThickness={0}
               xAxisThickness={1}
               xAxisColor={colors.border}
               highlightEnabled={activeIndex !== null}
               highlightedBarIndex={activeIndex ?? undefined}
               lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </ChartTouchOverlay>
           <View>
             {sales.topReferrers.map((name) => (
               <LegendItem
@@ -233,7 +246,13 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <ChartTouchOverlay
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={dates.length}
+            onBarSelect={handleBarPress}
+            height={120}
+          >
             <BarChart
               stackData={visitsChartData}
               height={120}
@@ -244,15 +263,15 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               hideRules
               hideYAxisText
               disableScroll
+              disablePress
               yAxisThickness={0}
               xAxisThickness={1}
               xAxisColor={colors.border}
               highlightEnabled={activeIndex !== null}
               highlightedBarIndex={activeIndex ?? undefined}
               lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </ChartTouchOverlay>
           <View>
             {visits.topReferrers.map((name) => (
               <LegendItem

--- a/tests/components/analytics/analytics-bar-chart.test.ts
+++ b/tests/components/analytics/analytics-bar-chart.test.ts
@@ -1,0 +1,52 @@
+import { getBarIndexFromX, Y_AXIS_EMPTY_LABEL_WIDTH } from "@/components/analytics/analytics-bar-chart";
+
+describe("getBarIndexFromX", () => {
+  const barWidth = 20;
+  const spacing = 4;
+  const dataLength = 7;
+  const yAxisOffset = Y_AXIS_EMPTY_LABEL_WIDTH;
+
+  it("returns null when dataLength is 0", () => {
+    expect(getBarIndexFromX(50, barWidth, spacing, 0)).toBeNull();
+  });
+
+  it("returns 0 for taps in the first bar column", () => {
+    expect(getBarIndexFromX(yAxisOffset + 5, barWidth, spacing, dataLength)).toBe(0);
+  });
+
+  it("returns the correct index for taps in a middle column", () => {
+    const thirdBarStart = yAxisOffset + 2 * (barWidth + spacing);
+    expect(getBarIndexFromX(thirdBarStart + 5, barWidth, spacing, dataLength)).toBe(2);
+  });
+
+  it("returns 0 for taps to the left of the chart area", () => {
+    expect(getBarIndexFromX(0, barWidth, spacing, dataLength)).toBe(0);
+  });
+
+  it("clamps to the last index for taps beyond the chart area", () => {
+    expect(getBarIndexFromX(500, barWidth, spacing, dataLength)).toBe(dataLength - 1);
+  });
+
+  it("returns the last index at the end of the last bar", () => {
+    const lastBarEnd = yAxisOffset + (dataLength - 1) * (barWidth + spacing) + barWidth;
+    expect(getBarIndexFromX(lastBarEnd - 1, barWidth, spacing, dataLength)).toBe(dataLength - 1);
+  });
+
+  it("maps taps in the spacing area to the current bar", () => {
+    const spacingArea = yAxisOffset + barWidth + 1;
+    expect(getBarIndexFromX(spacingArea, barWidth, spacing, dataLength)).toBe(0);
+  });
+
+  it("maps taps at the exact boundary to the next bar", () => {
+    const boundary = yAxisOffset + barWidth + spacing;
+    expect(getBarIndexFromX(boundary, barWidth, spacing, dataLength)).toBe(1);
+  });
+
+  it("returns null for negative dataLength", () => {
+    expect(getBarIndexFromX(50, barWidth, spacing, -1)).toBeNull();
+  });
+
+  it("returns 0 for a single bar regardless of x position", () => {
+    expect(getBarIndexFromX(yAxisOffset + 100, barWidth, spacing, 1)).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #26

## Summary

Adds a gesture overlay to all analytics bar charts so users can tap anywhere above a bar (in the same column) to select it and slide horizontally to scrub through bars, matching the behavior of the current production app.

A `ChartTouchOverlay` component wraps each `BarChart` with a transparent gesture layer using `react-native-gesture-handler`. It uses `Gesture.Race(pan, tap)` to support both tap-to-select and slide-to-scrub. The X-to-index mapping accounts for the chart library's internal 10px y-axis offset and the dynamic bar width + spacing per column. Haptic feedback fires when crossing into a new bar column.

`activeOffsetX` and `failOffsetY` thresholds ensure vertical scrolling still works normally.

## AI disclosure

- Model: Claude Opus 4 via Claude Code
- Used for: Codebase exploration, understanding react-native-gifted-charts internal layout, code generation, test writing, code review
- All code was reviewed, tested, and verified by me