### PR TITLE
fix: improve bar chart touch targets in analytics charts

### DIFF
--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -36,6 +36,17 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
       value: value === 0 ? 0 : value,
       frontColor: index === activeIndex ? accentColor : colors.muted,
       onPress: () => handleBarPress(index),
+      topLabelComponent: () => (
+        <View 
+          style={{
+            height: 120, // 匹配 BarChart 的高度
+            width: barWidth + spacing,
+            backgroundColor: 'transparent',
+            marginLeft: -(spacing / 2),
+          }}
+          onTouchStart={() => handleBarPress(index)}
+        />
+      ),
     }));
 
   const revenueData = createChartData(totals);

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -95,6 +95,18 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
       return {
         stacks,
         label: index === activeIndex ? item.date : "",
+        onPress: () => handleBarPress(index),
+        topLabelComponent: () => (
+          <View 
+            style={{
+              height: 120,
+              width: barWidth + spacing,
+              backgroundColor: 'transparent',
+              marginLeft: -(spacing / 2),
+            }}
+            onTouchStart={() => handleBarPress(index)}
+          />
+        ),
       };
     });
 


### PR DESCRIPTION
## Overview
Improved the interaction for bar charts in both Sales and Traffic tabs to allow selecting bars by tapping above them, especially useful for short bars or narrow screens.

## Key Changes
- **Expanded Touch Targets**: Added a transparent `topLabelComponent` to each bar that spans the full height of the chart (120px), ensuring the entire column is interactive.
- **Improved Selection Logic**: Applied the same interaction improvements to both `SalesTab` and `TrafficTab` for consistency.
- **Enhanced UX**: Users can now easily select data points even when values are low or bars are visually small.

## Payout Information
Address: 0xa5F1e2596DC1e878a6a039f41330d9A97c771bE9