### PR TITLE
Use ephemeral browser session and surface auth errors on login

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -12,11 +12,10 @@ import { StyledImage } from "../components/styled";
 import { useAuth } from "../lib/auth-context";
 
 export default function LoginScreen() {
-  const { isAuthenticated, isLoading, login } = useAuth();
+  const { isAuthenticated, isLoading, error, login } = useAuth();
   const { theme } = useUniwind();
 
   useEffect(() => {
-    // Speeds up opening the browser for the auth flow on Android
     WebBrowser.warmUpAsync();
 
     return () => {
@@ -30,9 +29,13 @@ export default function LoginScreen() {
     <View className="flex-1 items-center justify-center gap-12 bg-background px-6">
       <StyledImage source={theme === "dark" ? logoDark : logoLight} className="aspect-158/22 w-50" />
 
-      <Button variant="accent" onPress={login} disabled={isLoading}>
-        {isLoading ? <LoadingSpinner size="small" /> : <Text>Sign in with Gumroad</Text>}
-      </Button>
+      <View className="w-full items-center gap-3">
+        <Button variant="accent" onPress={login} disabled={isLoading}>
+          {isLoading ? <LoadingSpinner size="small" /> : <Text>Sign in with Gumroad</Text>}
+        </Button>
+
+        {error ? <Text className="text-center text-sm text-destructive">{error}</Text> : null}
+      </View>
     </View>
   );
 }

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -1,0 +1,159 @@
+import { AuthProvider, useAuth } from "@/lib/auth-context";
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import * as SecureStore from "expo-secure-store";
+import React, { ReactNode } from "react";
+
+const mockPromptAsync = jest.fn();
+let mockResponse: unknown = null;
+
+jest.mock("expo-auth-session", () => ({
+  useAuthRequest: () => [
+    { codeVerifier: "test-verifier" },
+    mockResponse,
+    mockPromptAsync,
+  ],
+  makeRedirectUri: () => "gumroadmobile://redirect",
+  ResponseType: { Code: "code" },
+}));
+
+jest.mock("expo-web-browser", () => ({
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+const mockRequest = jest.fn();
+jest.mock("@/lib/request", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => <AuthProvider>{children}</AuthProvider>;
+
+describe("AuthProvider login flow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResponse = null;
+    mockPromptAsync.mockResolvedValue(undefined);
+  });
+
+  it("sets loading to true when login is called", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      result.current.login();
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("passes ephemeral session option to promptAsync", async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(mockPromptAsync).toHaveBeenCalledWith({
+      preferEphemeralSession: true,
+    });
+  });
+
+  it("surfaces error when token exchange fails", async () => {
+    mockRequest.mockRejectedValueOnce(new Error("Network error"));
+    mockResponse = {
+      type: "success",
+      params: { code: "auth-code" },
+    };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBe("Network error"));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("surfaces error on auth error response", async () => {
+    mockResponse = {
+      type: "error",
+      error: { message: "Access denied" },
+    };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBe("Access denied"));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("uses fallback message when auth error has no message", async () => {
+    mockResponse = {
+      type: "error",
+      error: {},
+    };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBe("Authentication failed"));
+  });
+
+  it("resets loading on cancel response", async () => {
+    mockResponse = { type: "cancel" };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resets loading on dismiss response", async () => {
+    mockResponse = { type: "dismiss" };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears previous error on new login attempt", async () => {
+    mockResponse = {
+      type: "error",
+      error: { message: "Previous failure" },
+    };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.error).toBe("Previous failure"));
+
+    await act(async () => {
+      await result.current.login();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
+  it("stores tokens and sets authenticated on successful exchange", async () => {
+    mockRequest.mockResolvedValueOnce({
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+    });
+    mockRequest.mockResolvedValueOnce({ products: [] });
+    mockResponse = {
+      type: "success",
+      params: { code: "auth-code" },
+    };
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith("gumroad_access_token", "new-token");
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith("gumroad_refresh_token", "new-refresh");
+    expect(result.current.error).toBeNull();
+  });
+});


### PR DESCRIPTION
Issue: #24

# Description

## Problem

The login flow has two UX issues:

1. **No loading feedback while the browser is open** -- pressing "Sign in" only shows a spinner during the token exchange, not while the browser is open. Users can double-tap and open multiple browser sessions.
2. **Auth errors are never surfaced to users** -- failures from the code exchange, cancelled sessions, and OAuth errors are only logged to the console with no visible feedback.
3. **Browser session reuses cookies** -- the in-app browser persists cookies from previous sessions, which prevents switching between accounts and (once `skip_authorization` is enabled on the backend) would silently auto-authorize without showing the login form.

## Solution

Three targeted changes to `auth-context.tsx` and `login.tsx`:

- **Ephemeral browser session**: pass `preferEphemeralSession: true` to `promptAsync()` so each OAuth flow starts a fresh private browser session with no persisted cookies. This enables account switching and prevents auto-skipping the login form when the backend enables `skip_authorization` for the mobile client.
- **Full-flow loading state**: set `isLoading` to `true` the moment `promptAsync()` is called (before the browser opens), not just during token exchange. The button shows a spinner and is disabled for the entire auth flow, preventing double-taps.
- **Visible error feedback**: add an `error` field to the auth context. Token exchange failures and OAuth errors are surfaced on the login screen via a destructive-colored text element. Errors auto-clear on the next login attempt. Cancel/dismiss responses properly reset loading state without showing an error.

---

# Before/After

**Before**: pressing "Sign in" opens the browser with no spinner until the token exchange starts. Errors are silently logged. Cached cookies can auto-authorize.

**After**: spinner shows immediately when "Sign in" is pressed. Errors display below the button in red. Each login opens a fresh browser session.

N/A for screenshots -- these are behavioral changes to loading/error state and browser session handling that cannot be captured in a static screenshot. The visual change is the error text element appearing below the sign-in button on failure, using the existing `text-destructive` design token.

---

# Test Results

9 new tests covering the auth flow behavior:

```
PASS tests/lib/auth-context.test.tsx
  AuthProvider login flow
    ✓ sets loading to true when login is called
    ✓ passes ephemeral session option to promptAsync
    ✓ surfaces error when token exchange fails
    ✓ surfaces error on auth error response
    ✓ uses fallback message when auth error has no message
    ✓ resets loading on cancel response
    ✓ resets loading on dismiss response
    ✓ clears previous error on new login attempt
    ✓ stores tokens and sets authenticated on successful exchange

Test Suites: 7 passed, 7 total
Tests:       71 passed, 71 total
```

TypeScript compiles cleanly (`tsc --noEmit` passes). ESLint passes with no errors.

---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

- Model: Claude Opus 4 via Claude Code
- Used for: codebase exploration, understanding existing auth flow patterns, generating test scaffolding
- All code was manually reviewed and validated by me

/claim #24