### PR TITLE
feat: Replace WebView content navigation with native sticky footer in purchase reader

### DIFF
--- a/components/purchase-content-navigation-footer.tsx
+++ b/components/purchase-content-navigation-footer.tsx
@@ -1,0 +1,48 @@
+import { LineIcon, SolidIcon } from "@/components/icon";
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import type { ContentPageNavigationStatePayload } from "@/lib/purchase-content-navigation";
+import { View } from "react-native";
+
+type PurchaseContentNavigationFooterProps = {
+  state: ContentPageNavigationStatePayload;
+  bottomInset: number;
+  onGoPrevious: () => void;
+  onGoNext: () => void;
+  onOpenTableOfContents: () => void;
+};
+
+const CONTENTS_ICON_SIZE = 22;
+const PAGE_NAVIGATION_ICON_SIZE = 20;
+
+export const PurchaseContentNavigationFooter = ({
+  state,
+  bottomInset,
+  onGoPrevious,
+  onGoNext,
+  onOpenTableOfContents,
+}: PurchaseContentNavigationFooterProps) => {
+  if (!state.isVisible) return null;
+
+  return (
+    <View className="border-t border-border bg-background px-3 pt-3" style={{ paddingBottom: bottomInset }}>
+      <View className="flex-row items-center gap-2 pb-3">
+        {state.hasTableOfContents ? (
+          <Button variant="outline" size="icon" onPress={onOpenTableOfContents}>
+            <SolidIcon name="book-content" size={CONTENTS_ICON_SIZE} className="text-foreground" />
+          </Button>
+        ) : null}
+
+        <Button variant="outline" className="flex-1" onPress={onGoPrevious} disabled={!state.canGoPrevious}>
+          <LineIcon name="left-arrow-alt" size={PAGE_NAVIGATION_ICON_SIZE} className="text-foreground" />
+          <Text>Previous</Text>
+        </Button>
+
+        <Button variant="outline" className="flex-1" onPress={onGoNext} disabled={!state.canGoNext}>
+          <Text>Next</Text>
+          <LineIcon name="right-arrow-alt" size={PAGE_NAVIGATION_ICON_SIZE} className="text-foreground" />
+        </Button>
+      </View>
+    </View>
+  );
+};

--- a/lib/purchase-content-navigation.ts
+++ b/lib/purchase-content-navigation.ts
@@ -1,0 +1,292 @@
+export type ClickPayload = {
+  resourceId: string;
+  isDownload: boolean;
+  isPost: boolean;
+  type?: string | null;
+  extension?: string | null;
+  isPlaying?: "true" | "false" | null;
+  resumeAt?: string | null;
+  contentLength?: string | null;
+};
+
+export type ClickMessage = {
+  type: "click";
+  payload: ClickPayload;
+};
+
+export const CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE = "contentPageNavigationState";
+export const MOBILE_APP_CONTENT_PAGE_NAVIGATION_COMMAND_MESSAGE_TYPE = "mobileAppContentPageNavigationCommand";
+
+export type ContentPageNavigationStatePayload = {
+  isVisible: boolean;
+  hasTableOfContents: boolean;
+  canGoPrevious: boolean;
+  canGoNext: boolean;
+};
+
+export type ContentPageNavigationStateMessage = {
+  type: typeof CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE;
+  payload: ContentPageNavigationStatePayload;
+};
+
+export type MobileAppContentPageNavigationCommandAction = "openTableOfContents" | "goPrevious" | "goNext";
+
+const OPEN_TABLE_OF_CONTENTS_ACTION: MobileAppContentPageNavigationCommandAction = "openTableOfContents";
+const GO_PREVIOUS_ACTION: MobileAppContentPageNavigationCommandAction = "goPrevious";
+const GO_NEXT_ACTION: MobileAppContentPageNavigationCommandAction = "goNext";
+
+type PurchaseWebViewMessage = ClickMessage | ContentPageNavigationStateMessage;
+
+type JsonRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isClickPayload = (value: unknown): value is ClickPayload => {
+  if (!isRecord(value)) return false;
+
+  return typeof value.resourceId === "string";
+};
+
+const isClickMessage = (value: unknown): value is ClickMessage =>
+  isRecord(value) && value.type === "click" && isClickPayload(value.payload);
+
+const isContentPageNavigationStatePayload = (value: unknown): value is ContentPageNavigationStatePayload => {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.isVisible === "boolean" &&
+    typeof value.hasTableOfContents === "boolean" &&
+    typeof value.canGoPrevious === "boolean" &&
+    typeof value.canGoNext === "boolean"
+  );
+};
+
+const isContentPageNavigationStateMessage = (value: unknown): value is ContentPageNavigationStateMessage =>
+  isRecord(value) &&
+  value.type === CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE &&
+  isContentPageNavigationStatePayload(value.payload);
+
+export const parsePurchaseWebViewMessage = (data: string): PurchaseWebViewMessage | null => {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(data);
+  } catch {
+    return null;
+  }
+
+  if (isClickMessage(parsed)) return parsed;
+  if (isContentPageNavigationStateMessage(parsed)) return parsed;
+  return null;
+};
+
+export const createContentPageNavigationCommandMessage = (action: MobileAppContentPageNavigationCommandAction) =>
+  JSON.stringify({
+    type: MOBILE_APP_CONTENT_PAGE_NAVIGATION_COMMAND_MESSAGE_TYPE,
+    payload: { action },
+  });
+
+export const DEFAULT_CONTENT_PAGE_NAVIGATION_STATE: ContentPageNavigationStatePayload = {
+  isVisible: false,
+  hasTableOfContents: false,
+  canGoPrevious: false,
+  canGoNext: false,
+};
+
+const CONTENT_PAGE_NAVIGATION_STATE_DEBOUNCE_MS = 60;
+const CONTENT_PAGE_NAVIGATION_STATE_AFTER_ACTION_DELAY_MS = 150;
+const CONTENT_PAGE_NAVIGATION_STATE_AFTER_LOAD_DELAY_MS = 400;
+
+export const purchaseContentNavigationBridgeScript = `
+(() => {
+  if (window.__gumroadMobileContentNavigationBridgeInstalled) return;
+  window.__gumroadMobileContentNavigationBridgeInstalled = true;
+
+  const commandType = "${MOBILE_APP_CONTENT_PAGE_NAVIGATION_COMMAND_MESSAGE_TYPE}";
+  const stateType = "${CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE}";
+  const openTableOfContentsAction = "${OPEN_TABLE_OF_CONTENTS_ACTION}";
+  const goPreviousAction = "${GO_PREVIOUS_ACTION}";
+  const goNextAction = "${GO_NEXT_ACTION}";
+  const clickableSelector = "button, a, [role='button']";
+  const disabledClassPattern = /\\bdisabled\\b/i;
+  const debounceMs = ${CONTENT_PAGE_NAVIGATION_STATE_DEBOUNCE_MS};
+  const afterActionDelayMs = ${CONTENT_PAGE_NAVIGATION_STATE_AFTER_ACTION_DELAY_MS};
+  const afterLoadDelayMs = ${CONTENT_PAGE_NAVIGATION_STATE_AFTER_LOAD_DELAY_MS};
+
+  let lastSerializedState = "";
+  let updateTimeoutId = null;
+
+  const normalizeText = (value) => value.toLowerCase().replace(/\\s+/g, " ").trim();
+  const getClickableElements = (root) => Array.from(root.querySelectorAll(clickableSelector));
+  const getElementText = (element) => normalizeText(element.innerText || element.textContent || "");
+  const hasAnyLabel = (element, labels) => {
+    const text = getElementText(element);
+    return labels.some((label) => text.includes(label));
+  };
+
+  const findElementsByLabels = (labels, root = document) =>
+    getClickableElements(root).filter((element) => hasAnyLabel(element, labels));
+
+  const findNearestSharedContainer = (first, second) => {
+    let current = first.parentElement;
+    while (current && current !== document.body) {
+      if (current.contains(second)) return current;
+      current = current.parentElement;
+    }
+    return null;
+  };
+
+  const findBestNavigationPair = () => {
+    const previousCandidates = findElementsByLabels(["previous"]);
+    const nextCandidates = findElementsByLabels(["next"]);
+
+    let bestMatch = null;
+    let bestScore = Number.MAX_SAFE_INTEGER;
+
+    for (const previousButton of previousCandidates) {
+      for (const nextButton of nextCandidates) {
+        const container = findNearestSharedContainer(previousButton, nextButton);
+        if (!container) continue;
+
+        const score = getClickableElements(container).length;
+        if (score >= bestScore) continue;
+
+        bestScore = score;
+        bestMatch = { previousButton, nextButton, container };
+      }
+    }
+
+    return bestMatch;
+  };
+
+  const findTableOfContentsButton = (container, previousButton, nextButton) => {
+    if (container) {
+      const elements = getClickableElements(container);
+      for (const element of elements) {
+        if (element === previousButton || element === nextButton) continue;
+        if (hasAnyLabel(element, ["previous", "next"])) continue;
+        return element;
+      }
+    }
+    return null;
+  };
+
+  const findControls = () => {
+    const pair = findBestNavigationPair();
+    if (!pair) {
+      return { previousButton: null, nextButton: null, tableOfContentsButton: null, container: null };
+    }
+
+    const tableOfContentsButton = findTableOfContentsButton(pair.container, pair.previousButton, pair.nextButton);
+
+    return {
+      previousButton: pair.previousButton,
+      nextButton: pair.nextButton,
+      tableOfContentsButton,
+      container: pair.container,
+    };
+  };
+
+  const isDisabled = (element) => {
+    if (!element) return true;
+    if (element.hasAttribute("disabled")) return true;
+    if (element.getAttribute("aria-disabled") === "true") return true;
+
+    const className = typeof element.className === "string" ? element.className : "";
+    return disabledClassPattern.test(className);
+  };
+
+  const hideHtmlControls = (container) => {
+    if (!container) return;
+    if (container.dataset.gumroadMobileNativeFooterHidden === "true") return;
+
+    container.dataset.gumroadMobileNativeFooterHidden = "true";
+    container.style.display = "none";
+  };
+
+  const postNavigationState = () => {
+    const { previousButton, nextButton, tableOfContentsButton, container } = findControls();
+
+    if (container) hideHtmlControls(container);
+
+    const payload = {
+      isVisible: Boolean(previousButton || nextButton || tableOfContentsButton),
+      hasTableOfContents: Boolean(tableOfContentsButton),
+      canGoPrevious: Boolean(previousButton) && !isDisabled(previousButton),
+      canGoNext: Boolean(nextButton) && !isDisabled(nextButton),
+    };
+
+    const serializedPayload = JSON.stringify(payload);
+    if (serializedPayload === lastSerializedState) return;
+    lastSerializedState = serializedPayload;
+
+    if (!window.ReactNativeWebView || typeof window.ReactNativeWebView.postMessage !== "function") return;
+    window.ReactNativeWebView.postMessage(JSON.stringify({ type: stateType, payload }));
+  };
+
+  const click = (element) => {
+    if (!element || typeof element.click !== "function") return false;
+    element.click();
+    return true;
+  };
+
+  const runAction = (action) => {
+    const { previousButton, nextButton, tableOfContentsButton } = findControls();
+
+    const didClick =
+      action === openTableOfContentsAction
+        ? click(tableOfContentsButton)
+        : action === goPreviousAction
+          ? click(previousButton)
+          : action === goNextAction
+            ? click(nextButton)
+            : false;
+
+    if (didClick) window.setTimeout(postNavigationState, afterActionDelayMs);
+  };
+
+  const handleMessage = (event) => {
+    if (!event || typeof event.data !== "string") return;
+
+    let parsed = null;
+    try {
+      parsed = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+
+    if (!parsed || parsed.type !== commandType || !parsed.payload || typeof parsed.payload.action !== "string") {
+      return;
+    }
+
+    runAction(parsed.payload.action);
+  };
+
+  document.addEventListener("message", handleMessage);
+  window.addEventListener("message", handleMessage);
+
+  const observerTarget = document.documentElement || document.body;
+  if (observerTarget) {
+    const observer = new MutationObserver(() => {
+      if (updateTimeoutId !== null) window.clearTimeout(updateTimeoutId);
+      updateTimeoutId = window.setTimeout(postNavigationState, debounceMs);
+    });
+
+    observer.observe(observerTarget, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", postNavigationState);
+  } else {
+    postNavigationState();
+  }
+
+  window.setTimeout(postNavigationState, afterLoadDelayMs);
+})();
+true;
+`;

--- a/tests/lib/purchase-content-navigation.test.ts
+++ b/tests/lib/purchase-content-navigation.test.ts
@@ -1,0 +1,88 @@
+import {
+  CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE,
+  MOBILE_APP_CONTENT_PAGE_NAVIGATION_COMMAND_MESSAGE_TYPE,
+  createContentPageNavigationCommandMessage,
+  parsePurchaseWebViewMessage,
+} from "@/lib/purchase-content-navigation";
+
+describe("purchase content navigation", () => {
+  describe("parsePurchaseWebViewMessage", () => {
+    it("parses click messages", () => {
+      const rawMessage = JSON.stringify({
+        type: "click",
+        payload: {
+          resourceId: "resource-1",
+          isDownload: false,
+          isPost: false,
+        },
+      });
+
+      expect(parsePurchaseWebViewMessage(rawMessage)).toEqual({
+        type: "click",
+        payload: {
+          resourceId: "resource-1",
+          isDownload: false,
+          isPost: false,
+        },
+      });
+    });
+
+    it("parses content page navigation state messages", () => {
+      const rawMessage = JSON.stringify({
+        type: CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE,
+        payload: {
+          isVisible: true,
+          hasTableOfContents: true,
+          canGoPrevious: false,
+          canGoNext: true,
+        },
+      });
+
+      expect(parsePurchaseWebViewMessage(rawMessage)).toEqual({
+        type: CONTENT_PAGE_NAVIGATION_STATE_MESSAGE_TYPE,
+        payload: {
+          isVisible: true,
+          hasTableOfContents: true,
+          canGoPrevious: false,
+          canGoNext: true,
+        },
+      });
+    });
+
+    it("returns null for malformed json", () => {
+      expect(parsePurchaseWebViewMessage("{")).toBeNull();
+    });
+
+    it("returns null for messages with unsupported types", () => {
+      const rawMessage = JSON.stringify({
+        type: "unknown",
+        payload: {},
+      });
+
+      expect(parsePurchaseWebViewMessage(rawMessage)).toBeNull();
+    });
+
+    it("returns null for click messages with missing resource id", () => {
+      const rawMessage = JSON.stringify({
+        type: "click",
+        payload: {
+          isDownload: false,
+          isPost: false,
+        },
+      });
+
+      expect(parsePurchaseWebViewMessage(rawMessage)).toBeNull();
+    });
+  });
+
+  describe("createContentPageNavigationCommandMessage", () => {
+    it("builds a navigation command message", () => {
+      expect(createContentPageNavigationCommandMessage("goNext")).toBe(
+        JSON.stringify({
+          type: MOBILE_APP_CONTENT_PAGE_NAVIGATION_COMMAND_MESSAGE_TYPE,
+          payload: { action: "goNext" },
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Issue 
Closes #27 

## Summary
Replaced the in-page HTML content navigation (table of contents / previous / next) in purchase pages with a native sticky footer in the mobile app.

## Root cause
The navigation controls were rendered inside WebView HTML only. On long pages, users had to scroll to the bottom to navigate, and React Native had no state/command contract for those controls.

## What changed
- Added a WebView bridge contract for content navigation state and commands.
- Injected a mobile bridge script to:
  - detect and report content navigation state to React Native
  - hide HTML navigation controls in mobile app view
  - execute native commands (`openTableOfContents`, `goPrevious`, `goNext`) by triggering the corresponding DOM actions
- Added a native sticky footer with:
  - table of contents button
  - previous/next buttons
  - disabled states based on bridge state
  - safe-area handling
- Kept existing media click handling (audio/video/pdf/download) intact.
- Added unit tests for message parsing and command serialization.

## Files
- `app/purchase/[id].tsx`
- `components/purchase-content-navigation-footer.tsx`
- `lib/purchase-content-navigation.ts`
- `tests/lib/purchase-content-navigation.test.ts`

## Testing
- Unit: `tests/lib/purchase-content-navigation.test.ts`
- Manual app testing: Not run on device/emulator due to local device constraints.
- Automated testing: npm run test (all suites passing).
- Risk: UI behavior on real device still needs reviewer verification.

## Evidence
- Local test pass screenshot: 
<img width="1073" height="447" alt="Screenshot from 2026-02-20 17-14-02" src="https://github.com/user-attachments/assets/6d5ddec2-1d08-4ea9-9039-46612ee2a245" />


<img width="1073" height="447" alt="Screenshot from 2026-02-20 17-08-30" src="https://github.com/user-attachments/assets/e84bec91-b25f-4b4b-8201-0171c2abfbe5" />



## Self-review
- The non-obvious part is the bridge heuristic in `purchase-content-navigation.ts`; it picks the closest previous/next control pair and mirrors state to native.
- The parser remains backward-compatible with existing WebView `click` messages to avoid regressions.

## AI disclosure
- Model: GPT-5.3 Codex xhigh
- Tooling : Codex VS Code Extension
- Used for: codebase exploration,  test scaffolding, and PR description drafting
- I manually reviewed and adjusted all code and this PR description.

## Confirmation
I watched the Antiwork PR live streaming videos.
