### PR TITLE
Fix: Sanitize HTML error responses in request() to improve Sentry reporting

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -31,8 +31,15 @@ export const request = async <T>(url: string, options?: RequestInit & { data?: a
     throw new UnauthorizedError("Unauthorized");
   }
   if (!response.ok) {
-    const error = (await response.text()).slice(0, 10000);
-    console.info("HTTP request", { ...details, error });
+    const rawError = (await response.text()).slice(0, 10000);
+    const isHtml =
+      rawError.trimStart().startsWith("<!DOCTYPE") ||
+      rawError.trimStart().startsWith("<html") ||
+      (response.headers.get("content-type") ?? "").includes("text/html");
+    const error = isHtml
+      ? rawError.match(/<title[^>]*>([^<]+)<\/title>/i)?.[1]?.trim() || "HTML error page"
+      : rawError.slice(0, 200);
+    console.info("HTTP request", { ...details, error: rawError.slice(0, 500) });
     throw new Error(`Request failed: ${response.status} ${error}`);
   }
   console.info("HTTP request", details);

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -29,13 +29,11 @@ describe("request", () => {
   it("includes plain-text error body in thrown error (truncated to 200 chars)", async () => {
     const longError = "x".repeat(300);
     mockFetch(500, longError);
-    await expect(request("https://api.example.com/test")).rejects.toThrow(
-      `Request failed: 500 ${"x".repeat(200)}`,
-    );
+    await expect(request("https://api.example.com/test")).rejects.toThrow(`Request failed: 500 ${"x".repeat(200)}`);
   });
 
   it("extracts <title> from HTML error responses instead of including raw HTML", async () => {
-    const html = '<!DOCTYPE html><html><head><title>Page not found</title></head><body><h1>404</h1></body></html>';
+    const html = "<!DOCTYPE html><html><head><title>Page not found</title></head><body><h1>404</h1></body></html>";
     mockFetch(404, html);
     await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 404 Page not found");
   });

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -1,0 +1,54 @@
+import { request, UnauthorizedError } from "@/lib/request";
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+const mockFetch = (status: number, body: string, headers: Record<string, string> = {}) => {
+  jest.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(headers),
+    json: () => Promise.resolve(JSON.parse(body)),
+    text: () => Promise.resolve(body),
+  } as Response);
+};
+
+describe("request", () => {
+  it("returns parsed JSON on success", async () => {
+    mockFetch(200, '{"id": 1}');
+    const result = await request<{ id: number }>("https://api.example.com/test");
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it("throws UnauthorizedError on 401", async () => {
+    mockFetch(401, "Unauthorized");
+    await expect(request("https://api.example.com/test")).rejects.toThrow(UnauthorizedError);
+  });
+
+  it("includes plain-text error body in thrown error (truncated to 200 chars)", async () => {
+    const longError = "x".repeat(300);
+    mockFetch(500, longError);
+    await expect(request("https://api.example.com/test")).rejects.toThrow(
+      `Request failed: 500 ${"x".repeat(200)}`,
+    );
+  });
+
+  it("extracts <title> from HTML error responses instead of including raw HTML", async () => {
+    const html = '<!DOCTYPE html><html><head><title>Page not found</title></head><body><h1>404</h1></body></html>';
+    mockFetch(404, html);
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 404 Page not found");
+  });
+
+  it("falls back to 'HTML error page' when HTML has no <title>", async () => {
+    const html = "<!DOCTYPE html><html><body><h1>Error</h1></body></html>";
+    mockFetch(404, html);
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 404 HTML error page");
+  });
+
+  it("detects HTML via content-type header even without DOCTYPE", async () => {
+    const html = "<div>Some error</div>";
+    mockFetch(500, html, { "content-type": "text/html; charset=utf-8" });
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 500 HTML error page");
+  });
+});


### PR DESCRIPTION
## Problem

When the API returns a non-OK response with an HTML body (e.g. a 404 "Page not found" page), the entire HTML gets stuffed into the `Error` message. This causes:

1. Sentry to misparse stacktraces (HTML tags appear as function names)
2. Error grouping to break
3. Noisy, unreadable error messages

Sentry issue: https://gumroad-to.sentry.io/issues/7369975611/

## Solution

Detect HTML error responses via:
- `<!DOCTYPE` or `<html` prefix in the response body
- `text/html` in the `Content-Type` header

When HTML is detected, extract just the `<title>` text (e.g. "Page not found"), falling back to "HTML error page". Plain-text errors are truncated to 200 chars for cleaner Sentry reporting.

The full raw error body (up to 500 chars) is still logged to `console.info` for debugging.

## Tests

Added 6 tests covering: success path, 401, plain-text truncation, HTML title extraction, HTML without title fallback, and content-type detection.