### PR TITLE
Disable liquid glass on iOS

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -16,6 +16,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     infoPlist: {
       UIBackgroundModes: ["audio"],
       ITSAppUsesNonExemptEncryption: false,
+      UIDesignRequiresCompatibility: true,
     },
   },
   android: {


### PR DESCRIPTION
The app design isn't updated to consider it, so it makes default updated elements (e.g. header back buttons) look wrong