### PR TITLE
feat: track loading state during auth browser session and surface errors to users

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -12,11 +12,10 @@ import { StyledImage } from "../components/styled";
 import { useAuth } from "../lib/auth-context";
 
 export default function LoginScreen() {
-  const { isAuthenticated, isLoading, login } = useAuth();
+  const { isAuthenticated, isLoading, authError, login } = useAuth();
   const { theme } = useUniwind();
 
   useEffect(() => {
-    // Speeds up opening the browser for the auth flow on Android
     WebBrowser.warmUpAsync();
 
     return () => {
@@ -30,9 +29,13 @@ export default function LoginScreen() {
     <View className="flex-1 items-center justify-center gap-12 bg-background px-6">
       <StyledImage source={theme === "dark" ? logoDark : logoLight} className="aspect-158/22 w-50" />
 
-      <Button variant="accent" onPress={login} disabled={isLoading}>
-        {isLoading ? <LoadingSpinner size="small" /> : <Text>Sign in with Gumroad</Text>}
-      </Button>
+      <View className="items-center gap-3">
+        <Button variant="accent" onPress={login} disabled={isLoading}>
+          {isLoading ? <LoadingSpinner size="small" /> : <Text>Sign in with Gumroad</Text>}
+        </Button>
+
+        {authError ? <Text className="text-destructive text-sm">{authError}</Text> : null}
+      </View>
     </View>
   );
 }


### PR DESCRIPTION
## Problem

The login screen has two UX issues with the OAuth browser flow:

1. **No loading feedback while the browser is open.** The button only shows a spinner during the token exchange phase. Between pressing "Sign in" and the browser opening (and throughout the auth session), `isLoading` is `false`, so the button appears idle. Users can tap the button multiple times and open multiple browser sessions.

2. **Auth errors are never shown to users.** When the code exchange fails, the user cancels, or the OAuth server returns an error, the failure is only logged to the console. The login screen shows no indication that anything went wrong.

## Root cause

In `auth-context.tsx`, `isLoading` is set to `true` only when the code exchange begins (inside `handleAuthResponse`), not when `promptAsync()` is called. The `response` state only covers successful and error OAuth responses — cancel/dismiss responses were unhandled.

## Solution

- Set `isLoading = true` before calling `promptAsync()` in `login`, and reset it to `false` if the result is not a successful code (so the token exchange path still manages its own loading state).
- Handle `cancel` and `dismiss` response types explicitly to clear the loading state.
- Add `authError: string | null` to the auth context, populated on error or failed token exchange.
- Display the error message below the sign-in button in `login.tsx`.
- Clear `authError` when a new login attempt begins.

## Changes

- `lib/auth-context.tsx` — loading state from `promptAsync` call, error state, cancel/dismiss handling
- `app/login.tsx` — display error message, group button and error in a `View`

## Testing

- TypeScript: `npx tsc --noEmit` — pre-existing error in `_layout.tsx` (`@rn-primitives/portal`, unrelated), zero errors in changed files
- Tests: `npm test` — 50/50 pass

Fixes #24
/claim #24