### PR TITLE
feat: add tap and pan gesture support for chart bar selection

### DIFF
--- a/components/analytics/interactive-chart.tsx
+++ b/components/analytics/interactive-chart.tsx
@@ -1,0 +1,54 @@
+import { ReactNode, useCallback } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+
+interface InteractiveChartProps {
+  children: ReactNode;
+  barWidth: number;
+  spacing: number;
+  dataLength: number;
+  onBarSelect: (index: number) => void;
+}
+
+export const InteractiveChart = ({
+  children,
+  barWidth,
+  spacing,
+  dataLength,
+  onBarSelect,
+}: InteractiveChartProps) => {
+  const getBarIndex = useCallback(
+    (x: number): number | null => {
+      if (dataLength === 0) return null;
+      const totalBarWidth = barWidth + spacing;
+      const index = Math.floor(x / totalBarWidth);
+      if (index < 0 || index >= dataLength) return null;
+      return index;
+    },
+    [barWidth, spacing, dataLength],
+  );
+
+  const tap = Gesture.Tap().onEnd((event) => {
+    const index = getBarIndex(event.x);
+    if (index !== null) {
+      onBarSelect(index);
+    }
+  });
+
+  const pan = Gesture.Pan()
+    .onUpdate((event) => {
+      const index = getBarIndex(event.x);
+      if (index !== null) {
+        onBarSelect(index);
+      }
+    })
+    .activeOffsetX([-5, 5]);
+
+  const gesture = Gesture.Race(pan, tap);
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <View className="mt-4">{children}</View>
+    </GestureDetector>
+  );
+};

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -1,10 +1,11 @@
 import { Text } from "@/components/ui/text";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { useCSSVariable } from "uniwind";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { InteractiveChart } from "./interactive-chart";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
@@ -27,8 +28,17 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const selectedViews = activeIndex !== null ? views[activeIndex] : 0;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
+  const lastPanIndex = useRef<number | null>(null);
+
   const handleBarPress = useCallback((index: number) => {
     setSelectedIndex((prev) => (prev === index ? null : index));
+    lastPanIndex.current = null;
+  }, []);
+
+  const handleBarPan = useCallback((index: number) => {
+    if (lastPanIndex.current === index) return;
+    lastPanIndex.current = index;
+    setSelectedIndex(index);
   }, []);
 
   const createChartData = (values: number[]) =>
@@ -69,7 +79,12 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View className="mt-4">
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={totals.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               data={revenueData}
               height={120}
@@ -87,7 +102,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </InteractiveChart>
         </ChartContainer>
 
         <ChartContainer
@@ -104,7 +119,12 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={sales.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               data={salesData}
               height={120}
@@ -122,7 +142,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </InteractiveChart>
         </ChartContainer>
 
         <ChartContainer
@@ -139,7 +159,12 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               </Text>
             )}
           </View>
-          <View className="mt-4">
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={views.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               data={viewsData}
               height={120}
@@ -157,7 +182,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               xAxisThickness={1}
               xAxisColor={colors.border}
             />
-          </View>
+          </InteractiveChart>
         </ChartContainer>
       </View>
     </ScrollView>

--- a/components/analytics/traffic-tab.tsx
+++ b/components/analytics/traffic-tab.tsx
@@ -1,9 +1,10 @@
 import { Text } from "@/components/ui/text";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { ScrollView, View } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { formatCurrency, formatNumber, useChartColors, useChartDimensions } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
+import { InteractiveChart } from "./interactive-chart";
 import { AnalyticsTimeRange } from "./use-analytics-by-date";
 import { useAnalyticsByReferral } from "./use-analytics-by-referral";
 
@@ -38,8 +39,17 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
   const activeIndex = selectedIndex;
   const selectedDate = activeIndex !== null && dates[activeIndex] ? dates[activeIndex] : "";
 
+  const lastPanIndex = useRef<number | null>(null);
+
   const handleBarPress = useCallback((index: number) => {
     setSelectedIndex((prev) => (prev === index ? null : index));
+    lastPanIndex.current = null;
+  }, []);
+
+  const handleBarPan = useCallback((index: number) => {
+    if (lastPanIndex.current === index) return;
+    lastPanIndex.current = index;
+    setSelectedIndex(index);
   }, []);
 
   const calculateTotals = (
@@ -141,7 +151,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
             {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
           </View>
-          <View>
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={revenue.data.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               stackData={revenueChartData}
               height={120}
@@ -160,7 +175,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </InteractiveChart>
           <View>
             {revenue.topReferrers.map((name) => (
               <LegendItem
@@ -187,7 +202,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={sales.data.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               stackData={salesChartData}
               height={120}
@@ -206,7 +226,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </InteractiveChart>
           <View>
             {sales.topReferrers.map((name) => (
               <LegendItem
@@ -233,7 +253,12 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               </Text>
             )}
           </View>
-          <View>
+          <InteractiveChart
+            barWidth={barWidth}
+            spacing={spacing}
+            dataLength={visits.data.length}
+            onBarSelect={handleBarPan}
+          >
             <BarChart
               stackData={visitsChartData}
               height={120}
@@ -252,7 +277,7 @@ export const TrafficTab = ({ timeRange }: TrafficTabProps) => {
               lowlightOpacity={0.4}
               onPress={(_: unknown, index: number) => handleBarPress(index)}
             />
-          </View>
+          </InteractiveChart>
           <View>
             {visits.topReferrers.map((name) => (
               <LegendItem


### PR DESCRIPTION
## Summary

Closes #26

Adds touch gesture support so users can tap anywhere on a chart (not just on the bar itself) and slide their finger to scrub through bars  matching the behavior described in the issue.

## Changes

**New file:** components/analytics/interactive-chart.tsx
- Reusable InteractiveChart wrapper component
- Uses Gesture.Race(pan, tap) from eact-native-gesture-handler (already a dependency)
- Calculates bar index from touch X coordinate using arWidth + spacing
- Pan gesture deduplication via useRef to avoid unnecessary re-renders

**Modified:** components/analytics/sales-tab.tsx
- Wrapped all 3 BarChart instances (Revenue, Sales, Views) with InteractiveChart
- Added handleBarPan callback for scrub selection
- Existing onPress on individual bars still works as fallback

**Modified:** components/analytics/traffic-tab.tsx
- Same changes as sales-tab for stacked bar charts (Revenue, Sales, Visits)
- Existing onPress + highlight behavior preserved

## How it works

1. **Tap above a short bar**  Gesture.Tap() fires, X coordinate maps to the nearest bar index
2. **Slide finger across chart**  Gesture.Pan() fires on each move, selecting the bar under the finger
3. **Tap directly on a bar**  Original onPress callback still works (toggle behavior preserved)

## Technical details

- Gesture.Race(pan, tap) ensures only one gesture wins per interaction
- ctiveOffsetX([-5, 5]) on pan prevents accidental activation during vertical scroll
- No new dependencies  uses existing eact-native-gesture-handler (~2.28.0)
- arIndex = Math.floor(x / (barWidth + spacing)) with bounds checking