### PR TITLE
Fix TypeError: Cannot read property 'title' of undefined in ContentPageNav

### DIFF
--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -103,8 +103,9 @@ export default function DownloadScreen() {
       console.info("WebView message received:", message);
 
       if (message.type === "tocData") {
-        setTocPages(message.payload.pages);
-        setActivePageIndex(message.payload.activePageIndex);
+        const pages = message.payload.pages;
+        setTocPages(pages);
+        setActivePageIndex(Math.min(message.payload.activePageIndex, Math.max(pages.length - 1, 0)));
         return;
       }
 

--- a/components/content-page-nav.tsx
+++ b/components/content-page-nav.tsx
@@ -31,8 +31,9 @@ export const ContentPageNav = ({
   onPageChange: (index: number) => void;
 }) => {
   const [sheetOpen, setSheetOpen] = useState(false);
-  const hasPrevious = activePageIndex > 0;
-  const hasNext = activePageIndex < pages.length - 1;
+  const safeIndex = Math.max(0, Math.min(activePageIndex, pages.length - 1));
+  const hasPrevious = safeIndex > 0;
+  const hasNext = safeIndex < pages.length - 1;
 
   return (
     <>
@@ -40,12 +41,12 @@ export const ContentPageNav = ({
         <Pressable onPress={() => setSheetOpen(true)} className="flex-1 flex-row items-center gap-1.5 px-4 py-3">
           <LineIcon name="list-ul" size={18} className="text-foreground" />
           <Text className="text-sm font-bold text-foreground" numberOfLines={1}>
-            {pages[activePageIndex].title}
+            {pages[safeIndex]?.title ?? "Untitled"}
           </Text>
         </Pressable>
 
         <Pressable
-          onPress={() => onPageChange(activePageIndex - 1)}
+          onPress={() => onPageChange(safeIndex - 1)}
           disabled={!hasPrevious}
           className={cn("flex-row items-center gap-1 px-4 py-3", !hasPrevious && "opacity-50")}
         >
@@ -54,7 +55,7 @@ export const ContentPageNav = ({
         </Pressable>
 
         <Pressable
-          onPress={() => onPageChange(activePageIndex + 1)}
+          onPress={() => onPageChange(safeIndex + 1)}
           disabled={!hasNext}
           className={cn("flex-row items-center gap-1 px-4 py-3", !hasNext && "opacity-50")}
         >
@@ -72,7 +73,7 @@ export const ContentPageNav = ({
             data={pages}
             keyExtractor={(item) => item.page_id}
             renderItem={({ item, index }) => {
-              const isActive = index === activePageIndex;
+              const isActive = index === safeIndex;
               return (
                 <Pressable
                   onPress={() => {

--- a/tests/components/content-page-nav.test.tsx
+++ b/tests/components/content-page-nav.test.tsx
@@ -54,6 +54,16 @@ describe("ContentPageNav", () => {
     expect(screen.getByText("Untitled")).toBeTruthy();
   });
 
+  it("clamps out-of-bounds activePageIndex to last page", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={10} onPageChange={onPageChange} />);
+    expect(screen.getByText("Page 3")).toBeTruthy();
+  });
+
+  it("clamps negative activePageIndex to first page", () => {
+    render(<ContentPageNav pages={makePages(3)} activePageIndex={-5} onPageChange={onPageChange} />);
+    expect(screen.getByText("Page 1")).toBeTruthy();
+  });
+
   it("calls onPageChange when a page is selected in the sheet", () => {
     render(<ContentPageNav pages={makePages(3)} activePageIndex={0} onPageChange={onPageChange} />);
     fireEvent.press(screen.getByText("Page 1"));


### PR DESCRIPTION
## Summary
- **Sentry issue**: `TypeError: Cannot read property 'title' of undefined` when `activePageIndex` is out of bounds for the `pages` array in `ContentPageNav`
- Clamp `activePageIndex` to valid bounds in `ContentPageNav` using `Math.max(0, Math.min(activePageIndex, pages.length - 1))` with an optional chaining fallback for the title display
- Clamp `activePageIndex` at the source in the `tocData` WebView message handler in `app/purchase/[token].tsx`
- Added tests confirming out-of-bounds indices (both positive and negative) are handled gracefully

## Test plan
- [x] New tests: out-of-bounds `activePageIndex` clamps to last page, negative index clamps to first page
- [x] All 91 existing tests pass
- [ ] Manual: open a purchase with content pages and verify navigation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)