### PR TITLE
Use ephemeral browser session for OAuth login

### DIFF
--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -123,7 +123,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [response, redirectUri, authRequest?.codeVerifier, storeTokens]);
 
   const login = useCallback(async () => {
-    if (authRequest) await promptAsync();
+    if (authRequest) await promptAsync({ preferEphemeralWebBrowserSession: true });
   }, [authRequest, promptAsync]);
 
   const logout = useCallback(async () => {


### PR DESCRIPTION
## Summary   

Companion to antiwork/gumroad#3829: with `skip_authorization` enabled for the mobile app, the in-app browser would reuse cookies and silently auto-authorize without showing the login form. This 1-line fix ensures each login opens an ephemeral (private) browser session.
                                                                             
  - Pass `preferEphemeralWebBrowserSession: true` to `promptAsync()` so each OAuth flow starts a fresh browser session with no persisted cookies
  - Prevents auto-skipping the login form when the user was previously logged in, allowing account switching



  Ref #24

  ## Test plan
  N/A — 1-line config change passing a supported option to `expo-auth-session`. Behavior is best verified on a real device (iOS simulator does not fully respect ephemeral session cookies).

  ## Demo
  N/A

  ## Self-review
  N/A — single line change