### PR TITLE
Allow tapping and sliding anywhere on analytics charts to select bars

### DIFF
--- a/components/analytics/analytics-bar-chart.ts
+++ b/components/analytics/analytics-bar-chart.ts
@@ -66,3 +66,16 @@ export const useChartDimensions = (dataLength: number) => {
     spacing,
   };
 };
+
+export const getBarIndexFromX = (
+  touchX: number,
+  barWidth: number,
+  spacing: number,
+  dataLength: number,
+): number | null => {
+  if (dataLength === 0) return null;
+  const slotWidth = barWidth + spacing;
+  const index = Math.floor(touchX / slotWidth);
+  if (index < 0 || index >= dataLength) return null;
+  return index;
+};

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -1,9 +1,9 @@
 import { Text } from "@/components/ui/text";
 import { useCallback, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { GestureResponderEvent, ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
-import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
+import { formatCurrency, formatNumber, getBarIndexFromX, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
@@ -30,6 +30,14 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const handleBarPress = useCallback((index: number) => {
     setSelectedIndex((prev) => (prev === index ? null : index));
   }, []);
+
+  const handleChartTouch = useCallback(
+    (e: GestureResponderEvent) => {
+      const index = getBarIndexFromX(e.nativeEvent.locationX, barWidth, spacing, dates.length);
+      if (index !== null) setSelectedIndex(index);
+    },
+    [barWidth, spacing, dates.length],
+  );
 
   const createChartData = (values: number[]) =>
     values.map((value, index) => ({
@@ -69,7 +77,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
+          <View
+            className="mt-4"
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               data={revenueData}
               height={120}
@@ -104,7 +118,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <View
+            className="mt-4"
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               data={salesData}
               height={120}
@@ -139,7 +159,13 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <View
+            className="mt-4"
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               data={viewsData}
               height={120}

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -1,8 +1,8 @@
 import { Text } from "@/components/ui/text";
 import { useCallback, useState } from "react";
-import { ScrollView, View } from "react-native";
+import { GestureResponderEvent, ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
-import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
+import { formatCurrency, formatNumber, getBarIndexFromX, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
@@ -41,6 +41,14 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const handleBarPress = useCallback((index: number) => {
     setSelectedIndex((prev) => (prev === index ? null : index));
   }, []);
+
+  const handleChartTouch = useCallback(
+    (e: GestureResponderEvent) => {
+      const index = getBarIndexFromX(e.nativeEvent.locationX, barWidth, spacing, dates.length);
+      if (index !== null) setSelectedIndex(index);
+    },
+    [barWidth, spacing, dates.length],
+  );
 
   const calculateTotals = (
     data: { date: string; referrers: { name: string; value: number; color: string }[] }[],
@@ -141,7 +149,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
+          <View
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               stackData={revenueChartData}
               height={120}
@@ -187,7 +200,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <View
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               stackData={salesChartData}
               height={120}
@@ -233,7 +251,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <View
+            onStartShouldSetResponder={() => true}
+            onMoveShouldSetResponder={() => true}
+            onResponderGrant={handleChartTouch}
+            onResponderMove={handleChartTouch}
+          >
             <BarChart
               stackData={visitsChartData}
               height={120}

--- a/tests/components/analytics/analytics-bar-chart.test.ts
+++ b/tests/components/analytics/analytics-bar-chart.test.ts
@@ -1,0 +1,69 @@
+import { formatCurrency, formatNumber, getBarIndexFromX } from "@/components/analytics/analytics-bar-chart";
+
+describe("getBarIndexFromX", () => {
+  const barWidth = 20;
+  const spacing = 4;
+  const dataLength = 7;
+
+  it("returns the first bar index for a touch at the start", () => {
+    expect(getBarIndexFromX(5, barWidth, spacing, dataLength)).toBe(0);
+  });
+
+  it("returns the correct bar index for a touch in the middle", () => {
+    expect(getBarIndexFromX(72, barWidth, spacing, dataLength)).toBe(3);
+  });
+
+  it("returns the last bar index for a touch at the end", () => {
+    expect(getBarIndexFromX(150, barWidth, spacing, dataLength)).toBe(6);
+  });
+
+  it("returns null for a negative touch position", () => {
+    expect(getBarIndexFromX(-10, barWidth, spacing, dataLength)).toBeNull();
+  });
+
+  it("returns null for a touch beyond the last bar", () => {
+    expect(getBarIndexFromX(200, barWidth, spacing, dataLength)).toBeNull();
+  });
+
+  it("returns null when there are no bars", () => {
+    expect(getBarIndexFromX(50, barWidth, spacing, 0)).toBeNull();
+  });
+
+  it("returns the bar index when touching the spacing between bars", () => {
+    const touchInSpacing = barWidth + 1;
+    expect(getBarIndexFromX(touchInSpacing, barWidth, spacing, dataLength)).toBe(0);
+  });
+
+  it("returns the next bar index after a full slot width", () => {
+    const slotWidth = barWidth + spacing;
+    expect(getBarIndexFromX(slotWidth, barWidth, spacing, dataLength)).toBe(1);
+  });
+});
+
+describe("formatCurrency", () => {
+  it("formats small amounts with two decimal places", () => {
+    expect(formatCurrency(999)).toBe("$9.99");
+  });
+
+  it("formats thousands with K suffix", () => {
+    expect(formatCurrency(150000)).toBe("$1.5K");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(formatCurrency(200000000)).toBe("$2.0M");
+  });
+});
+
+describe("formatNumber", () => {
+  it("formats small numbers with commas", () => {
+    expect(formatNumber(42)).toBe("42");
+  });
+
+  it("formats thousands with K suffix", () => {
+    expect(formatNumber(2500)).toBe("2.5K");
+  });
+
+  it("formats millions with M suffix", () => {
+    expect(formatNumber(3000000)).toBe("3.0M");
+  });
+});


### PR DESCRIPTION
Issue: #26

# Description

## Problem

Tapping on analytics charts only works when precisely hitting a bar element. Users must tap the exact bar to select it, which is frustrating on touch devices.

## Solution

Added touch responder handling to chart wrapper Views so users can tap anywhere at a given X position to select the corresponding bar. Sliding/dragging horizontally also changes the selection smoothly.

- Added `getBarIndexFromX` utility in `analytics-bar-chart.ts` that maps a touch X coordinate to a bar index
- Wrapped each `BarChart` in both `SalesTab` and `TrafficTab` with a `View` that captures touch responder events
- Used React Native's built-in responder system (`onResponderGrant`, `onResponderMove`) to avoid gesture handler conflicts with parent ScrollView

---

# Before/After

**Before:** Must tap directly on a bar to select it
**After:** Tap anywhere in the chart area or slide finger horizontally to select bars

---

# Test Results

14 unit tests added for `getBarIndexFromX`, `formatCurrency`, and `formatNumber`. Full test suite: 64 tests passing.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

AI (Claude) was used to assist with implementation and test writing.