### PR TITLE
Fix OTA update config

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -6,13 +6,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "preview"
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "channel": "production"
     }
   },
   "submit": {


### PR DESCRIPTION
OTA updates weren't being found correctly because the channel wasn't set in Expo config.