### PR TITLE
Hide library carousel when searching

### DIFF
--- a/components/library/use-library-filters.ts
+++ b/components/library/use-library-filters.ts
@@ -39,7 +39,7 @@ export const useLibraryFilters = (): UseLibraryFiltersReturn => {
     return filters;
   }, [debouncedSearchText, selectedCreators, showArchivedOnly, sortBy]);
 
-  const hasActiveFilters = selectedCreators.size > 0 || showArchivedOnly;
+  const hasActiveFilters = selectedCreators.size > 0 || showArchivedOnly || searchText.length > 0;
   const isSearchPending = searchText.trim() !== debouncedSearchText;
 
   const handleCreatorToggle = (creatorId: string) => {


### PR DESCRIPTION
The library carousel is meant to hide while filtering or searching, but it was only hiding while filtering.