### PR TITLE
Fix Sentry errors

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -46,7 +46,6 @@ const RootLayout = () => {
 
   useEffect(() => {
     setupPlayer().catch((error) => {
-      Sentry.captureException(error);
       console.error("Failed to setup player:", error);
     });
   }, []);

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -115,6 +115,10 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
 
   useEffect(() => {
     const intervalId = setInterval(async () => {
+      if (!isPlayerSetup) {
+        console.warn("Audio polling called before player setup");
+        return;
+      }
       const { state } = await TrackPlayer.getPlaybackState();
       if (state === State.Playing) {
         await sendAudioPlayerInfo({ isPlaying: true });
@@ -142,6 +146,10 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
   }, [sendAudioPlayerInfo, syncMediaLocation]);
 
   const pauseAudio = useCallback(async () => {
+    if (!isPlayerSetup) {
+      console.warn("pauseAudio called before player setup");
+      return;
+    }
     await TrackPlayer.pause();
     await sendAudioPlayerInfo({ isPlaying: false });
   }, [sendAudioPlayerInfo]);
@@ -187,6 +195,10 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
       artwork?: string | null;
       tracks: AudioTrackInfo[];
     }) => {
+      if (!isPlayerSetup) {
+        console.warn("playAudio called before player setup");
+        return;
+      }
       const audio = tracks.find((track) => track.resourceId === resourceId);
       if (!audio) {
         console.warn(`Couldn't find track ${resourceId}. Available:`, tracks);


### PR DESCRIPTION
These came up while testing but don't seem to affect functionality; switching each case to logging means we'll get breadcrumbs if someone submits feedback because they're causing a genuine issue but they won't spam and take up replay budget.