### PR TITLE
Render table of contents natively on the purchase page

### DIFF
--- a/components/content-pages-footer.tsx
+++ b/components/content-pages-footer.tsx
@@ -1,0 +1,93 @@
+import { LineIcon } from "@/components/icon";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { FlatList, Modal, Pressable, TouchableOpacity, View } from "react-native";
+
+export type ContentPage = {
+  id: string;
+  title: string;
+};
+
+type ContentPagesFooterProps = {
+  pages: ContentPage[];
+  activeIndex: number;
+  onPageChange: (index: number) => void;
+};
+
+export const ContentPagesFooter = ({ pages, activeIndex, onPageChange }: ContentPagesFooterProps) => {
+  const [tocVisible, setTocVisible] = useState(false);
+  const hasPrevious = activeIndex > 0;
+  const hasNext = activeIndex < pages.length - 1;
+
+  if (pages.length <= 1) return null;
+
+  return (
+    <>
+      <View className="flex-row items-center gap-2 border-t border-border bg-background px-3 py-2">
+        <TouchableOpacity
+          onPress={() => setTocVisible(true)}
+          className="size-10 items-center justify-center rounded border border-border"
+          accessibilityLabel="Table of Contents"
+        >
+          <LineIcon name="list-ul" size={20} className="text-foreground" />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onPageChange(activeIndex - 1)}
+          disabled={!hasPrevious}
+          className={cn(
+            "h-10 flex-1 flex-row items-center justify-center gap-1 rounded border border-border",
+            !hasPrevious && "opacity-40",
+          )}
+        >
+          <LineIcon name="chevron-left" size={16} className="text-foreground" />
+          <Text className="text-sm text-foreground">Previous</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onPageChange(activeIndex + 1)}
+          disabled={!hasNext}
+          className={cn(
+            "h-10 flex-1 flex-row items-center justify-center gap-1 rounded border border-border",
+            !hasNext && "opacity-40",
+          )}
+        >
+          <Text className="text-sm text-foreground">Next</Text>
+          <LineIcon name="chevron-right" size={16} className="text-foreground" />
+        </TouchableOpacity>
+      </View>
+
+      <Modal visible={tocVisible} animationType="slide" presentationStyle="pageSheet" onRequestClose={() => setTocVisible(false)}>
+        <View className="flex-1 bg-background">
+          <View className="flex-row items-center justify-between border-b border-border px-4 py-3">
+            <Text className="text-lg font-bold text-foreground">Table of Contents</Text>
+            <Pressable onPress={() => setTocVisible(false)} className="p-2">
+              <LineIcon name="x" size={24} className="text-foreground" />
+            </Pressable>
+          </View>
+          <FlatList
+            data={pages}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item, index }) => (
+              <Pressable
+                onPress={() => {
+                  onPageChange(index);
+                  setTocVisible(false);
+                }}
+                className={cn(
+                  "flex-row items-center gap-3 border-b border-border px-4 py-3",
+                  index === activeIndex && "bg-accent/10",
+                )}
+              >
+                <Text className={cn("text-base", index === activeIndex ? "font-bold text-accent" : "text-foreground")}>
+                  {item.title || "Untitled"}
+                </Text>
+              </Pressable>
+            )}
+          />
+        </View>
+      </Modal>
+    </>
+  );
+};


### PR DESCRIPTION
## Summary

Replaces the HTML-rendered table of contents and prev/next navigation on the purchase page with a native React Native sticky footer bar.

Closes #27

## Problem

For products with multiple content pages, the TOC button and previous/next buttons are rendered inside the WebView HTML. This has poor UX because:
- Non-native look and feel
- Users must scroll to the bottom of long pages to access navigation

## Solution

### New component: `ContentPagesFooter`
A native sticky footer bar that renders:
- **TOC button** — opens a native modal sheet listing all content pages
- **Previous/Next buttons** — for quick sequential navigation
- Only visible when the product has multiple content pages

### WebView JavaScript injection
Injected JS in the WebView that:
1. **Hides** the HTML `[role="navigation"]` bar (TOC + prev/next buttons)
2. **Extracts** page titles and active page index from the DOM
3. **Sends** page data to React Native via `ReactNativeWebView.postMessage()`
4. **Listens** for `changePage` messages from React Native to trigger page changes in the web content

### Message protocol
- **WebView → RN:** `{ type: "contentPages", payload: { pages, activeIndex } }` — sends page list and current page
- **RN → WebView:** `{ type: "changePage", payload: { index } }` — requests a page change

## Changes

- `app/purchase/[id].tsx` — Added injected JS, content pages state, and `ContentPagesFooter` to the purchase screen
- `components/content-pages-footer.tsx` — New native footer component with TOC modal and prev/next navigation

## Note on Gumroad web app changes

This PR handles hiding the HTML TOC entirely on the client side via injected JavaScript, so **no changes to the Gumroad web app (Ruby/Rails) are required**. The injected JS targets the `[role="navigation"]` element that contains the TOC popover and prev/next buttons, hiding it and extracting page data.

If a server-side approach is preferred (e.g., not rendering the navigation when `display=mobile_app`), that would be a change in `antiwork/gumroad` in the `WithContent` component (`app/javascript/components/DownloadPage/WithContent.tsx`) — specifically the `showPageList` conditional block at the bottom of the JSX.