### PR TITLE
Add native table of contents navigation for multi-page content products

### DIFF
--- a/app/purchase/[id].tsx
+++ b/app/purchase/[id].tsx
@@ -1,5 +1,5 @@
 import { usePurchases } from "@/app/(tabs)/library";
-import { ContentPageNav } from "@/components/content-page-nav";
+import { ContentPageNav, TocPage } from "@/components/content-page-nav";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledWebView } from "@/components/styled";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
@@ -36,7 +36,7 @@ type ClickMessage = {
 type TocDataMessage = {
   type: "tocData";
   payload: {
-    pages: { page_id: string; title: string | null }[];
+    pages: TocPage[];
     activePageIndex: number;
   };
 };
@@ -179,12 +179,13 @@ export default function DownloadScreen() {
           <LoadingSpinner size="large" />
         </View>
       )}
+      <View className="bg-body-bg">
+        <MiniAudioPlayer />
+      </View>
       {tocPages.length > 0 && (
         <ContentPageNav pages={tocPages} activePageIndex={activePageIndex} onPageChange={handleNativePageChange} />
       )}
-      <View className="bg-body-bg" style={{ paddingBottom: bottom }}>
-        <MiniAudioPlayer />
-      </View>
+      <View style={{ paddingBottom: bottom }} />
     </Screen>
   );
 }

--- a/components/content-page-nav.tsx
+++ b/components/content-page-nav.tsx
@@ -1,13 +1,24 @@
-import { LineIcon } from "@/components/icon";
+import { LineIcon, LineIconName } from "@/components/icon";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Text } from "@/components/ui/text";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { FlatList, Pressable, View } from "react-native";
 
-type TocPage = {
+export type TocPage = {
   page_id: string;
   title: string | null;
+  icon: PageIconType;
+};
+
+type PageIconType = "license-key" | "text-only" | "video-file" | "music-file" | "mixed-files";
+
+const PAGE_ICON_COMPONENTS: Record<PageIconType, LineIconName> = {
+  "license-key": "key",
+  "text-only": "file-detail",
+  "video-file": "movie-play",
+  "music-file": "music-alt",
+  "mixed-files": "file-detail",
 };
 
 export const ContentPageNav = ({
@@ -25,27 +36,27 @@ export const ContentPageNav = ({
 
   return (
     <>
-      <View className="flex-row items-center border-t border-border bg-background px-4 py-2">
+      <View className="flex-row items-center border-t border-border bg-body-bg">
+        <Pressable onPress={() => setSheetOpen(true)} className="flex-1 flex-row items-center gap-1.5 px-4 py-3">
+          <LineIcon name="list-ul" size={18} className="text-foreground" />
+          <Text className="text-sm font-bold text-foreground" numberOfLines={1}>
+            {pages[activePageIndex].title}
+          </Text>
+        </Pressable>
+
         <Pressable
           onPress={() => onPageChange(activePageIndex - 1)}
           disabled={!hasPrevious}
-          className={cn("flex-row items-center gap-1", !hasPrevious && "opacity-50")}
+          className={cn("flex-row items-center gap-1 px-4 py-3", !hasPrevious && "opacity-50")}
         >
           <LineIcon name="chevron-left" size={20} className="text-foreground" />
           <Text className="text-sm text-foreground">Previous</Text>
         </Pressable>
 
-        <Pressable onPress={() => setSheetOpen(true)} className="flex-1 flex-row items-center justify-center gap-1.5">
-          <LineIcon name="book-content" size={18} className="text-foreground" />
-          <Text className="text-sm font-bold text-foreground">
-            {activePageIndex + 1} of {pages.length}
-          </Text>
-        </Pressable>
-
         <Pressable
           onPress={() => onPageChange(activePageIndex + 1)}
           disabled={!hasNext}
-          className={cn("flex-row items-center gap-1", !hasNext && "opacity-50")}
+          className={cn("flex-row items-center gap-1 px-4 py-3", !hasNext && "opacity-50")}
         >
           <Text className="text-sm text-foreground">Next</Text>
           <LineIcon name="chevron-right" size={20} className="text-foreground" />
@@ -68,18 +79,14 @@ export const ContentPageNav = ({
                     onPageChange(index);
                     setSheetOpen(false);
                   }}
-                  className={cn("flex-row items-center gap-3 px-4 py-3", isActive && "bg-accent")}
+                  className={cn("flex-row items-center gap-3 px-4 py-3", isActive && "bg-muted/20")}
                 >
-                  <Text className={cn("text-sm", isActive ? "font-bold text-accent-foreground" : "text-foreground")}>
-                    {index + 1}.
-                  </Text>
-                  <Text
-                    className={cn(
-                      "flex-1 text-sm",
-                      isActive ? "font-bold text-accent-foreground" : "text-foreground",
-                    )}
-                    numberOfLines={2}
-                  >
+                  <LineIcon
+                    name={PAGE_ICON_COMPONENTS[item.icon] ?? "file-detail"}
+                    size={20}
+                    className="text-foreground"
+                  />
+                  <Text className={cn("flex-1", isActive && "font-bold")} numberOfLines={2}>
                     {item.title ?? "Untitled"}
                   </Text>
                 </Pressable>

--- a/tests/components/content-page-nav.test.tsx
+++ b/tests/components/content-page-nav.test.tsx
@@ -5,6 +5,7 @@ const makePages = (count: number) =>
   Array.from({ length: count }, (_, i) => ({
     page_id: `page-${i}`,
     title: `Page ${i + 1}`,
+    icon: "text-only" as const,
   }));
 
 describe("ContentPageNav", () => {
@@ -14,9 +15,9 @@ describe("ContentPageNav", () => {
     jest.clearAllMocks();
   });
 
-  it("renders page counter with correct position", () => {
+  it("renders active page title", () => {
     render(<ContentPageNav pages={makePages(5)} activePageIndex={2} onPageChange={onPageChange} />);
-    expect(screen.getByText("3 of 5")).toBeTruthy();
+    expect(screen.getByText("Page 3")).toBeTruthy();
   });
 
   it("calls onPageChange with previous index when Previous is pressed", () => {
@@ -45,18 +46,17 @@ describe("ContentPageNav", () => {
 
   it("displays page titles with 'Untitled' for null titles in sheet", () => {
     const pages = [
-      { page_id: "p1", title: "Introduction" },
-      { page_id: "p2", title: null },
+      { page_id: "p1", title: "Introduction", icon: "text-only" as const },
+      { page_id: "p2", title: null, icon: "text-only" as const },
     ];
     render(<ContentPageNav pages={pages} activePageIndex={0} onPageChange={onPageChange} />);
-    fireEvent.press(screen.getByText("1 of 2"));
-    expect(screen.getByText("Introduction")).toBeTruthy();
+    fireEvent.press(screen.getByText("Introduction"));
     expect(screen.getByText("Untitled")).toBeTruthy();
   });
 
   it("calls onPageChange when a page is selected in the sheet", () => {
     render(<ContentPageNav pages={makePages(3)} activePageIndex={0} onPageChange={onPageChange} />);
-    fireEvent.press(screen.getByText("1 of 3"));
+    fireEvent.press(screen.getByText("Page 1"));
     fireEvent.press(screen.getByText("Page 3"));
     expect(onPageChange).toHaveBeenCalledWith(2);
   });


### PR DESCRIPTION
Issue: #27 

# Description

## Problem

Products with multiple content pages show a web-based TOC button and Previous/Next buttons at the bottom of the HTML content in the WebView. This requires scrolling down on long pages to navigate between pages, which is a poor mobile UX.

## Solution

Replace the web-based navigation with a native sticky footer bar that is always visible. The footer has Previous/Next buttons, a page counter ("2 of 5"), and a TOC button that opens a sheet with the full page list.

**Mobile app changes (`gumroad-mobile`):**
- New `ContentPageNav` component: sticky footer with Previous/Next, page counter, and TOC sheet
- Updated purchase page to handle `tocData` messages from web and send `mobileAppPageChange` messages back

**Web changes (`gumroad`):**
- Hide web TOC/Previous/Next nav when in mobile app WebView
- Send `tocData` message to React Native with pages and active index
- Listen for `mobileAppPageChange` messages from React Native

**Companion web changes:** This feature requires changes to `gumroad` web repo (`WithContent.tsx`). The implementation is ready on branch [`feat/native-toc-navigation`](https://github.com/yashranaway/gumroad/tree/feat/native-toc-navigation) but I'm unable to open a PR on `antiwork/gumroad` since it's limited to collaborators. The web-side diff is small (1 file, ~40 lines)  happy to share it however is preferred.

---

# Before/After

## before
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/652ca59a-7b93-4065-9f76-5eeffc9d73fe" />

## after
https://github.com/user-attachments/assets/5387b7d0-edbb-4ccd-ac2b-1d39058893f5



---

# Test Results

<img width="424" height="136" alt="image" src="https://github.com/user-attachments/assets/61cca25c-ecd4-4102-9019-fbefdbe3ba44" />


---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Claude Opus 4.6 was used to assist with implementation and test writing.
