### PR TITLE
Render table of contents natively on the purchase page

### DIFF
--- a/components/content-page-nav.tsx
+++ b/components/content-page-nav.tsx
@@ -1,0 +1,97 @@
+import { LineIcon } from "@/components/icon";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Text } from "@/components/ui/text";
+import { cn } from "@/lib/utils";
+import { useState } from "react";
+import { FlatList, Pressable, View } from "react-native";
+
+type TocPage = {
+  page_id: string;
+  title: string | null;
+};
+
+export const ContentPageNav = ({
+  pages,
+  activePageIndex,
+  onPageChange,
+}: {
+  pages: TocPage[];
+  activePageIndex: number;
+  onPageChange: (index: number) => void;
+}) => {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const hasPrevious = activePageIndex > 0;
+  const hasNext = activePageIndex < pages.length - 1;
+
+  return (
+    <>
+      <View className="flex-row items-center border-t border-border bg-background px-4 py-2">
+        <Pressable
+          onPress={() => onPageChange(activePageIndex - 1)}
+          disabled={!hasPrevious}
+          className={cn("flex-row items-center gap-1", !hasPrevious && "opacity-50")}
+        >
+          <LineIcon name="chevron-left" size={20} className="text-foreground" />
+          <Text className="text-sm text-foreground">Previous</Text>
+        </Pressable>
+
+        <Pressable
+          onPress={() => setSheetOpen(true)}
+          className="flex-1 flex-row items-center justify-center gap-1.5 self-center rounded-full border border-border px-3 py-1"
+        >
+          <LineIcon name="list-ul" size={16} className="text-foreground" />
+          <Text className="text-sm font-bold text-foreground">
+            {activePageIndex + 1} of {pages.length}
+          </Text>
+          <LineIcon name="chevron-down" size={14} className="text-muted-foreground" />
+        </Pressable>
+
+        <Pressable
+          onPress={() => onPageChange(activePageIndex + 1)}
+          disabled={!hasNext}
+          className={cn("flex-row items-center gap-1", !hasNext && "opacity-50")}
+        >
+          <Text className="text-sm text-foreground">Next</Text>
+          <LineIcon name="chevron-right" size={20} className="text-foreground" />
+        </Pressable>
+      </View>
+
+      <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+        <SheetHeader onClose={() => setSheetOpen(false)}>
+          <SheetTitle>Table of contents</SheetTitle>
+        </SheetHeader>
+        <SheetContent>
+          <FlatList
+            data={pages}
+            keyExtractor={(item) => item.page_id}
+            renderItem={({ item, index }) => {
+              const isActive = index === activePageIndex;
+              return (
+                <Pressable
+                  onPress={() => {
+                    onPageChange(index);
+                    setSheetOpen(false);
+                  }}
+                  className={cn("flex-row items-center gap-3 px-4 py-3", isActive && "bg-accent")}
+                >
+                  <Text className={cn("text-sm", isActive ? "font-bold text-accent-foreground" : "text-foreground")}>
+                    {index + 1}.
+                  </Text>
+                  <Text
+                    className={cn(
+                      "flex-1 text-sm",
+                      isActive ? "font-bold text-accent-foreground" : "text-foreground",
+                    )}
+                    numberOfLines={2}
+                  >
+                    {item.title ?? "Untitled"}
+                  </Text>
+                </Pressable>
+              );
+            }}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};

--- a/components/use-webview-message.ts
+++ b/components/use-webview-message.ts
@@ -1,0 +1,42 @@
+import { useCallback } from "react";
+import type { WebViewMessageEvent } from "react-native-webview";
+
+type MessageHandler<T extends string, P> = {
+  type: T;
+  handler: (payload: P) => void | Promise<void>;
+};
+
+type AnyMessageHandler = MessageHandler<string, unknown>;
+
+export const useWebViewMessage = (handlers: AnyMessageHandler[]) => {
+  const onMessage = useCallback(
+    async (event: WebViewMessageEvent) => {
+      const raw = event.nativeEvent.data;
+
+      let parsed: { type?: string; payload?: unknown };
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        console.warn("Failed to parse WebView message:", raw);
+        return;
+      }
+
+      if (!parsed.type) {
+        console.warn("WebView message missing type:", parsed);
+        return;
+      }
+
+      console.info("WebView message received:", parsed);
+
+      const match = handlers.find((h) => h.type === parsed.type);
+      if (match) {
+        await match.handler(parsed.payload);
+      } else {
+        console.warn("Unhandled WebView message type:", parsed.type);
+      }
+    },
+    [handlers],
+  );
+
+  return onMessage;
+};

--- a/tests/components/content-page-nav.test.tsx
+++ b/tests/components/content-page-nav.test.tsx
@@ -1,0 +1,63 @@
+import { ContentPageNav } from "@/components/content-page-nav";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+const makePages = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    page_id: `page-${i}`,
+    title: `Page ${i + 1}`,
+  }));
+
+describe("ContentPageNav", () => {
+  const onPageChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders page counter with correct position", () => {
+    render(<ContentPageNav pages={makePages(5)} activePageIndex={2} onPageChange={onPageChange} />);
+    expect(screen.getByText("3 of 5")).toBeTruthy();
+  });
+
+  it("calls onPageChange with previous index when Previous is pressed", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={1} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("Previous"));
+    expect(onPageChange).toHaveBeenCalledWith(0);
+  });
+
+  it("calls onPageChange with next index when Next is pressed", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={0} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("Next"));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("disables Previous button on first page", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={0} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("Previous"));
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("disables Next button on last page", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={2} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("Next"));
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it("displays page titles with 'Untitled' for null titles in sheet", () => {
+    const pages = [
+      { page_id: "p1", title: "Introduction" },
+      { page_id: "p2", title: null },
+    ];
+    render(<ContentPageNav pages={pages} activePageIndex={0} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("1 of 2"));
+    expect(screen.getByText("Introduction")).toBeTruthy();
+    expect(screen.getByText("Untitled")).toBeTruthy();
+  });
+
+  it("calls onPageChange when a page is selected in the sheet", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={0} onPageChange={onPageChange} />);
+    fireEvent.press(screen.getByText("1 of 3"));
+    fireEvent.press(screen.getByText("Page 3"));
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+});

--- a/tests/components/use-webview-message.test.ts
+++ b/tests/components/use-webview-message.test.ts
@@ -1,0 +1,64 @@
+import { useWebViewMessage } from "@/components/use-webview-message";
+import { renderHook } from "@testing-library/react-native";
+import type { WebViewMessageEvent } from "react-native-webview";
+
+const makeEvent = (data: string): WebViewMessageEvent =>
+  ({ nativeEvent: { data } } as WebViewMessageEvent);
+
+describe("useWebViewMessage", () => {
+  const clickHandler = jest.fn();
+  const tocHandler = jest.fn();
+
+  const handlers = [
+    { type: "click", handler: clickHandler },
+    { type: "tocData", handler: tocHandler },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("dispatches to the correct handler based on message type", async () => {
+    const { result } = renderHook(() => useWebViewMessage(handlers));
+    await result.current(makeEvent(JSON.stringify({ type: "click", payload: { resourceId: "abc" } })));
+    expect(clickHandler).toHaveBeenCalledWith({ resourceId: "abc" });
+    expect(tocHandler).not.toHaveBeenCalled();
+  });
+
+  it("dispatches tocData messages to the toc handler", async () => {
+    const { result } = renderHook(() => useWebViewMessage(handlers));
+    const payload = { pages: [{ page_id: "p1", title: "Intro" }], activePageIndex: 0 };
+    await result.current(makeEvent(JSON.stringify({ type: "tocData", payload })));
+    expect(tocHandler).toHaveBeenCalledWith(payload);
+    expect(clickHandler).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages with invalid JSON", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const { result } = renderHook(() => useWebViewMessage(handlers));
+    await result.current(makeEvent("not json"));
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(tocHandler).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("ignores messages with unknown types", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const { result } = renderHook(() => useWebViewMessage(handlers));
+    await result.current(makeEvent(JSON.stringify({ type: "unknown", payload: {} })));
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(tocHandler).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("ignores messages without a type field", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation();
+    const { result } = renderHook(() => useWebViewMessage(handlers));
+    await result.current(makeEvent(JSON.stringify({ payload: {} })));
+    expect(clickHandler).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Issue: #27

## Problem

Products with multiple content pages show a web-based table of contents and Previous/Next buttons embedded in the page HTML. This is poor mobile UX because users need to scroll to the bottom of long pages just to navigate between content pages.

## Solution

Replace the web-based navigation with a native sticky footer bar that stays visible at all times, regardless of scroll position. The footer uses a three-part layout:

- **Previous/Next buttons** on the left and right edges, disabled with reduced opacity at the boundaries
- **A centered pill button** showing the page counter ("2 of 5") with a list icon and chevron-down hint, making it visually clear the button opens the table of contents
- **A full-page sheet** listing all content pages with active-page highlighting, triggered by tapping the center pill

### Architecture decisions

**Shared `useWebViewMessage` hook:** Rather than duplicating JSON parsing, window/document listener setup, and type checking across components, I extracted a reusable hook that accepts an array of typed message handlers and dispatches incoming WebView messages to the correct one. This keeps the purchase page handler clean and makes it trivial to add new message types later.

**Expo-specific display parameter:** The WebView URL now sends `display=expo_app` instead of `mobile_app`. This is important because the existing Gumroad native apps (iOS/Android) still rely on the web-based TOC navigation. By using a distinct flag, the Gumroad web backend can check `is_expo_app` to gate the TOC-hiding and `tocData` message behavior, while `is_mobile_app_web_view` continues to work for layout hiding across all native apps.

**Design:** The center pill has a visible border, a list icon, and a chevron-down indicator. This is intentionally more tappable-looking than a plain text counter -- inspired by Apple Books' bottom navigation bar but with clearer affordances.

### Web-side changes needed

This feature requires companion changes in the `antiwork/gumroad` web repo to:
1. Hide the web TOC/Previous/Next nav when `is_expo_app` is true
2. Send `tocData` messages to React Native with pages and active index
3. Listen for `mobileAppPageChange` messages from React Native and navigate accordingly

The web-side diff is small (~40 lines in one file). Happy to share however preferred.

## Test results

All tests pass (typecheck, lint, jest):

- `npm run typecheck` -- clean
- `npm run lint` -- clean
- `npm test` -- 62 tests across 6 suites, 0 failures

New tests:
- `ContentPageNav`: 7 test cases covering page counter rendering, Previous/Next navigation, boundary disabling, sheet opening, null title fallback, and sheet page selection
- `useWebViewMessage`: 5 test cases covering type dispatch, invalid JSON handling, unknown types, and missing type fields

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

## AI disclosure

Claude Opus 4 was used for implementation assistance and test writing.

/claim #27