### PR TITLE
Improve analytics chart touch selection (tap/drag anywhere on chart)

### DIFF
--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -3,7 +3,13 @@ import { useCallback, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
-import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
+import {
+  formatCurrency,
+  formatNumber,
+  useChartColors,
+  useChartDimensions,
+  useChartTouchSelection,
+} from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
@@ -28,8 +34,14 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
   const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+    setSelectedIndex(index);
   }, []);
+  const chartTouchHandlers = useChartTouchSelection({
+    barCount: dates.length,
+    barWidth,
+    spacing,
+    onSelectIndex: handleBarPress,
+  });
 
   const createChartData = (values: number[]) =>
     values.map((value, index) => ({
@@ -69,7 +81,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
+          <View className="relative mt-4">
             <BarChart
               data={revenueData}
               height={120}
@@ -87,6 +99,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
         </ChartContainer>
 
@@ -104,7 +117,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <View className="relative mt-4">
             <BarChart
               data={salesData}
               height={120}
@@ -122,6 +135,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
         </ChartContainer>
 
@@ -139,7 +153,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <View className="relative mt-4">
             <BarChart
               data={viewsData}
               height={120}
@@ -157,6 +171,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
         </ChartContainer>
       </View>

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -2,7 +2,13 @@ import { Text } from "@/components/ui/text";
 import { useCallback, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
-import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
+import {
+  formatCurrency,
+  formatNumber,
+  useChartColors,
+  useChartDimensions,
+  useChartTouchSelection,
+} from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
@@ -39,8 +45,14 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
   const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+    setSelectedIndex(index);
   }, []);
+  const chartTouchHandlers = useChartTouchSelection({
+    barCount: dates.length,
+    barWidth,
+    spacing,
+    onSelectIndex: handleBarPress,
+  });
 
   const calculateTotals = (
     data: { date: string; referrers: { name: string; value: number; color: string }[] }[],
@@ -141,7 +153,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
+          <View className="relative">
             <BarChart
               stackData={revenueChartData}
               height={120}
@@ -160,6 +172,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
           <View>
             {revenue.topReferrers.map((name) => (
@@ -187,7 +200,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <View className="relative">
             <BarChart
               stackData={salesChartData}
               height={120}
@@ -206,6 +219,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
           <View>
             {sales.topReferrers.map((name) => (
@@ -233,7 +247,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <View className="relative">
             <BarChart
               stackData={visitsChartData}
               height={120}
@@ -252,6 +266,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
+            <View className="absolute inset-0" {...chartTouchHandlers} />
           </View>
           <View>
             {visits.topReferrers.map((name) => (


### PR DESCRIPTION
Fixes #26.

Root cause
The chart only selected bars through per-bar press handlers, so touches above short bars or in narrow gaps were ignored and dragging across X positions did not continuously update selection.

What changed
- Added chart-level touch handling that maps finger X position to the nearest bar index.
- Added drag support so moving across the chart continuously updates selected period.
- Applied this behavior to both sales and traffic analytics charts.

Self-review
- The non-obvious part is converting touch X into a stable index across different bar widths/spacings; this is centralized in a shared hook to keep behavior consistent.
- Existing bar `onPress` handlers were kept so both direct bar taps and chart-area gestures work.

Testing
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`