### PR TITLE
Fix leftover state when switching users

### DIFF
--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -208,6 +208,7 @@ export default function DownloadScreen() {
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled
         pullToRefreshEnabled
+        incognito
         mediaPlaybackRequiresUserAction={false}
         originWhitelist={["*"]}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,4 +1,5 @@
 import { assertDefined } from "@/lib/assert";
+import { queryClient } from "@/lib/query-client";
 import { env } from "@/lib/env";
 import { request } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
@@ -138,6 +139,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       await SecureStore.deleteItemAsync(refreshTokenKey);
       setAccessToken(null);
       setIsCreator(false);
+      queryClient.clear();
       router.replace("/login");
     } catch (error) {
       Sentry.captureException(error);

--- a/lib/query-client.tsx
+++ b/lib/query-client.tsx
@@ -10,7 +10,7 @@ focusManager.setEventListener((handleFocus) => {
   return () => subscription.remove();
 });
 
-const queryClient = new QueryClient({
+export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes


### PR DESCRIPTION
Fixes a couple of bugs that happened when logging out and back in

* The React Query cache would persist, meaning screens like the library would show the old user's purchases until refreshed
* The webview session would persist, so a "this product belongs to another email" prompt would show if you viewed a library product