### PR TITLE
Paginate products in the library

### DIFF
--- a/app/purchase/[id].tsx
+++ b/app/purchase/[id].tsx
@@ -1,4 +1,4 @@
-import { usePurchases } from "@/app/(tabs)/library";
+import { usePurchase } from "@/lib/use-purchases";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledWebView } from "@/components/styled";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
@@ -49,12 +49,10 @@ const shareFile = async (uri: string) => {
 export default function DownloadScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [isDownloading, setIsDownloading] = useState(false);
-  const { data: purchases = [] } = usePurchases();
+  const purchase = usePurchase(id);
   const router = useRouter();
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
-
-  const purchase = purchases.find((p) => p.url_redirect_token === id);
   const url = `${env.EXPO_PUBLIC_GUMROAD_URL}/d/${id}?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`;
 
   const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);

--- a/components/library-filters.tsx
+++ b/components/library-filters.tsx
@@ -1,5 +1,6 @@
 import { LineIcon } from "@/components/icon";
-import { CreatorCount, SortOption } from "@/components/use-library-filters";
+import { SortOption } from "@/components/use-library-filters";
+import { Seller } from "@/lib/use-purchases";
 import { useState } from "react";
 import { FlatList, Platform, TextInput, TouchableOpacity, View } from "react-native";
 import { Drawer } from "react-native-drawer-layout";
@@ -18,10 +19,9 @@ export interface LibraryFiltersProps {
   showArchivedOnly: boolean;
   sortBy: SortOption;
   setSortBy: (sort: SortOption) => void;
-  hasArchivedProducts: boolean;
   hasActiveFilters: boolean;
-  creatorCounts: CreatorCount[];
-  handleCreatorToggle: (creatorName: string) => void;
+  sellers: Seller[];
+  handleCreatorToggle: (creatorId: string) => void;
   handleSelectAllCreators: () => void;
   handleClearFilters: () => void;
   handleToggleArchived: () => void;
@@ -35,9 +35,8 @@ export const LibraryFilters = ({
   showArchivedOnly,
   sortBy,
   setSortBy,
-  hasArchivedProducts,
   hasActiveFilters,
-  creatorCounts,
+  sellers,
   handleCreatorToggle,
   handleSelectAllCreators,
   handleClearFilters,
@@ -71,18 +70,15 @@ export const LibraryFilters = ({
           <View className="border-b border-border p-4">
             <RadioGroup value={sortBy} onValueChange={(value) => setSortBy(value as SortOption)}>
               <View className="flex flex-row items-center gap-3">
-                <RadioGroupItem value="content_updated_at" id="content_updated_at" />
-                <Label
-                  htmlFor="content_updated_at"
-                  onPress={Platform.select({ native: () => setSortBy("content_updated_at") })}
-                >
-                  Recently updated
+                <RadioGroupItem value="date-desc" id="date-desc" />
+                <Label htmlFor="date-desc" onPress={Platform.select({ native: () => setSortBy("date-desc") })}>
+                  Newest
                 </Label>
               </View>
               <View className="flex flex-row items-center gap-3">
-                <RadioGroupItem value="purchased_at" id="purchased_at" />
-                <Label htmlFor="purchased_at" onPress={Platform.select({ native: () => setSortBy("purchased_at") })}>
-                  Purchase date
+                <RadioGroupItem value="date-asc" id="date-asc" />
+                <Label htmlFor="date-asc" onPress={Platform.select({ native: () => setSortBy("date-asc") })}>
+                  Oldest
                 </Label>
               </View>
             </RadioGroup>
@@ -90,8 +86,8 @@ export const LibraryFilters = ({
 
           <View className="flex-1 border-b border-border px-4 py-3">
             <FlatList
-              data={creatorCounts}
-              keyExtractor={(item) => item.name}
+              data={sellers}
+              keyExtractor={(item) => item.id}
               ListHeaderComponent={
                 <View className="flex flex-row items-center gap-3 py-1">
                   <Checkbox
@@ -107,29 +103,27 @@ export const LibraryFilters = ({
               renderItem={({ item }) => (
                 <View className="flex flex-row items-center gap-3 py-1">
                   <Checkbox
-                    id={item.username}
-                    checked={selectedCreators.has(item.username)}
-                    onCheckedChange={() => handleCreatorToggle(item.username)}
+                    id={item.id}
+                    checked={selectedCreators.has(item.id)}
+                    onCheckedChange={() => handleCreatorToggle(item.id)}
                   />
                   <Label
-                    onPress={Platform.select({ native: () => handleCreatorToggle(item.username) })}
-                    htmlFor={item.username}
+                    onPress={Platform.select({ native: () => handleCreatorToggle(item.id) })}
+                    htmlFor={item.id}
                   >
-                    {item.name} ({item.count})
+                    {item.name} ({item.purchases_count})
                   </Label>
                 </View>
               )}
             />
           </View>
 
-          {hasArchivedProducts ? (
-            <View className="flex-row items-center gap-3 border-b border-border px-4 py-3">
-              <Checkbox id="archived" checked={showArchivedOnly} onCheckedChange={handleToggleArchived} />
-              <Label onPress={Platform.select({ native: handleToggleArchived })} htmlFor="archived">
-                Show archived only
-              </Label>
-            </View>
-          ) : null}
+          <View className="flex-row items-center gap-3 border-b border-border px-4 py-3">
+            <Checkbox id="archived" checked={showArchivedOnly} onCheckedChange={handleToggleArchived} />
+            <Label onPress={Platform.select({ native: handleToggleArchived })} htmlFor="archived">
+              Show archived only
+            </Label>
+          </View>
 
           <View className="px-4 pt-4">
             <Button onPress={() => setDrawerOpen(false)}>

--- a/components/use-library-filters.ts
+++ b/components/use-library-filters.ts
@@ -1,20 +1,7 @@
-import { Purchase } from "@/app/(tabs)/library";
-import { useMemo, useState } from "react";
+import { ApiFilters } from "@/lib/use-purchases";
+import { useEffect, useMemo, useState } from "react";
 
-export type SortOption = "content_updated_at" | "purchased_at";
-
-export interface LibraryFiltersState {
-  searchText: string;
-  selectedCreators: Set<string>;
-  showArchivedOnly: boolean;
-  sortBy: SortOption;
-}
-
-export interface CreatorCount {
-  username: string;
-  name: string;
-  count: number;
-}
+export type SortOption = "date-desc" | "date-asc";
 
 export interface UseLibraryFiltersReturn {
   searchText: string;
@@ -23,80 +10,44 @@ export interface UseLibraryFiltersReturn {
   showArchivedOnly: boolean;
   sortBy: SortOption;
   setSortBy: (sort: SortOption) => void;
-  hasArchivedProducts: boolean;
   hasActiveFilters: boolean;
-  creatorCounts: CreatorCount[];
-  filteredPurchases: Purchase[];
-  handleCreatorToggle: (creatorName: string) => void;
+  apiFilters: ApiFilters;
+  handleCreatorToggle: (creatorId: string) => void;
   handleSelectAllCreators: () => void;
   handleClearFilters: () => void;
   handleToggleArchived: () => void;
 }
 
-export const useLibraryFilters = (purchases: Purchase[]): UseLibraryFiltersReturn => {
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const useLibraryFilters = (): UseLibraryFiltersReturn => {
   const [searchText, setSearchText] = useState("");
+  const [debouncedSearchText, setDebouncedSearchText] = useState("");
   const [selectedCreators, setSelectedCreators] = useState<Set<string>>(new Set());
   const [showArchivedOnly, setShowArchivedOnly] = useState(false);
-  const [sortBy, setSortBy] = useState<SortOption>("content_updated_at");
+  const [sortBy, setSortBy] = useState<SortOption>("date-desc");
 
-  const hasArchivedProducts = useMemo(() => purchases.some((p) => p.is_archived), [purchases]);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearchText(searchText.trim()), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [searchText]);
 
-  const creatorCounts = useMemo(() => {
-    const basePurchases = showArchivedOnly
-      ? purchases.filter((p) => p.is_archived)
-      : purchases.filter((p) => !p.is_archived);
-
-    const counts = new Map<string, { name: string; count: number }>();
-    for (const purchase of basePurchases) {
-      counts.set(purchase.creator_username, {
-        name: purchase.creator_name,
-        count: (counts.get(purchase.creator_username)?.count ?? 0) + 1,
-      });
-    }
-
-    return Array.from(counts.entries())
-      .sort((a, b) => {
-        if (b[1].count !== a[1].count) return b[1].count - a[1].count;
-        return a[1].name.localeCompare(b[1].name);
-      })
-      .map(([username, { name, count }]) => ({ username, name, count }));
-  }, [purchases, showArchivedOnly]);
-
-  const filteredPurchases = useMemo(() => {
-    let result = showArchivedOnly ? purchases.filter((p) => p.is_archived) : purchases.filter((p) => !p.is_archived);
-
-    if (searchText.trim()) {
-      const search = searchText.toLowerCase();
-      result = result.filter(
-        (p) => p.name.toLowerCase().includes(search) || p.creator_name.toLowerCase().includes(search),
-      );
-    }
-
-    if (selectedCreators.size > 0) {
-      result = result.filter((p) => selectedCreators.has(p.creator_username));
-    }
-
-    result = [...result].sort((a, b) => {
-      const aDate = sortBy === "content_updated_at" ? a.content_updated_at : a.purchased_at;
-      const bDate = sortBy === "content_updated_at" ? b.content_updated_at : b.purchased_at;
-      if (!aDate && !bDate) return 0;
-      if (!aDate) return 1;
-      if (!bDate) return -1;
-      return new Date(bDate).getTime() - new Date(aDate).getTime();
-    });
-
-    return result;
-  }, [purchases, searchText, selectedCreators, showArchivedOnly, sortBy]);
+  const apiFilters = useMemo((): ApiFilters => {
+    const filters: ApiFilters = { order: sortBy, archived: showArchivedOnly };
+    if (debouncedSearchText) filters.q = debouncedSearchText;
+    if (selectedCreators.size > 0) filters.seller = Array.from(selectedCreators);
+    return filters;
+  }, [debouncedSearchText, selectedCreators, showArchivedOnly, sortBy]);
 
   const hasActiveFilters = selectedCreators.size > 0 || showArchivedOnly;
 
-  const handleCreatorToggle = (username: string) => {
+  const handleCreatorToggle = (creatorId: string) => {
     setSelectedCreators((prev) => {
       const next = new Set(prev);
-      if (next.has(username)) {
-        next.delete(username);
+      if (next.has(creatorId)) {
+        next.delete(creatorId);
       } else {
-        next.add(username);
+        next.add(creatorId);
       }
       return next;
     });
@@ -122,10 +73,8 @@ export const useLibraryFilters = (purchases: Purchase[]): UseLibraryFiltersRetur
     showArchivedOnly,
     sortBy,
     setSortBy,
-    hasArchivedProducts,
     hasActiveFilters,
-    creatorCounts,
-    filteredPurchases,
+    apiFilters,
     handleCreatorToggle,
     handleSelectAllCreators,
     handleClearFilters,

--- a/lib/use-purchases.ts
+++ b/lib/use-purchases.ts
@@ -1,0 +1,144 @@
+import { assertDefined } from "@/lib/assert";
+import { useAuth } from "@/lib/auth-context";
+import { requestAPI, UnauthorizedError } from "@/lib/request";
+import { useInfiniteQuery, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo } from "react";
+
+export interface Purchase {
+  name: string;
+  creator_name: string;
+  creator_username: string;
+  creator_profile_picture_url: string;
+  thumbnail_url: string | null;
+  url_redirect_token: string;
+  purchase_email: string;
+  purchase_id?: string;
+  is_archived?: boolean;
+  content_updated_at?: string;
+  purchased_at?: string;
+  file_data?: {
+    id: string;
+    name: string;
+    filegroup?: string;
+    streaming_url?: string;
+  }[];
+}
+
+export interface Seller {
+  id: string;
+  name: string;
+  purchases_count: number;
+}
+
+export interface ApiFilters {
+  q?: string;
+  seller?: string[];
+  archived?: boolean;
+  order?: "date-desc" | "date-asc";
+}
+
+interface Pagination {
+  count: number;
+  items: number;
+  page: number;
+  pages: number;
+  prev: number | null;
+  next: number | null;
+  last: number;
+}
+
+interface SearchResponse {
+  success: boolean;
+  user_id: string;
+  purchases: Purchase[];
+  sellers: Seller[];
+  meta: { pagination: Pagination };
+}
+
+const PER_PAGE = 24;
+
+const buildSearchPath = (page: number, filters: ApiFilters) => {
+  const params = new URLSearchParams();
+  params.set("items", String(PER_PAGE));
+  params.set("page", String(page));
+  if (filters.q) params.set("q", filters.q);
+  if (filters.seller?.length) {
+    for (const id of filters.seller) params.append("seller[]", id);
+  }
+  if (filters.archived !== undefined) params.set("archived", String(filters.archived));
+  if (filters.order) params.set("order", filters.order);
+  return `mobile/purchases/search?${params.toString()}`;
+};
+
+export const usePurchases = (filters: ApiFilters = {}) => {
+  const { accessToken, logout, isLoading: isAuthLoading } = useAuth();
+
+  const query = useInfiniteQuery<SearchResponse, Error>({
+    queryKey: ["purchases", filters],
+    queryFn: ({ pageParam }) =>
+      requestAPI<SearchResponse>(buildSearchPath(pageParam as number, filters), {
+        accessToken: assertDefined(accessToken),
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.meta.pagination.next ?? undefined,
+    enabled: !!accessToken,
+  });
+
+  const purchases = useMemo(() => query.data?.pages.flatMap((page) => page.purchases) ?? [], [query.data]);
+
+  const sellers = useMemo(() => query.data?.pages[0]?.sellers ?? [], [query.data]);
+
+  const totalCount = query.data?.pages[0]?.meta.pagination.count ?? 0;
+
+  const refetch = useCallback(() => query.refetch(), [query.refetch]);
+
+  const fetchNextPage = useCallback(() => {
+    if (query.hasNextPage && !query.isFetchingNextPage) query.fetchNextPage();
+  }, [query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage]);
+
+  useEffect(() => {
+    if ((!isAuthLoading && !accessToken) || query.error instanceof UnauthorizedError) logout();
+  }, [isAuthLoading, accessToken, query.error, logout]);
+
+  return {
+    purchases,
+    sellers,
+    totalCount,
+    isLoading: query.isLoading,
+    isRefetching: query.isRefetching,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage ?? false,
+    error: query.error,
+    refetch,
+    fetchNextPage,
+  };
+};
+
+const findPurchaseInCache = (queryClient: ReturnType<typeof useQueryClient>, id: string): Purchase | undefined =>
+  queryClient
+    .getQueriesData<{ pages: SearchResponse[] }>({ queryKey: ["purchases"] })
+    .flatMap(([, data]) => data?.pages ?? [])
+    .flatMap((page) => page.purchases)
+    .find((p) => p.url_redirect_token === id);
+
+export const usePurchase = (id: string) => {
+  const { accessToken } = useAuth();
+  const queryClient = useQueryClient();
+  const cachedPurchase = findPurchaseInCache(queryClient, id);
+
+  const query = useQuery<Purchase | undefined, Error>({
+    queryKey: ["purchase", id],
+    queryFn: async () => {
+      const response = await requestAPI<SearchResponse>(
+        `mobile/purchases/search?${new URLSearchParams({ q: id, items: "1" }).toString()}`,
+        { accessToken: assertDefined(accessToken) },
+      );
+      return response.purchases.find((p) => p.url_redirect_token === id);
+    },
+    enabled: !!accessToken && !cachedPurchase,
+    initialData: cachedPurchase,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return cachedPurchase ?? query.data;
+};

--- a/tests/components/use-library-filters.test.ts
+++ b/tests/components/use-library-filters.test.ts
@@ -1,174 +1,89 @@
 import { renderHook, act } from "@testing-library/react-native";
 import { useLibraryFilters } from "@/components/use-library-filters";
-import { Purchase } from "@/app/(tabs)/library";
-
-const makePurchase = (overrides: Partial<Purchase> = {}): Purchase => ({
-  name: "Test Product",
-  creator_name: "Test Creator",
-  creator_username: "testcreator",
-  creator_profile_picture_url: "https://example.com/pic.jpg",
-  thumbnail_url: null,
-  url_redirect_token: "token123",
-  purchase_email: "test@example.com",
-  ...overrides,
-});
-
-const purchases: Purchase[] = [
-  makePurchase({
-    name: "Learn React",
-    creator_name: "Alice",
-    creator_username: "alice",
-    content_updated_at: "2024-03-01T00:00:00Z",
-    purchased_at: "2024-01-15T00:00:00Z",
-  }),
-  makePurchase({
-    name: "Design Basics",
-    creator_name: "Bob",
-    creator_username: "bob",
-    content_updated_at: "2024-02-01T00:00:00Z",
-    purchased_at: "2024-02-20T00:00:00Z",
-  }),
-  makePurchase({
-    name: "Advanced TypeScript",
-    creator_name: "Alice",
-    creator_username: "alice",
-    content_updated_at: "2024-01-01T00:00:00Z",
-    purchased_at: "2024-03-10T00:00:00Z",
-  }),
-  makePurchase({
-    name: "Archived Course",
-    creator_name: "Charlie",
-    creator_username: "charlie",
-    is_archived: true,
-    content_updated_at: "2024-04-01T00:00:00Z",
-    purchased_at: "2024-01-01T00:00:00Z",
-  }),
-];
 
 describe("useLibraryFilters", () => {
-  describe("filtering", () => {
-    it("excludes archived products by default", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      expect(result.current.filteredPurchases).toHaveLength(3);
-      expect(result.current.filteredPurchases.every((p) => !p.is_archived)).toBe(true);
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("apiFilters", () => {
+    it("returns default filters", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      expect(result.current.apiFilters).toEqual({ order: "date-desc", archived: false });
     });
 
-    it("shows only archived products when toggled", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.handleToggleArchived());
-      expect(result.current.filteredPurchases).toHaveLength(1);
-      expect(result.current.filteredPurchases[0].name).toBe("Archived Course");
-    });
-
-    it("filters by product name (case-insensitive)", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+    it("includes search query after debounce", () => {
+      const { result } = renderHook(() => useLibraryFilters());
       act(() => result.current.setSearchText("react"));
-      expect(result.current.filteredPurchases).toHaveLength(1);
-      expect(result.current.filteredPurchases[0].name).toBe("Learn React");
+      expect(result.current.apiFilters.q).toBeUndefined();
+      act(() => jest.advanceTimersByTime(300));
+      expect(result.current.apiFilters.q).toBe("react");
     });
 
-    it("filters by creator name (case-insensitive)", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.setSearchText("BOB"));
-      expect(result.current.filteredPurchases).toHaveLength(1);
-      expect(result.current.filteredPurchases[0].name).toBe("Design Basics");
+    it("trims search text", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.setSearchText("  react  "));
+      act(() => jest.advanceTimersByTime(300));
+      expect(result.current.apiFilters.q).toBe("react");
     });
 
-    it("filters by selected creator", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.handleCreatorToggle("alice"));
-      expect(result.current.filteredPurchases).toHaveLength(2);
-      expect(result.current.filteredPurchases.every((p) => p.creator_username === "alice")).toBe(true);
+    it("does not include empty search query", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.setSearchText("   "));
+      act(() => jest.advanceTimersByTime(300));
+      expect(result.current.apiFilters.q).toBeUndefined();
     });
 
-    it("combines search and creator filter", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+    it("includes selected creators as seller param", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.handleCreatorToggle("seller-abc"));
+      expect(result.current.apiFilters.seller).toEqual(["seller-abc"]);
+    });
+
+    it("includes multiple selected creators", () => {
+      const { result } = renderHook(() => useLibraryFilters());
       act(() => {
-        result.current.handleCreatorToggle("alice");
-        result.current.setSearchText("typescript");
+        result.current.handleCreatorToggle("seller-abc");
+        result.current.handleCreatorToggle("seller-xyz");
       });
-      expect(result.current.filteredPurchases).toHaveLength(1);
-      expect(result.current.filteredPurchases[0].name).toBe("Advanced TypeScript");
-    });
-  });
-
-  describe("sorting", () => {
-    it("sorts by content_updated_at descending by default", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      const names = result.current.filteredPurchases.map((p) => p.name);
-      expect(names).toEqual(["Learn React", "Design Basics", "Advanced TypeScript"]);
+      expect(result.current.apiFilters.seller).toHaveLength(2);
+      expect(result.current.apiFilters.seller).toContain("seller-abc");
+      expect(result.current.apiFilters.seller).toContain("seller-xyz");
     });
 
-    it("sorts by purchased_at descending", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.setSortBy("purchased_at"));
-      const names = result.current.filteredPurchases.map((p) => p.name);
-      expect(names).toEqual(["Advanced TypeScript", "Design Basics", "Learn React"]);
-    });
-
-    it("handles missing dates by pushing them to the end", () => {
-      const data = [
-        makePurchase({
-          name: "No Date",
-          creator_username: "x",
-          creator_name: "X",
-        }),
-        makePurchase({
-          name: "Has Date",
-          creator_username: "y",
-          creator_name: "Y",
-          content_updated_at: "2024-01-01T00:00:00Z",
-        }),
-      ];
-      const { result } = renderHook(() => useLibraryFilters(data));
-      expect(result.current.filteredPurchases[0].name).toBe("Has Date");
-      expect(result.current.filteredPurchases[1].name).toBe("No Date");
-    });
-  });
-
-  describe("creatorCounts", () => {
-    it("aggregates by creator username and sorts by count then name", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      expect(result.current.creatorCounts).toEqual([
-        { username: "alice", name: "Alice", count: 2 },
-        { username: "bob", name: "Bob", count: 1 },
-      ]);
-    });
-
-    it("only includes archived creators when showArchivedOnly is true", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+    it("includes archived flag", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      expect(result.current.apiFilters.archived).toBe(false);
       act(() => result.current.handleToggleArchived());
-      expect(result.current.creatorCounts).toEqual([{ username: "charlie", name: "Charlie", count: 1 }]);
-    });
-  });
-
-  describe("hasArchivedProducts", () => {
-    it("returns true when archived products exist", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      expect(result.current.hasArchivedProducts).toBe(true);
+      expect(result.current.apiFilters.archived).toBe(true);
     });
 
-    it("returns false when no archived products exist", () => {
-      const data = [makePurchase({ creator_username: "a", creator_name: "A" })];
-      const { result } = renderHook(() => useLibraryFilters(data));
-      expect(result.current.hasArchivedProducts).toBe(false);
+    it("includes sort order", () => {
+      const { result } = renderHook(() => useLibraryFilters());
+      expect(result.current.apiFilters.order).toBe("date-desc");
+      act(() => result.current.setSortBy("date-asc"));
+      expect(result.current.apiFilters.order).toBe("date-asc");
     });
   });
 
   describe("hasActiveFilters", () => {
     it("returns false by default", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+      const { result } = renderHook(() => useLibraryFilters());
       expect(result.current.hasActiveFilters).toBe(false);
     });
 
     it("returns true when a creator is selected", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.handleCreatorToggle("alice"));
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.handleCreatorToggle("seller-abc"));
       expect(result.current.hasActiveFilters).toBe(true);
     });
 
     it("returns true when showArchivedOnly is toggled", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+      const { result } = renderHook(() => useLibraryFilters());
       act(() => result.current.handleToggleArchived());
       expect(result.current.hasActiveFilters).toBe(true);
     });
@@ -176,25 +91,25 @@ describe("useLibraryFilters", () => {
 
   describe("state handlers", () => {
     it("handleCreatorToggle adds and removes creators", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.handleCreatorToggle("alice"));
-      expect(result.current.selectedCreators.has("alice")).toBe(true);
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.handleCreatorToggle("seller-abc"));
+      expect(result.current.selectedCreators.has("seller-abc")).toBe(true);
 
-      act(() => result.current.handleCreatorToggle("alice"));
-      expect(result.current.selectedCreators.has("alice")).toBe(false);
+      act(() => result.current.handleCreatorToggle("seller-abc"));
+      expect(result.current.selectedCreators.has("seller-abc")).toBe(false);
     });
 
     it("handleSelectAllCreators clears selection", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
-      act(() => result.current.handleCreatorToggle("alice"));
+      const { result } = renderHook(() => useLibraryFilters());
+      act(() => result.current.handleCreatorToggle("seller-abc"));
       act(() => result.current.handleSelectAllCreators());
       expect(result.current.selectedCreators.size).toBe(0);
     });
 
     it("handleClearFilters resets creators and archived toggle", () => {
-      const { result } = renderHook(() => useLibraryFilters(purchases));
+      const { result } = renderHook(() => useLibraryFilters());
       act(() => {
-        result.current.handleCreatorToggle("alice");
+        result.current.handleCreatorToggle("seller-abc");
         result.current.handleToggleArchived();
       });
       expect(result.current.hasActiveFilters).toBe(true);

--- a/tests/lib/use-purchases.test.ts
+++ b/tests/lib/use-purchases.test.ts
@@ -1,0 +1,177 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const mockRequestAPI = jest.fn();
+jest.mock("@/lib/request", () => ({
+  requestAPI: (...args: unknown[]) => mockRequestAPI(...args),
+  UnauthorizedError: class extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "UnauthorizedError";
+    }
+  },
+}));
+
+const mockLogout = jest.fn();
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ accessToken: "test-token", logout: mockLogout, isLoading: false }),
+}));
+
+jest.mock("@/lib/assert", () => ({
+  assertDefined: <T>(value: T) => value,
+}));
+
+import { usePurchases, usePurchase } from "@/lib/use-purchases";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+const makeSearchResponse = (
+  purchases: { name: string; url_redirect_token: string }[],
+  options: { next?: number | null; count?: number; page?: number; sellers?: { id: string; name: string; purchases_count: number }[] } = {},
+) => ({
+  success: true,
+  user_id: "user-1",
+  purchases: purchases.map((p) => ({
+    creator_name: "Creator",
+    creator_username: "creator",
+    creator_profile_picture_url: "https://example.com/pic.jpg",
+    thumbnail_url: null,
+    purchase_email: "test@example.com",
+    ...p,
+  })),
+  sellers: options.sellers ?? [],
+  meta: {
+    pagination: {
+      count: options.count ?? purchases.length,
+      items: 24,
+      page: options.page ?? 1,
+      pages: options.next ? 2 : 1,
+      prev: null,
+      next: options.next ?? null,
+      last: options.next ? 2 : 1,
+    },
+  },
+});
+
+describe("usePurchases", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches from the search endpoint", async () => {
+    mockRequestAPI.mockResolvedValue(makeSearchResponse([{ name: "Product 1", url_redirect_token: "tok1" }]));
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.purchases).toHaveLength(1));
+
+    expect(mockRequestAPI).toHaveBeenCalledWith(
+      expect.stringContaining("mobile/purchases/search"),
+      expect.objectContaining({ accessToken: "test-token" }),
+    );
+  });
+
+  it("passes filter params to the API", async () => {
+    mockRequestAPI.mockResolvedValue(makeSearchResponse([]));
+    const filters = { q: "test", seller: ["abc"], archived: true as const, order: "date-asc" as const };
+    const { result } = renderHook(() => usePurchases(filters), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const url = mockRequestAPI.mock.calls[0][0] as string;
+    expect(url).toContain("q=test");
+    expect(url).toContain("seller%5B%5D=abc");
+    expect(url).toContain("archived=true");
+    expect(url).toContain("order=date-asc");
+  });
+
+  it("includes page and items params", async () => {
+    mockRequestAPI.mockResolvedValue(makeSearchResponse([{ name: "P1", url_redirect_token: "t1" }]));
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.purchases).toHaveLength(1));
+
+    const url = mockRequestAPI.mock.calls[0][0] as string;
+    expect(url).toContain("items=24");
+    expect(url).toContain("page=1");
+  });
+
+  it("uses meta.pagination.next for next page detection", async () => {
+    mockRequestAPI.mockResolvedValue(
+      makeSearchResponse([{ name: "P1", url_redirect_token: "t1" }], { next: 2, count: 48 }),
+    );
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+  });
+
+  it("has no next page when pagination.next is null", async () => {
+    mockRequestAPI.mockResolvedValue(
+      makeSearchResponse([{ name: "P1", url_redirect_token: "t1" }], { next: null }),
+    );
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.purchases).toHaveLength(1));
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("exposes sellers from the response", async () => {
+    const sellers = [
+      { id: "s1", name: "Alice", purchases_count: 3 },
+      { id: "s2", name: "Bob", purchases_count: 1 },
+    ];
+    mockRequestAPI.mockResolvedValue(
+      makeSearchResponse([{ name: "P1", url_redirect_token: "t1" }], { sellers }),
+    );
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.sellers).toHaveLength(2));
+    expect(result.current.sellers).toEqual(sellers);
+  });
+
+  it("exposes totalCount from pagination metadata", async () => {
+    mockRequestAPI.mockResolvedValue(
+      makeSearchResponse([{ name: "P1", url_redirect_token: "t1" }], { count: 42 }),
+    );
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.totalCount).toBe(42));
+  });
+
+  it("returns empty purchases while loading", () => {
+    mockRequestAPI.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    expect(result.current.purchases).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("returns zero totalCount before data loads", () => {
+    mockRequestAPI.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => usePurchases(), { wrapper: createWrapper() });
+    expect(result.current.totalCount).toBe(0);
+  });
+});
+
+describe("usePurchase", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("finds a purchase from the cached query data", async () => {
+    mockRequestAPI.mockResolvedValue(
+      makeSearchResponse([
+        { name: "Product A", url_redirect_token: "tok-a" },
+        { name: "Product B", url_redirect_token: "tok-b" },
+      ]),
+    );
+    const wrapper = createWrapper();
+    const { result: purchasesResult } = renderHook(() => usePurchases(), { wrapper });
+    await waitFor(() => expect(purchasesResult.current.purchases).toHaveLength(2));
+
+    const { result } = renderHook(() => usePurchase("tok-b"), { wrapper });
+    expect(result.current?.name).toBe("Product B");
+  });
+
+  it("returns undefined when purchase is not in cache", () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => usePurchase("nonexistent"), { wrapper });
+    expect(result.current).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Issue: #23

## Problem

The library fetches all products in a single API call via `mobile/purchases/index`, which degrades performance for large libraries and can fail entirely. Creator filter counts are computed client-side from the full dataset, so they break under pagination.

## Solution

Switched from the `index` endpoint to `mobile/purchases/search`, which supports pagination, full-text search, archived filtering, creator filtering, and returns seller aggregation counts as metadata. No backend changes needed.

### Key changes

**`usePurchases` hook** (`lib/use-purchases.ts`) uses `useInfiniteQuery` from TanStack Query v5 to hit the search endpoint with `items=24` per page. Filter params (`q`, `seller[]`, `archived`, `order`) are part of the query key, so changing any filter resets pagination and refetches from page 1. Exposes stable `refetch` and `fetchNextPage` callbacks via `useCallback` to avoid unnecessary re-renders.

**`usePurchase` hook** uses the query cache as initial data but also falls back to a search query for direct navigation (expo-web support). Uses `flatMap` chains instead of nested loops for cache lookup, per the pattern suggested in prior review feedback.

**`useLibraryFilters` is now state-only.** Manages filter UI state and produces an `apiFilters` object passed to `usePurchases`. Search text is debounced at 300ms with a named constant. No more client-side filtering or creator count computation.

**Library screen** uses `FlatList` with `onEndReached` + `onEndReachedThreshold={0.5}` for infinite scroll. Shows a centered loading spinner in the footer while fetching the next page. Error state includes a retry button.

**Sort options** changed to "Newest" / "Oldest", mapped to the search endpoint's `date-desc` / `date-asc` params.

**Sellers** come from the API response metadata, providing accurate counts that update based on the active search query and archived filter.

## Changes

**Modified (5):** `app/(tabs)/library.tsx`, `app/purchase/[id].tsx`, `components/library-filters.tsx`, `components/use-library-filters.ts`, `tests/components/use-library-filters.test.ts`

**Created (2):** `lib/use-purchases.ts`, `tests/lib/use-purchases.test.ts`

## Test results

5 suites, 56 tests, all passing. TypeScript and ESLint checks clean.

## AI disclosure

Model: Claude Opus 4.6 via Claude Code CLI

Used for: implementation of pagination hooks, updating filter logic, writing tests, and ensuring type safety.

Architecture decisions and code review were mine. All code reviewed before committing.