### PR TITLE
Render table of contents natively on the purchase page

### DIFF
--- a/.maestro/toc-navigation.yaml
+++ b/.maestro/toc-navigation.yaml
@@ -1,0 +1,50 @@
+appId: ${APP_ID}
+---
+- runFlow:
+      file: utils/launch.yaml
+- runFlow:
+      when:
+          visible: Logout
+      commands:
+          - tapOn: Logout
+- tapOn: Sign in with Gumroad
+- runFlow:
+      when:
+          visible: Continue
+      commands:
+          - tapOn: Continue
+- scrollUntilVisible:
+      element: Login
+- tapOn: Email
+- inputText: ${TEST_EMAIL}
+- pressKey: enter
+- inputText: password
+- pressKey: enter
+- runFlow:
+      when:
+          visible: Not Now
+      commands:
+          - tapOn: Not Now
+- runFlow:
+      when:
+          visible: Authentication Token
+      commands:
+          - tapOn: Login
+- assertVisible: Authorize
+- tapOn: Authorize
+- assertVisible: Library
+- tapOn:
+      index: 0
+- runFlow:
+      when:
+          visible: Contents
+      commands:
+          - assertVisible: Prev
+          - assertVisible: Next
+          - tapOn: Next
+          - assertVisible: Contents
+          - tapOn: Contents
+          - assertVisible: Contents
+          - tapOn:
+                index: 0
+          - assertVisible: Contents

--- a/__tests__/purchase/toc-navigation.test.tsx
+++ b/__tests__/purchase/toc-navigation.test.tsx
@@ -1,0 +1,265 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import { act } from "react";
+
+const mockPush = jest.fn();
+const mockInjectJavaScript = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ accessToken: "test-token", isLoading: false }),
+}));
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ id: "test-token-123" }),
+  useRouter: () => ({ push: mockPush }),
+  Stack: { Screen: () => null },
+}));
+
+jest.mock("@/app/(tabs)/library", () => ({
+  usePurchases: () => ({
+    data: [
+      {
+        name: "Test Product",
+        url_redirect_token: "test-token-123",
+        creator_name: "Test Creator",
+        thumbnail_url: null,
+        purchase_id: "purchase-1",
+        file_data: [],
+      },
+    ],
+  }),
+}));
+
+jest.mock("@/components/use-audio-player-sync", () => ({
+  useAudioPlayerSync: () => ({ pauseAudio: jest.fn(), playAudio: jest.fn() }),
+}));
+
+jest.mock("expo-file-system", () => ({
+  File: { downloadFileAsync: jest.fn() },
+  Paths: { cache: "/cache" },
+}));
+
+jest.mock("expo-sharing", () => ({
+  isAvailableAsync: jest.fn().mockResolvedValue(true),
+  shareAsync: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 34, left: 0, right: 0 }),
+}));
+
+jest.mock("react-native-track-player", () => ({
+  __esModule: true,
+  default: {
+    getActiveTrack: jest.fn().mockResolvedValue(undefined),
+    pause: jest.fn(),
+    play: jest.fn(),
+    getProgress: jest.fn().mockResolvedValue({ position: 0, duration: 0 }),
+    seekTo: jest.fn(),
+  },
+  State: { Playing: "playing", Buffering: "buffering", Loading: "loading" },
+  useActiveTrack: () => undefined,
+  usePlaybackState: () => ({ state: undefined }),
+  useProgress: () => ({ position: 0, duration: 0 }),
+}));
+
+jest.mock("react-native-webview", () => {
+  const { forwardRef, useImperativeHandle } = require("react");
+  const { View } = require("react-native");
+  const WebView = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+    useImperativeHandle(ref, () => ({
+      injectJavaScript: mockInjectJavaScript,
+    }));
+    return <View testID="webview" {...props} />;
+  });
+  WebView.displayName = "WebView";
+  return { WebView, WebViewMessageEvent: {} };
+});
+
+jest.mock("@/components/styled", () => {
+  const { forwardRef, useImperativeHandle } = require("react");
+  const { View } = require("react-native");
+  const StyledWebView = forwardRef((props: Record<string, unknown>, ref: unknown) => {
+    useImperativeHandle(ref, () => ({
+      injectJavaScript: mockInjectJavaScript,
+    }));
+    return <View testID="styled-webview" {...props} />;
+  });
+  StyledWebView.displayName = "StyledWebView";
+  return { StyledWebView, StyledImage: View };
+});
+
+const renderScreen = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const DownloadScreen = require("@/app/purchase/[id]").default;
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DownloadScreen />
+    </QueryClientProvider>,
+  );
+};
+
+const simulateTocMessage = (payload: {
+  items: { id: string; title: string }[];
+  currentIndex: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}) => {
+  const webview = screen.getByTestId("styled-webview");
+  const onMessage = webview.props.onMessage;
+  act(() => {
+    onMessage({
+      nativeEvent: {
+        data: JSON.stringify({ type: "toc_state", payload }),
+      },
+    });
+  });
+};
+
+const MULTI_ITEM_PAYLOAD = {
+  items: [
+    { id: "0", title: "Introduction" },
+    { id: "1", title: "Chapter 1" },
+    { id: "2", title: "Chapter 2" },
+  ],
+  currentIndex: 1,
+  hasNext: true,
+  hasPrev: true,
+};
+
+const SINGLE_ITEM_PAYLOAD = {
+  items: [{ id: "0", title: "Only page" }],
+  currentIndex: 0,
+  hasNext: false,
+  hasPrev: false,
+};
+
+describe("TOC Navigation Footer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("injects TOC bridge JavaScript into the WebView", () => {
+    renderScreen();
+    const webview = screen.getByTestId("styled-webview");
+    const injectedJS = webview.props.injectedJavaScript;
+    expect(injectedJS).toBeDefined();
+    expect(injectedJS).toContain("__tocBridgeInitialized");
+    expect(injectedJS).toContain("ReactNativeWebView.postMessage");
+    expect(injectedJS).toContain("native_navigate_toc");
+    expect(injectedJS).toContain('role="navigation"');
+    expect(injectedJS).toContain("MutationObserver");
+  });
+
+  it("footer does not render when no toc_state has been received", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("footer does not render when toc_state has only one item", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    renderScreen();
+    simulateTocMessage(SINGLE_ITEM_PAYLOAD);
+    expect(screen.queryByText("Prev")).toBeNull();
+    expect(screen.queryByText("Next")).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("footer renders when toc_state payload contains more than one item", () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    expect(screen.getByText("Contents")).toBeTruthy();
+    expect(screen.getByText("Prev")).toBeTruthy();
+    expect(screen.getByText("Next")).toBeTruthy();
+  });
+
+  it("Prev button does not trigger navigation when hasPrev is false", () => {
+    renderScreen();
+    simulateTocMessage({ ...MULTI_ITEM_PAYLOAD, currentIndex: 0, hasPrev: false });
+    fireEvent.press(screen.getByText("Prev"));
+    expect(mockInjectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it("Next button does not trigger navigation when hasNext is false", () => {
+    renderScreen();
+    simulateTocMessage({ ...MULTI_ITEM_PAYLOAD, currentIndex: 2, hasNext: false });
+    fireEvent.press(screen.getByText("Next"));
+    expect(mockInjectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it("Prev button triggers navigation to previous index", () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    fireEvent.press(screen.getByText("Prev"));
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("native_navigate_toc"),
+    );
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("index: 0"),
+    );
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringMatching(/\)\); true;$/),
+    );
+  });
+
+  it("Next button triggers navigation to next index", () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    fireEvent.press(screen.getByText("Next"));
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("native_navigate_toc"),
+    );
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("index: 2"),
+    );
+  });
+
+  it("Contents button opens toc sheet", () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    fireEvent.press(screen.getByText("Contents"));
+    expect(screen.getByText("Introduction")).toBeTruthy();
+    expect(screen.getByText("Chapter 1")).toBeTruthy();
+    expect(screen.getByText("Chapter 2")).toBeTruthy();
+  });
+
+  it("toc sheet item press navigates to target index and closes sheet", () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    fireEvent.press(screen.getByText("Contents"));
+    fireEvent.press(screen.getByText("Introduction"));
+    expect(mockInjectJavaScript).toHaveBeenCalledWith(
+      expect.stringContaining("index: 0"),
+    );
+  });
+
+  it("click messages are still handled correctly after toc_state received", async () => {
+    renderScreen();
+    simulateTocMessage(MULTI_ITEM_PAYLOAD);
+    expect(screen.getByText("Contents")).toBeTruthy();
+    const webview = screen.getByTestId("styled-webview");
+    const onMessage = webview.props.onMessage;
+    await act(async () => {
+      onMessage({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: "click",
+            payload: {
+              resourceId: "file-1",
+              isDownload: false,
+              isPost: false,
+              extension: "PDF",
+            },
+          }),
+        },
+      });
+    });
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: "/pdf-viewer" }),
+    );
+  });
+});

--- a/app/purchase/[id].tsx
+++ b/app/purchase/[id].tsx
@@ -1,21 +1,25 @@
 import { usePurchases } from "@/app/(tabs)/library";
+import { LineIcon } from "@/components/icon";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledWebView } from "@/components/styled";
+import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Text } from "@/components/ui/text";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { buildApiUrl } from "@/lib/request";
+import { cn } from "@/lib/utils";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { useRef, useState } from "react";
-import { Alert, View } from "react-native";
+import { Alert, ScrollView, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
 
-// See antiwork/gumroad:app/javascript/components/Download/Interactions.tsx
 type ClickPayload = {
   resourceId: string;
   isDownload: boolean;
@@ -27,10 +31,162 @@ type ClickPayload = {
   contentLength?: string | null;
 };
 
-type ClickMessage = {
-  type: "click";
-  payload: ClickPayload;
+type TocItem = {
+  id: string;
+  title: string;
 };
+
+type TocStatePayload = {
+  items: TocItem[];
+  currentIndex: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+};
+
+type WebMessage =
+  | { type: "click"; payload: ClickPayload }
+  | { type: "toc_state"; payload: TocStatePayload };
+
+const ICON_SIZE_CHEVRON = 20;
+const ICON_SIZE_LIST = 16;
+
+const TOC_BRIDGE_JS = `
+(function() {
+  if (window.__tocBridgeInitialized) return;
+  window.__tocBridgeInitialized = true;
+
+  var NAV_SELECTORS = [
+    '[role="navigation"]',
+    '.content-page-navigation',
+    'nav[class*="page"]'
+  ];
+
+  function findNavElement() {
+    for (var i = 0; i < NAV_SELECTORS.length; i++) {
+      var el = document.querySelector(NAV_SELECTORS[i]);
+      if (el) return el;
+    }
+    return null;
+  }
+
+  function hideNavElement() {
+    var nav = findNavElement();
+    if (nav) nav.style.display = 'none';
+    return nav;
+  }
+
+  function extractTocState() {
+    var nav = findNavElement();
+    if (!nav) return null;
+
+    var buttons = nav.querySelectorAll('button, a[role="button"], [data-page]');
+    var pageButtons = [];
+    var currentIndex = -1;
+
+    buttons.forEach(function(btn, idx) {
+      var text = (btn.textContent || '').trim();
+      var isNavBtn = /^(previous|next|prev|←|→)/i.test(text);
+      if (isNavBtn || !text) return;
+
+      var isCurrent = btn.getAttribute('aria-current') === 'page'
+        || btn.classList.contains('active')
+        || btn.getAttribute('data-active') === 'true'
+        || btn.getAttribute('aria-selected') === 'true';
+
+      pageButtons.push({ el: btn, title: text });
+      if (isCurrent) currentIndex = pageButtons.length - 1;
+    });
+
+    if (pageButtons.length <= 1) {
+      var popoverTrigger = nav.querySelector('[data-popover-trigger], [aria-haspopup]');
+      if (popoverTrigger) {
+        popoverTrigger.click();
+        setTimeout(function() {
+          var listItems = document.querySelectorAll('[role="menu"] [role="menuitem"], [data-popover] button, [data-popover] a');
+          var popoverButtons = [];
+          var popCurrentIndex = -1;
+          listItems.forEach(function(item) {
+            var itemText = (item.textContent || '').trim();
+            if (!itemText) return;
+            var isActive = item.classList.contains('active')
+              || item.getAttribute('aria-current') === 'page'
+              || item.getAttribute('data-active') === 'true';
+            popoverButtons.push({ el: item, title: itemText });
+            if (isActive) popCurrentIndex = popoverButtons.length - 1;
+          });
+          if (popoverButtons.length > 1) {
+            window.__tocPageButtons = popoverButtons;
+            if (popCurrentIndex === -1) popCurrentIndex = 0;
+            sendTocState(popoverButtons, popCurrentIndex);
+          }
+          popoverTrigger.click();
+        }, 100);
+        return 'deferred';
+      }
+      return null;
+    }
+
+    window.__tocPageButtons = pageButtons;
+    if (currentIndex === -1) currentIndex = 0;
+    return { buttons: pageButtons, currentIndex: currentIndex };
+  }
+
+  function sendTocState(pageButtons, currentIndex) {
+    var items = pageButtons.map(function(p, i) {
+      return { id: String(i), title: p.title };
+    });
+    var payload = {
+      type: 'toc_state',
+      payload: {
+        items: items,
+        currentIndex: currentIndex,
+        hasNext: currentIndex < items.length - 1,
+        hasPrev: currentIndex > 0
+      }
+    };
+    if (window.ReactNativeWebView) {
+      window.ReactNativeWebView.postMessage(JSON.stringify(payload));
+    }
+  }
+
+  function handleExtraction() {
+    var result = extractTocState();
+    if (result && result !== 'deferred') {
+      hideNavElement();
+      sendTocState(result.buttons, result.currentIndex);
+    } else if (result === null) {
+      hideNavElement();
+    }
+  }
+
+  window.addEventListener('native_navigate_toc', function(e) {
+    var index = e.detail && e.detail.index;
+    if (typeof index !== 'number' || !window.__tocPageButtons) return;
+    var target = window.__tocPageButtons[index];
+    if (target && target.el) {
+      target.el.click();
+      setTimeout(handleExtraction, 300);
+    }
+  });
+
+  var observer = new MutationObserver(function() {
+    hideNavElement();
+    setTimeout(handleExtraction, 200);
+  });
+
+  function init() {
+    handleExtraction();
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    setTimeout(init, 500);
+  } else {
+    document.addEventListener('DOMContentLoaded', function() { setTimeout(init, 500); });
+  }
+})();
+true;
+`;
 
 const downloadUrl = (token: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${token}/${productFileId}`);
@@ -46,9 +202,11 @@ const shareFile = async (uri: string) => {
   await Sharing.shareAsync(uri);
 };
 
-export default function DownloadScreen() {
+const DownloadScreen = () => {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [isDownloading, setIsDownloading] = useState(false);
+  const [tocState, setTocState] = useState<TocStatePayload | null>(null);
+  const [isTocSheetOpen, setTocSheetOpen] = useState(false);
   const { data: purchases = [] } = usePurchases();
   const router = useRouter();
   const { isLoading, accessToken } = useAuth();
@@ -60,11 +218,23 @@ export default function DownloadScreen() {
   const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
 
+  const navigateToPage = (index: number) => {
+    webViewRef.current?.injectJavaScript(
+      `window.dispatchEvent(new CustomEvent('native_navigate_toc', { detail: { index: ${index} } })); true;`,
+    );
+    setTocSheetOpen(false);
+  };
+
   const handleMessage = async (event: WebViewMessageEvent) => {
     const data = event.nativeEvent.data;
     try {
-      const message = JSON.parse(data) as ClickMessage;
+      const message = JSON.parse(data) as WebMessage;
       console.info("WebView message received:", message);
+
+      if (message.type === "toc_state") {
+        setTocState(message.payload);
+        return;
+      }
 
       if (message.type !== "click") {
         console.warn("Unknown message from webview:", message);
@@ -87,6 +257,7 @@ export default function DownloadScreen() {
         });
         return;
       }
+
       if (message.payload.type === "audio" && !message.payload.isDownload) {
         if (message.payload.isPlaying === "true") {
           await pauseAudio();
@@ -105,6 +276,7 @@ export default function DownloadScreen() {
         }
         return;
       }
+
       if (fileData?.filegroup === "video" && !message.payload.isDownload) {
         router.push({
           pathname: "/video-player",
@@ -152,15 +324,67 @@ export default function DownloadScreen() {
         mediaPlaybackRequiresUserAction={false}
         originWhitelist={["*"]}
         onMessage={handleMessage}
+        injectedJavaScript={TOC_BRIDGE_JS}
       />
       {isDownloading && (
         <View className="absolute inset-0 items-center justify-center bg-black/50">
           <LoadingSpinner size="large" />
         </View>
       )}
+      {tocState && tocState.items.length > 1 && (
+        <View className="flex-row items-center justify-between border-t border-border bg-background px-4 py-3">
+          <TouchableOpacity
+            onPress={() => navigateToPage(tocState.currentIndex - 1)}
+            disabled={!tocState.hasPrev}
+            className={cn("flex-row items-center gap-1", !tocState.hasPrev && "opacity-30")}
+          >
+            <LineIcon name="chevron-left" size={ICON_SIZE_CHEVRON} className="text-foreground" />
+            <Text className="text-sm text-foreground">Prev</Text>
+          </TouchableOpacity>
+          <Button variant="outline" size="sm" onPress={() => setTocSheetOpen(true)}>
+            <LineIcon name="list-ul" size={ICON_SIZE_LIST} className="text-foreground" />
+            <Text>Contents</Text>
+          </Button>
+          <TouchableOpacity
+            onPress={() => navigateToPage(tocState.currentIndex + 1)}
+            disabled={!tocState.hasNext}
+            className={cn("flex-row items-center gap-1", !tocState.hasNext && "opacity-30")}
+          >
+            <Text className="text-sm text-foreground">Next</Text>
+            <LineIcon name="chevron-right" size={ICON_SIZE_CHEVRON} className="text-foreground" />
+          </TouchableOpacity>
+        </View>
+      )}
       <View className="bg-body-bg" style={{ paddingBottom: bottom }}>
         <MiniAudioPlayer />
       </View>
+      <Sheet open={isTocSheetOpen} onOpenChange={setTocSheetOpen}>
+        <SheetContent>
+          <SheetHeader onClose={() => setTocSheetOpen(false)}>
+            <SheetTitle>Contents</SheetTitle>
+          </SheetHeader>
+          <ScrollView>
+            {tocState?.items.map((item, index) => (
+              <TouchableOpacity
+                key={item.id}
+                onPress={() => navigateToPage(index)}
+                className={cn("border-b border-border p-4", index === tocState.currentIndex && "bg-muted/50")}
+              >
+                <Text
+                  className={cn(
+                    "font-sans text-base",
+                    index === tocState.currentIndex ? "font-bold text-accent" : "text-foreground",
+                  )}
+                >
+                  {item.title}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </SheetContent>
+      </Sheet>
     </Screen>
   );
-}
+};
+
+export default DownloadScreen;


### PR DESCRIPTION
Closes #27

### Problem

Products with multiple content pages show a TOC button and prev/next buttons inside the WebView HTML. This is suboptimal because the controls are non-native and disappear when you scroll down on long pages.

### Solution

Replaced the in-page HTML controls with a native React Native sticky footer that stays visible at all times.

The approach uses a JS bridge injected into the WebView that:
1. Finds the DOM navigation element and hides it
2. Extracts page button data (titles, active state) and posts it up to React Native via postMessage
3. Listens for a 
ative_navigate_toc CustomEvent dispatched from the native side to trigger page changes
4. Uses a MutationObserver to re-extract state after DOM updates from navigation

On the native side, the footer renders prev/next buttons with proper disabled states and a Contents button that opens a bottom sheet listing all pages. The current page is highlighted in the sheet.

### Testing

11 unit tests covering:
- JS bridge injection into WebView
- Footer visibility based on item count
- Prev/next navigation and disabled states
- Sheet open/close and item selection
- Click message passthrough after TOC state is received

Maestro E2E test for on-device verification.

### AI disclosure

- Models: Claude Opus 4.6, Gemini (via Antigravity coding assistant)
- Used for: codebase exploration, understanding existing patterns, code generation, test writing, debugging
- All generated code was reviewed and validated by me