### PR TITLE
feat: Render table of contents natively on the purchase page

### DIFF
--- a/components/table-of-contents-bar.tsx
+++ b/components/table-of-contents-bar.tsx
@@ -1,0 +1,97 @@
+import { LineIcon } from "@/components/icon";
+import { Text } from "@/components/ui/text";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { FlatList, Pressable, View } from "react-native";
+
+export type ContentPage = {
+  id: string;
+  name: string;
+};
+
+type TableOfContentsBarProps = {
+  pages: ContentPage[];
+  currentPageIndex: number;
+  onNavigate: (pageIndex: number) => void;
+};
+
+export const TableOfContentsBar = ({ pages, currentPageIndex, onNavigate }: TableOfContentsBarProps) => {
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  if (pages.length <= 1) return null;
+
+  const hasPrev = currentPageIndex > 0;
+  const hasNext = currentPageIndex < pages.length - 1;
+  const currentPage = pages[currentPageIndex];
+
+  return (
+    <>
+      <View className="flex-row items-center border-t border-border bg-body-bg px-2 py-1">
+        <Pressable
+          onPress={() => hasPrev && onNavigate(currentPageIndex - 1)}
+          className={cn("p-3", !hasPrev && "opacity-30")}
+          disabled={!hasPrev}
+          accessibilityLabel="Previous page"
+          accessibilityRole="button"
+        >
+          <LineIcon name="chevron-up" size={22} className="text-foreground" />
+        </Pressable>
+
+        <Pressable onPress={() => setSheetOpen(true)} className="flex-1 flex-row items-center justify-center px-2 py-2" accessibilityLabel="Table of contents" accessibilityRole="button">
+          <LineIcon name="book-content" size={18} className="mr-2 text-foreground" />
+          <Text className="text-sm text-foreground" numberOfLines={1}>
+            {currentPage?.name ?? `Page ${currentPageIndex + 1}`}
+          </Text>
+          <Text className="ml-1 text-xs text-muted-foreground">
+            ({currentPageIndex + 1}/{pages.length})
+          </Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => hasNext && onNavigate(currentPageIndex + 1)}
+          className={cn("p-3", !hasNext && "opacity-30")}
+          disabled={!hasNext}
+          accessibilityLabel="Next page"
+          accessibilityRole="button"
+        >
+          <LineIcon name="chevron-down" size={22} className="text-foreground" />
+        </Pressable>
+      </View>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetHeader onClose={() => setSheetOpen(false)}>
+          <SheetTitle>Table of Contents</SheetTitle>
+        </SheetHeader>
+        <SheetContent>
+          <FlatList
+            data={pages}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item, index }) => (
+              <Pressable
+                onPress={() => {
+                  onNavigate(index);
+                  setSheetOpen(false);
+                }}
+                className={cn(
+                  "border-b border-border px-4 py-3",
+                  index === currentPageIndex && "bg-accent",
+                )}
+                accessibilityRole="button"
+              >
+                <Text
+                  className={cn(
+                    "text-base text-foreground",
+                    index === currentPageIndex && "font-bold",
+                  )}
+                >
+                  {item.name}
+                </Text>
+              </Pressable>
+            )}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};

--- a/components/use-table-of-contents.ts
+++ b/components/use-table-of-contents.ts
@@ -1,0 +1,176 @@
+import { useCallback, useState } from "react";
+import type { WebView } from "react-native-webview";
+import type { ContentPage } from "./table-of-contents-bar";
+
+export type TocMessage =
+  | { type: "tocPages"; payload: { pages: ContentPage[]; currentPageIndex: number } }
+  | { type: "tocPageChanged"; payload: { currentPageIndex: number } };
+
+/**
+ * JavaScript injected into the WebView to:
+ * 1. Hide the HTML table of contents and navigation buttons
+ * 2. Extract page data and send it to React Native
+ * 3. Listen for navigation messages from React Native
+ */
+export const TOC_INJECTED_JS = `
+(function() {
+  // Hide the native TOC elements rendered by the Gumroad web app
+  function hideHtmlToc() {
+    var style = document.getElementById('mobile-app-toc-hide');
+    if (!style) {
+      style = document.createElement('style');
+      style.id = 'mobile-app-toc-hide';
+      style.textContent = [
+        '.content-page-navigation { display: none !important; }',
+        '.table-of-contents { display: none !important; }',
+        '[data-component="TableOfContents"] { display: none !important; }',
+        '.rich-content-toc { display: none !important; }',
+      ].join('\\n');
+      document.head.appendChild(style);
+    }
+  }
+
+  // Extract page data from the DOM
+  function extractPages() {
+    var pages = [];
+    var links = document.querySelectorAll('.table-of-contents a, [data-component="TableOfContents"] a, .content-page-navigation a');
+    var seen = new Set();
+    links.forEach(function(link) {
+      var href = link.getAttribute('href') || '';
+      var name = link.textContent.trim();
+      if (name && !seen.has(href)) {
+        seen.add(href);
+        pages.push({ id: href, name: name });
+      }
+    });
+
+    // Also try to extract from content page data attributes or script tags
+    if (pages.length === 0) {
+      var contentPages = document.querySelectorAll('[data-content-page]');
+      contentPages.forEach(function(el, i) {
+        pages.push({
+          id: el.getAttribute('data-content-page') || String(i),
+          name: el.getAttribute('data-content-page-name') || ('Page ' + (i + 1))
+        });
+      });
+    }
+
+    // Try extracting from React props in __NEXT_DATA__ or similar
+    if (pages.length === 0) {
+      try {
+        var scripts = document.querySelectorAll('script');
+        scripts.forEach(function(script) {
+          var text = script.textContent || '';
+          var match = text.match(/content_pages["\s]*:["\s]*(\[.*?\])/);
+          if (match) {
+            try {
+              var parsed = JSON.parse(match[1]);
+              parsed.forEach(function(p, i) {
+                pages.push({ id: p.id || String(i), name: p.name || p.title || ('Page ' + (i + 1)) });
+              });
+            } catch(e) {}
+          }
+        });
+      } catch(e) {}
+    }
+
+    return pages;
+  }
+
+  function getCurrentPageIndex(pages) {
+    var path = window.location.pathname + window.location.search;
+    for (var i = 0; i < pages.length; i++) {
+      if (path.indexOf(pages[i].id) !== -1) return i;
+    }
+    return 0;
+  }
+
+  function sendTocData() {
+    hideHtmlToc();
+    var pages = extractPages();
+    if (pages.length > 0) {
+      var currentPageIndex = getCurrentPageIndex(pages);
+      window.ReactNativeWebView.postMessage(JSON.stringify({
+        type: 'tocPages',
+        payload: { pages: pages, currentPageIndex: currentPageIndex }
+      }));
+    }
+  }
+
+  // Listen for navigation messages from React Native
+  window.addEventListener('message', function(event) {
+    try {
+      var msg = typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+      if (msg.type === 'navigateToPage' && msg.payload && msg.payload.pageId) {
+        // Navigate to the page
+        var link = document.querySelector('a[href*="' + msg.payload.pageId + '"]');
+        if (link) {
+          link.click();
+        } else {
+          window.location.href = msg.payload.pageId;
+        }
+      }
+    } catch(e) {}
+  });
+
+  // Run on load and on navigation
+  if (document.readyState === 'complete') {
+    setTimeout(sendTocData, 500);
+  } else {
+    window.addEventListener('load', function() { setTimeout(sendTocData, 500); });
+  }
+
+  // MutationObserver to detect page changes
+  var observer = new MutationObserver(function() {
+    hideHtmlToc();
+  });
+  observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
+
+  true;
+})();
+`;
+
+export const useTableOfContents = (webViewRef: React.RefObject<WebView | null>) => {
+  const [pages, setPages] = useState<ContentPage[]>([]);
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
+  const handleTocMessage = useCallback((data: string): boolean => {
+    try {
+      const message = JSON.parse(data) as TocMessage;
+      if (message.type === "tocPages") {
+        setPages(message.payload.pages);
+        setCurrentPageIndex(message.payload.currentPageIndex);
+        return true;
+      }
+      if (message.type === "tocPageChanged") {
+        setCurrentPageIndex(message.payload.currentPageIndex);
+        return true;
+      }
+    } catch {
+      // Not a TOC message
+    }
+    return false;
+  }, []);
+
+  const navigateToPage = useCallback(
+    (pageIndex: number) => {
+      const page = pages[pageIndex];
+      if (!page) return;
+      setCurrentPageIndex(pageIndex);
+      webViewRef.current?.postMessage(
+        JSON.stringify({
+          type: "navigateToPage",
+          payload: { pageId: page.id },
+        }),
+      );
+    },
+    [pages, webViewRef],
+  );
+
+  return {
+    pages,
+    currentPageIndex,
+    handleTocMessage,
+    navigateToPage,
+  };
+};

--- a/tests/components/table-of-contents-bar.test.tsx
+++ b/tests/components/table-of-contents-bar.test.tsx
@@ -1,0 +1,77 @@
+import { TableOfContentsBar, ContentPage } from "@/components/table-of-contents-bar";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+const mockPages: ContentPage[] = [
+  { id: "page-1", name: "Introduction" },
+  { id: "page-2", name: "Chapter 1" },
+  { id: "page-3", name: "Chapter 2" },
+];
+
+const mockOnNavigate = jest.fn();
+
+beforeEach(() => {
+  mockOnNavigate.mockClear();
+});
+
+describe("TableOfContentsBar", () => {
+  it("renders nothing when there is only one page", () => {
+    const { toJSON } = render(
+      <TableOfContentsBar pages={[mockPages[0]]} currentPageIndex={0} onNavigate={mockOnNavigate} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders nothing when there are no pages", () => {
+    const { toJSON } = render(
+      <TableOfContentsBar pages={[]} currentPageIndex={0} onNavigate={mockOnNavigate} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("displays the current page name and count", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={1} onNavigate={mockOnNavigate} />);
+    expect(screen.getByText("Chapter 1")).toBeTruthy();
+    expect(screen.getByText("(2/3)")).toBeTruthy();
+  });
+
+  it("calls onNavigate with previous page index", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={1} onNavigate={mockOnNavigate} />);
+    fireEvent.press(screen.getByLabelText("Previous page"));
+    expect(mockOnNavigate).toHaveBeenCalledWith(0);
+  });
+
+  it("calls onNavigate with next page index", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={1} onNavigate={mockOnNavigate} />);
+    fireEvent.press(screen.getByLabelText("Next page"));
+    expect(mockOnNavigate).toHaveBeenCalledWith(2);
+  });
+
+  it("disables previous button on first page", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={0} onNavigate={mockOnNavigate} />);
+    const prevButton = screen.getByLabelText("Previous page");
+    expect(prevButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it("disables next button on last page", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={2} onNavigate={mockOnNavigate} />);
+    const nextButton = screen.getByLabelText("Next page");
+    expect(nextButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it("opens table of contents sheet when center button is pressed", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={0} onNavigate={mockOnNavigate} />);
+    fireEvent.press(screen.getByLabelText("Table of contents"));
+    // All page names should be visible in the sheet (Introduction appears twice: bar + sheet)
+    expect(screen.getAllByText("Introduction").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Chapter 1").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Chapter 2").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Table of Contents")).toBeTruthy();
+  });
+
+  it("navigates when a page in the sheet is tapped", () => {
+    render(<TableOfContentsBar pages={mockPages} currentPageIndex={0} onNavigate={mockOnNavigate} />);
+    fireEvent.press(screen.getByLabelText("Table of contents"));
+    fireEvent.press(screen.getByText("Chapter 2"));
+    expect(mockOnNavigate).toHaveBeenCalledWith(2);
+  });
+});

--- a/tests/components/use-table-of-contents.test.ts
+++ b/tests/components/use-table-of-contents.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { useTableOfContents } from "@/components/use-table-of-contents";
+
+const mockPostMessage = jest.fn();
+const mockWebViewRef = { current: { postMessage: mockPostMessage } } as any;
+
+beforeEach(() => {
+  mockPostMessage.mockClear();
+});
+
+describe("useTableOfContents", () => {
+  it("initializes with empty pages", () => {
+    const { result } = renderHook(() => useTableOfContents(mockWebViewRef));
+    expect(result.current.pages).toEqual([]);
+    expect(result.current.currentPageIndex).toBe(0);
+  });
+
+  it("handles tocPages message", () => {
+    const { result } = renderHook(() => useTableOfContents(mockWebViewRef));
+    const pages = [
+      { id: "p1", name: "Page 1" },
+      { id: "p2", name: "Page 2" },
+    ];
+
+    act(() => {
+      const handled = result.current.handleTocMessage(
+        JSON.stringify({ type: "tocPages", payload: { pages, currentPageIndex: 1 } }),
+      );
+      expect(handled).toBe(true);
+    });
+
+    expect(result.current.pages).toEqual(pages);
+    expect(result.current.currentPageIndex).toBe(1);
+  });
+
+  it("handles tocPageChanged message", () => {
+    const { result } = renderHook(() => useTableOfContents(mockWebViewRef));
+
+    // First set pages
+    act(() => {
+      result.current.handleTocMessage(
+        JSON.stringify({
+          type: "tocPages",
+          payload: { pages: [{ id: "p1", name: "Page 1" }, { id: "p2", name: "Page 2" }], currentPageIndex: 0 },
+        }),
+      );
+    });
+
+    act(() => {
+      const handled = result.current.handleTocMessage(
+        JSON.stringify({ type: "tocPageChanged", payload: { currentPageIndex: 1 } }),
+      );
+      expect(handled).toBe(true);
+    });
+
+    expect(result.current.currentPageIndex).toBe(1);
+  });
+
+  it("returns false for non-TOC messages", () => {
+    const { result } = renderHook(() => useTableOfContents(mockWebViewRef));
+    act(() => {
+      const handled = result.current.handleTocMessage(JSON.stringify({ type: "click", payload: {} }));
+      expect(handled).toBe(false);
+    });
+  });
+
+  it("sends navigate message to WebView", () => {
+    const { result } = renderHook(() => useTableOfContents(mockWebViewRef));
+    const pages = [
+      { id: "p1", name: "Page 1" },
+      { id: "p2", name: "Page 2" },
+    ];
+
+    act(() => {
+      result.current.handleTocMessage(
+        JSON.stringify({ type: "tocPages", payload: { pages, currentPageIndex: 0 } }),
+      );
+    });
+
+    act(() => {
+      result.current.navigateToPage(1);
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith(
+      JSON.stringify({ type: "navigateToPage", payload: { pageId: "p2" } }),
+    );
+    expect(result.current.currentPageIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Resolves #27 — Replaces the HTML-based table of contents with a native sticky footer bar on the purchase page.

/claim #27

## What Changed

### New Components

**`TableOfContentsBar`** — A native sticky footer bar with:
- ⬆️ Previous / ⬇️ Next page navigation buttons (disabled at boundaries)
- 📖 Center button showing current page name and count (e.g. "Chapter 1 (2/5)")
- Tapping the center button opens a full **Table of Contents** bottom sheet (using the existing `Sheet` component)
- Selecting any page in the sheet navigates directly to it

**`useTableOfContents`** hook — Manages TOC state and WebView communication:
- Parses `tocPages` and `tocPageChanged` messages from the WebView
- Sends `navigateToPage` messages back to the WebView
- Optimistically updates the current page index for instant UI feedback

**Injected JavaScript** (`TOC_INJECTED_JS`):
- Hides the HTML table of contents and navigation buttons via CSS injection
- Extracts page data from the DOM (supports multiple selector strategies)
- Sends page data to React Native via `postMessage`
- Listens for navigation commands from React Native
- Uses `MutationObserver` to keep HTML TOC hidden on DOM changes

### Modified Files

**`app/purchase/[id].tsx`**:
- Integrates `TableOfContentsBar` in the footer area (above `MiniAudioPlayer`)
- Injects the TOC JavaScript into the WebView
- Routes TOC messages through the new hook before the existing click handler

## Architecture

```
┌─────────────────────────────┐
│   WebView (Gumroad web)     │
│                             │
│  Injected JS:               │
│  - Hides HTML TOC           │
│  - Extracts page data ──────┼──→ postMessage("tocPages")
│  - Listens for navigation ◄─┼──── postMessage("navigateToPage")
│                             │
└─────────────────────────────┘
         ↕ messages
┌─────────────────────────────┐
│   React Native              │
│                             │
│  useTableOfContents hook    │
│  TableOfContentsBar component│
│  - Previous/Next buttons    │
│  - TOC sheet (bottom sheet) │
└─────────────────────────────┘
```

## Web App Changes Needed

The injected JavaScript currently hides the HTML TOC via CSS selectors. For a more robust solution, the Gumroad web app should check for the `display=mobile_app` parameter and skip rendering the TOC server-side. The current CSS approach works as an interim solution.

## Tests

Added **14 new tests** (all passing, full suite: 64/64):

- `tests/components/table-of-contents-bar.test.tsx` — Renders nothing for ≤1 page, displays current page info, prev/next navigation, disabled states, sheet opening, sheet navigation
- `tests/components/use-table-of-contents.test.ts` — Initial state, tocPages handling, tocPageChanged handling, non-TOC message rejection, navigate message sending

## Demo

> **Note:** This requires the Gumroad web app to serve content pages with the expected DOM structure. The native bar renders conditionally — it only appears when the WebView reports multiple content pages, so single-page products are unaffected.

The bar sits fixed at the bottom above the audio player, providing instant navigation without scrolling to find the HTML TOC.