### PR TITLE
Fix unhandled rejection when Linking.openURL fails for embed URLs

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -11,6 +11,7 @@ import * as Sentry from "@sentry/react-native";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams } from "expo-router";
 import * as Sharing from "expo-sharing";
+import * as WebBrowser from "expo-web-browser";
 import { useCallback, useRef, useState } from "react";
 import { Alert, Linking, Pressable, ScrollView, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -80,11 +81,17 @@ export default function PostScreen() {
   };
 
   const handleCreatorPress = () => {
-    if (post?.creator_profile_url) Linking.openURL(post.creator_profile_url);
+    if (post?.creator_profile_url)
+      Linking.openURL(post.creator_profile_url).catch(() => {
+        WebBrowser.openBrowserAsync(post.creator_profile_url!);
+      });
   };
 
   const handleCtaPress = () => {
-    if (post?.call_to_action_url) Linking.openURL(post.call_to_action_url);
+    if (post?.call_to_action_url)
+      Linking.openURL(post.call_to_action_url).catch(() => {
+        WebBrowser.openBrowserAsync(post.call_to_action_url!);
+      });
   };
 
   if (!post) {

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -12,6 +12,7 @@ import { buildApiUrl } from "@/lib/request";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
+import * as WebBrowser from "expo-web-browser";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as Sentry from "@sentry/react-native";
 import { Alert, Linking, View } from "react-native";
@@ -86,7 +87,9 @@ export default function DownloadScreen() {
         !/^https?:\/\//.test(request.url)
       )
         return true;
-      Linking.openURL(request.url);
+      Linking.openURL(request.url).catch(() => {
+        WebBrowser.openBrowserAsync(request.url);
+      });
       return false;
     },
     [url],


### PR DESCRIPTION
## Summary
- Adds `.catch()` fallback on `Linking.openURL()` calls in `app/purchase/[token].tsx` and `app/post/[id].tsx`
- When `Linking.openURL` fails (e.g. for iframely embed URLs that can't be opened as native deep links), falls back to `WebBrowser.openBrowserAsync()` to open the URL in an in-app browser
- Fixes Sentry issue: unhandled promise rejection on iOS when WebView navigates to `cdn.iframe.ly` embed URLs

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 89 existing tests pass
- [ ] Open a purchase page with an embedded YouTube video, tap the embed, verify it opens in the in-app browser instead of crashing
- [ ] Verify normal external links (non-embed) still open correctly via `Linking.openURL`
- [ ] Verify creator profile and CTA links on post pages still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)