### PR TITLE
feat: add tap-anywhere and scrub gestures to analytics charts

### DIFF
--- a/components/analytics/chart-gesture-overlay.tsx
+++ b/components/analytics/chart-gesture-overlay.tsx
@@ -1,0 +1,70 @@
+import { ReactNode, useCallback, useRef, useState } from "react";
+import { GestureResponderEvent, PanResponder, View } from "react-native";
+
+export const ChartGestureOverlay = ({
+  dataLength,
+  barWidth,
+  spacing,
+  onSelectIndex,
+  children,
+}: {
+  dataLength: number;
+  barWidth: number;
+  spacing: number;
+  onSelectIndex: (index: number | null) => void;
+  children: ReactNode;
+}) => {
+  const overlayRef = useRef<View>(null);
+  const lastIndexRef = useRef<number | null>(null);
+  const offsetXRef = useRef(0);
+
+  const getIndexFromPageX = useCallback(
+    (pageX: number) => {
+      const x = pageX - offsetXRef.current;
+      if (x < 0 || dataLength === 0) return null;
+      const index = Math.floor(x / (barWidth + spacing));
+      if (index < 0 || index >= dataLength) return null;
+      return index;
+    },
+    [barWidth, spacing, dataLength],
+  );
+
+  const handleTouch = useCallback(
+    (pageX: number) => {
+      const index = getIndexFromPageX(pageX);
+      if (index !== lastIndexRef.current) {
+        lastIndexRef.current = index;
+        onSelectIndex(index);
+      }
+    },
+    [getIndexFromPageX, onSelectIndex],
+  );
+
+  const [panResponder] = useState(() =>
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt: GestureResponderEvent) => {
+        overlayRef.current?.measureInWindow((x: number) => {
+          offsetXRef.current = x;
+          handleTouch(evt.nativeEvent.pageX);
+        });
+      },
+      onPanResponderMove: (evt: GestureResponderEvent) => {
+        handleTouch(evt.nativeEvent.pageX);
+      },
+    }),
+  );
+
+  return (
+    <View className="relative">
+      {children}
+      <View
+        ref={overlayRef}
+        {...panResponder.panHandlers}
+        className="absolute inset-0"
+        style={{ zIndex: 10 }}
+      />
+    </View>
+  );
+};

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -5,6 +5,7 @@ import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartGestureOverlay } from "./chart-gesture-overlay";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
@@ -27,15 +28,14 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const selectedViews = activeIndex !== null ? views[activeIndex] : 0;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
-  const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+  const handleSelectIndex = useCallback((index: number | null) => {
+    setSelectedIndex(index);
   }, []);
 
   const createChartData = (values: number[]) =>
     values.map((value, index) => ({
       value: value === 0 ? 0 : value,
       frontColor: index === activeIndex ? accentColor : colors.muted,
-      onPress: () => handleBarPress(index),
     }));
 
   const revenueData = createChartData(totals);
@@ -69,25 +69,32 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={revenueData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={totals.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={revenueData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureOverlay>
         </ChartContainer>
 
         <ChartContainer
@@ -104,25 +111,32 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={salesData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={sales.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={salesData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureOverlay>
         </ChartContainer>
 
         <ChartContainer
@@ -139,25 +153,32 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={viewsData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={views.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={viewsData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureOverlay>
         </ChartContainer>
       </View>
     </ScrollView>

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -4,6 +4,7 @@ import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartGestureOverlay } from "./chart-gesture-overlay";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
 
@@ -38,8 +39,8 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const activeIndex = selectedIndex;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
-  const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+  const handleSelectIndex = useCallback((index: number | null) => {
+    setSelectedIndex(index);
   }, []);
 
   const calculateTotals = (
@@ -115,13 +116,13 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const getReferrerColors = (
     data: { date: string; referrers: { name: string; value: number; color: string }[] }[],
   ): Record<string, string> => {
-    const colors: Record<string, string> = {};
+    const colorMap: Record<string, string> = {};
     if (data.length > 0 && data[0].referrers) {
       data[0].referrers.forEach((r) => {
-        colors[r.name] = r.color;
+        colorMap[r.name] = r.color;
       });
     }
-    return colors;
+    return colorMap;
   };
 
   const revenueReferrerColors = getReferrerColors(revenue.data);
@@ -141,26 +142,32 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
-            <BarChart
-              stackData={revenueChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={revenue.data.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={revenueChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureOverlay>
           <View>
             {revenue.topReferrers.map((name) => (
               <LegendItem
@@ -187,26 +194,32 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
-            <BarChart
-              stackData={salesChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={sales.data.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={salesChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureOverlay>
           <View>
             {sales.topReferrers.map((name) => (
               <LegendItem
@@ -233,26 +246,32 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
-            <BarChart
-              stackData={visitsChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureOverlay
+            dataLength={visits.data.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={visitsChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureOverlay>
           <View>
             {visits.topReferrers.map((name) => (
               <LegendItem


### PR DESCRIPTION
Fixes #26

## Changes

Adds a `ChartGestureOverlay` component that wraps each `BarChart` with a transparent `PanResponder` overlay, enabling:

- **Tap anywhere** on the chart area to select the bar at that X position (not just on the bar itself)
- **Slide/scrub** your finger across the chart to smoothly switch between bars

### How it works

The overlay uses `PanResponder` to capture touch events, then converts the touch X coordinate to a bar index using `barWidth + spacing` from the existing `useChartDimensions` hook. `measureInWindow` is called on gesture start for accurate positioning.

### Files changed

- **New:** `components/analytics/chart-gesture-overlay.tsx` — reusable gesture overlay component
- **Modified:** `components/analytics/sales-tab.tsx` — wrapped all 3 charts (Revenue, Sales, Views) with overlay, removed per-bar `onPress`
- **Modified:** `components/analytics/traffic-tab.tsx` — wrapped all 3 stacked charts with overlay, removed per-bar `onPress`

### Testing

All 57 existing tests pass ✅