### PR TITLE
Expand chart hit area and add drag-to-scrub selection

### DIFF
--- a/components/analytics/chart-gesture-wrapper.tsx
+++ b/components/analytics/chart-gesture-wrapper.tsx
@@ -1,0 +1,68 @@
+import { ReactNode, useCallback, useRef } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+
+export const getBarIndex = (x: number, barWidth: number, spacing: number, barCount: number): number | null => {
+  const barSlotWidth = barWidth + spacing;
+  if (barSlotWidth <= 0 || barCount <= 0) return null;
+  const index = Math.floor(x / barSlotWidth);
+  if (index < 0 || index >= barCount) return null;
+  return index;
+};
+
+export const ChartGestureWrapper = ({
+  barCount,
+  barWidth,
+  spacing,
+  selectedIndex,
+  onSelectIndex,
+  children,
+}: {
+  barCount: number;
+  barWidth: number;
+  spacing: number;
+  selectedIndex: number | null;
+  onSelectIndex: (index: number | null) => void;
+  children: ReactNode;
+}) => {
+  const lastIndex = useRef<number | null>(null);
+  const didScrub = useRef(false);
+
+  const resolveIndex = useCallback(
+    (x: number) => getBarIndex(x, barWidth, spacing, barCount),
+    [barWidth, spacing, barCount],
+  );
+
+  const pan = Gesture.Pan()
+    .onBegin((event) => {
+      const index = resolveIndex(event.x);
+      lastIndex.current = index;
+      didScrub.current = false;
+      if (index !== null) {
+        onSelectIndex(index);
+      }
+    })
+    .onUpdate((event) => {
+      const index = resolveIndex(event.x);
+      if (index !== null && index !== lastIndex.current) {
+        didScrub.current = true;
+        lastIndex.current = index;
+        onSelectIndex(index);
+      }
+    })
+    .onEnd((event) => {
+      if (!didScrub.current) {
+        const index = resolveIndex(event.x);
+        if (index !== null && index === selectedIndex) {
+          onSelectIndex(null);
+        }
+      }
+    })
+    .minDistance(0);
+
+  return (
+    <GestureDetector gesture={pan}>
+      <View collapsable={false}>{children}</View>
+    </GestureDetector>
+  );
+};

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -5,6 +5,7 @@ import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartGestureWrapper } from "./chart-gesture-wrapper";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
@@ -27,15 +28,14 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const selectedViews = activeIndex !== null ? views[activeIndex] : 0;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
-  const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+  const handleSelectIndex = useCallback((index: number | null) => {
+    setSelectedIndex(index);
   }, []);
 
   const createChartData = (values: number[]) =>
     values.map((value, index) => ({
       value: value === 0 ? 0 : value,
       frontColor: index === activeIndex ? accentColor : colors.muted,
-      onPress: () => handleBarPress(index),
     }));
 
   const revenueData = createChartData(totals);
@@ -69,25 +69,33 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={revenueData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={revenueData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={revenueData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureWrapper>
         </ChartContainer>
 
         <ChartContainer
@@ -104,25 +112,33 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={salesData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={salesData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={salesData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureWrapper>
         </ChartContainer>
 
         <ChartContainer
@@ -139,25 +155,33 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
-            <BarChart
-              data={viewsData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              isAnimated={false}
-              barBorderTopLeftRadius={4}
-              barBorderTopRightRadius={4}
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={viewsData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View className="mt-4">
+              <BarChart
+                data={viewsData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                isAnimated={false}
+                barBorderTopLeftRadius={4}
+                barBorderTopRightRadius={4}
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+              />
+            </View>
+          </ChartGestureWrapper>
         </ChartContainer>
       </View>
     </ScrollView>

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -4,6 +4,7 @@ import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { ChartGestureWrapper } from "./chart-gesture-wrapper";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
 
@@ -38,8 +39,8 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const activeIndex = selectedIndex;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
-  const handleBarPress = useCallback((index: number) => {
-    setSelectedIndex((prev) => (prev === index ? null : index));
+  const handleSelectIndex = useCallback((index: number | null) => {
+    setSelectedIndex(index);
   }, []);
 
   const calculateTotals = (
@@ -141,26 +142,33 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
-            <BarChart
-              stackData={revenueChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={revenueChartData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={revenueChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureWrapper>
           <View>
             {revenue.topReferrers.map((name) => (
               <LegendItem
@@ -187,26 +195,33 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
-            <BarChart
-              stackData={salesChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={salesChartData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={salesChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureWrapper>
           <View>
             {sales.topReferrers.map((name) => (
               <LegendItem
@@ -233,26 +248,33 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
-            <BarChart
-              stackData={visitsChartData}
-              height={120}
-              barWidth={barWidth}
-              spacing={spacing}
-              initialSpacing={0}
-              endSpacing={0}
-              hideRules
-              hideYAxisText
-              disableScroll
-              yAxisThickness={0}
-              xAxisThickness={1}
-              xAxisColor={colors.border}
-              highlightEnabled={activeIndex !== null}
-              highlightedBarIndex={activeIndex ?? undefined}
-              lowlightOpacity={0.4}
-              onPress={(_: unknown, index: number) => handleBarPress(index)}
-            />
-          </View>
+          <ChartGestureWrapper
+            barCount={visitsChartData.length}
+            barWidth={barWidth}
+            spacing={spacing}
+            selectedIndex={selectedIndex}
+            onSelectIndex={handleSelectIndex}
+          >
+            <View>
+              <BarChart
+                stackData={visitsChartData}
+                height={120}
+                barWidth={barWidth}
+                spacing={spacing}
+                initialSpacing={0}
+                endSpacing={0}
+                hideRules
+                hideYAxisText
+                disableScroll
+                yAxisThickness={0}
+                xAxisThickness={1}
+                xAxisColor={colors.border}
+                highlightEnabled={activeIndex !== null}
+                highlightedBarIndex={activeIndex ?? undefined}
+                lowlightOpacity={0.4}
+              />
+            </View>
+          </ChartGestureWrapper>
           <View>
             {visits.topReferrers.map((name) => (
               <LegendItem

--- a/tests/components/analytics/chart-gesture-wrapper.test.ts
+++ b/tests/components/analytics/chart-gesture-wrapper.test.ts
@@ -1,0 +1,39 @@
+import { getBarIndex } from "@/components/analytics/chart-gesture-wrapper";
+
+const BAR_WIDTH = 20;
+const SPACING = 4;
+const BAR_COUNT = 7;
+
+describe("getBarIndex", () => {
+  it("returns index 0 for a tap at the start of the chart", () => {
+    expect(getBarIndex(5, BAR_WIDTH, SPACING, BAR_COUNT)).toBe(0);
+  });
+
+  it("returns the correct index for a tap in the middle", () => {
+    expect(getBarIndex(72, BAR_WIDTH, SPACING, BAR_COUNT)).toBe(3);
+  });
+
+  it("returns the last index for a tap near the end", () => {
+    expect(getBarIndex(150, BAR_WIDTH, SPACING, BAR_COUNT)).toBe(6);
+  });
+
+  it("returns null for a tap beyond all bars", () => {
+    expect(getBarIndex(200, BAR_WIDTH, SPACING, BAR_COUNT)).toBeNull();
+  });
+
+  it("returns null for a negative x position", () => {
+    expect(getBarIndex(-10, BAR_WIDTH, SPACING, BAR_COUNT)).toBeNull();
+  });
+
+  it("returns null when barCount is 0", () => {
+    expect(getBarIndex(10, BAR_WIDTH, SPACING, 0)).toBeNull();
+  });
+
+  it("returns null when bar slot width is 0", () => {
+    expect(getBarIndex(10, 0, 0, 5)).toBeNull();
+  });
+
+  it("handles narrow bars correctly", () => {
+    expect(getBarIndex(13, 4, 2, 10)).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #26

### Changes

- `chart-gesture-wrapper.tsx` — new component with a Pan gesture that covers the full chart area, plus an exported `getBarIndex` function for the coordinate-to-index mapping
- `sales-tab.tsx` — replaced per-item `onPress` callbacks with `ChartGestureWrapper`
- `traffic-tab.tsx` — replaced `BarChart` `onPress` prop with `ChartGestureWrapper`, kept `highlightEnabled`/`lowlightOpacity` for the stacked bar visual treatment
- `chart-gesture-wrapper.test.ts` — unit tests for `getBarIndex` edge cases (bounds, zero-width, negative coords)