### PR TITLE
Fix #23: Paginate products in the library

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -2,9 +2,12 @@ import { LibraryFilters } from "@/components/library-filters";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { useLibraryFilters } from "@/components/use-library-filters";
+import { assertDefined } from "@/lib/assert";
 import { useAuth } from "@/lib/auth-context";
-import { useAPIRequest } from "@/lib/request";
+import { requestAPI, UnauthorizedError, useAPIRequest } from "@/lib/request";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
+import { useEffect, useMemo } from "react";
 import { FlatList, Image, RefreshControl, Text, TouchableOpacity, View } from "react-native";
 import { useCSSVariable } from "uniwind";
 
@@ -34,20 +37,87 @@ interface PurchasesResponse {
   user_id: string;
 }
 
-export const usePurchases = () =>
-  useAPIRequest<PurchasesResponse, Purchase[]>({
-    queryKey: ["purchases"],
-    url: "mobile/purchases/index",
-    select: (data) => data.products,
+interface CreatorFiltersResponse {
+  success: boolean;
+  sellers: {
+    id: string;
+    name: string;
+    purchases_count: number;
+  }[];
+}
+
+const PURCHASES_PER_PAGE = 24;
+
+export const usePurchases = () => {
+  const { accessToken, logout, isLoading: isAuthLoading } = useAuth();
+
+  const query = useInfiniteQuery<PurchasesResponse, Error>({
+    queryKey: ["purchases", PURCHASES_PER_PAGE],
+    queryFn: ({ pageParam }) =>
+      requestAPI<PurchasesResponse>(
+        `mobile/purchases/index?page=${pageParam}&per_page=${PURCHASES_PER_PAGE}`,
+        { accessToken: assertDefined(accessToken) },
+      ),
+    enabled: !!accessToken,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.products.length === PURCHASES_PER_PAGE ? allPages.length + 1 : undefined,
+  });
+
+  useEffect(() => {
+    if ((!isAuthLoading && !accessToken) || query.error instanceof UnauthorizedError) logout();
+  }, [isAuthLoading, accessToken, query.error, logout]);
+
+  const purchases = useMemo(() => query.data?.pages.flatMap((page) => page.products) ?? [], [query.data?.pages]);
+
+  return {
+    ...query,
+    purchases,
+  };
+};
+
+const useCreatorCounts = (archived: boolean) =>
+  useAPIRequest<CreatorFiltersResponse, { username: string; name: string; count: number }[]>({
+    queryKey: ["purchase-creator-counts", archived],
+    url: `mobile/purchases/search?archived=${archived}&items=1`,
+    select: (data) =>
+      data.sellers
+        .map((seller) => ({
+          // We key by name because the purchase payload does not include seller external ID.
+          username: seller.name,
+          name: seller.name,
+          count: seller.purchases_count,
+        }))
+        .sort((a, b) => {
+          if (b.count !== a.count) return b.count - a.count;
+          return a.name.localeCompare(b.name);
+        }),
   });
 
 export default function Index() {
   const { isLoading } = useAuth();
-  const { data: purchases = [], isLoading: isLoadingPurchases, error, refetch, isRefetching } = usePurchases();
+  const {
+    purchases,
+    isLoading: isLoadingPurchases,
+    error,
+    refetch,
+    isRefetching,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = usePurchases();
+  const { data: activeCreatorCounts = [] } = useCreatorCounts(false);
+  const { data: archivedCreatorCounts = [] } = useCreatorCounts(true);
   const router = useRouter();
   const accentColor = useCSSVariable("--color-accent") as string;
 
-  const filters = useLibraryFilters(purchases);
+  const filters = useLibraryFilters(purchases, {
+    creatorCountsByArchivedState: {
+      active: activeCreatorCounts,
+      archived: archivedCreatorCounts,
+    },
+    hasArchivedProducts: archivedCreatorCounts.length > 0,
+  });
 
   if (error) {
     return (
@@ -94,6 +164,12 @@ export default function Index() {
             keyExtractor={(item) => item.url_redirect_token}
             contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 16, gap: 12 }}
             columnWrapperStyle={{ gap: 12 }}
+            onEndReachedThreshold={0.5}
+            onEndReached={() => {
+              if (hasNextPage && !isFetchingNextPage) {
+                fetchNextPage();
+              }
+            }}
             refreshControl={<RefreshControl refreshing={isRefetching} onRefresh={refetch} tintColor={accentColor} />}
             renderItem={({ item }) => (
               <TouchableOpacity
@@ -128,6 +204,13 @@ export default function Index() {
                   {filters.searchText || filters.hasActiveFilters ? "No matching products" : "No purchases yet"}
                 </Text>
               </View>
+            }
+            ListFooterComponent={
+              isFetchingNextPage ? (
+                <View className="py-4">
+                  <LoadingSpinner size="small" />
+                </View>
+              ) : null
             }
           />
         </LibraryFilters>

--- a/app/purchase/[id].tsx
+++ b/app/purchase/[id].tsx
@@ -60,7 +60,7 @@ export default function DownloadScreen() {
   const [isDownloading, setIsDownloading] = useState(false);
   const [tocPages, setTocPages] = useState<TocDataMessage["payload"]["pages"]>([]);
   const [activePageIndex, setActivePageIndex] = useState(0);
-  const { data: purchases = [] } = usePurchases();
+  const { purchases } = usePurchases();
   const router = useRouter();
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);

--- a/components/use-library-filters.ts
+++ b/components/use-library-filters.ts
@@ -33,15 +33,26 @@ export interface UseLibraryFiltersReturn {
   handleToggleArchived: () => void;
 }
 
-export const useLibraryFilters = (purchases: Purchase[]): UseLibraryFiltersReturn => {
+interface CreatorCountsByArchivedState {
+  active: CreatorCount[];
+  archived: CreatorCount[];
+}
+
+interface UseLibraryFiltersOptions {
+  creatorCountsByArchivedState?: CreatorCountsByArchivedState;
+  hasArchivedProducts?: boolean;
+}
+
+export const useLibraryFilters = (purchases: Purchase[], options: UseLibraryFiltersOptions = {}): UseLibraryFiltersReturn => {
   const [searchText, setSearchText] = useState("");
   const [selectedCreators, setSelectedCreators] = useState<Set<string>>(new Set());
   const [showArchivedOnly, setShowArchivedOnly] = useState(false);
   const [sortBy, setSortBy] = useState<SortOption>("content_updated_at");
 
-  const hasArchivedProducts = useMemo(() => purchases.some((p) => p.is_archived), [purchases]);
+  const localHasArchivedProducts = useMemo(() => purchases.some((p) => p.is_archived), [purchases]);
+  const hasArchivedProducts = options.hasArchivedProducts ?? localHasArchivedProducts;
 
-  const creatorCounts = useMemo(() => {
+  const localCreatorCounts = useMemo(() => {
     const basePurchases = showArchivedOnly
       ? purchases.filter((p) => p.is_archived)
       : purchases.filter((p) => !p.is_archived);
@@ -62,6 +73,13 @@ export const useLibraryFilters = (purchases: Purchase[]): UseLibraryFiltersRetur
       .map(([username, { name, count }]) => ({ username, name, count }));
   }, [purchases, showArchivedOnly]);
 
+  const creatorCounts = useMemo(() => {
+    if (!options.creatorCountsByArchivedState) {
+      return localCreatorCounts;
+    }
+    return showArchivedOnly ? options.creatorCountsByArchivedState.archived : options.creatorCountsByArchivedState.active;
+  }, [localCreatorCounts, options.creatorCountsByArchivedState, showArchivedOnly]);
+
   const filteredPurchases = useMemo(() => {
     let result = showArchivedOnly ? purchases.filter((p) => p.is_archived) : purchases.filter((p) => !p.is_archived);
 
@@ -73,7 +91,7 @@ export const useLibraryFilters = (purchases: Purchase[]): UseLibraryFiltersRetur
     }
 
     if (selectedCreators.size > 0) {
-      result = result.filter((p) => selectedCreators.has(p.creator_username));
+      result = result.filter((p) => selectedCreators.has(p.creator_username) || selectedCreators.has(p.creator_name));
     }
 
     result = [...result].sort((a, b) => {


### PR DESCRIPTION
## Summary

This PR resolves #23.

### Changes

Implemented paginated library loading with per_page/page using infinite queries, added creator count metadata queries via purchases search aggregation for filter support, and updated library filter hook + purchase detail consumer for the new paginated purchases API.

### Files Modified

- `app/(tabs)/library.tsx`
- `components/use-library-filters.ts`
- `app/purchase/[id].tsx`
- `DONE.json`

Happy to address any feedback or make adjustments.

/claim #23