### PR TITLE
Fix UnauthorizedError Sentry noise from expired tokens

### DIFF
--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 import { assertDefined } from "@/lib/assert";
 import { queryClient } from "@/lib/query-client";
 import { env } from "@/lib/env";
-import { request } from "@/lib/request";
+import { request, UnauthorizedError } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 import * as AuthSession from "expo-auth-session";
 import { useRouter } from "expo-router";
@@ -42,11 +42,22 @@ const fetchCreatorStatus = async (token: string): Promise<boolean> => {
     });
     return (response.products?.length ?? 0) > 0;
   } catch (e) {
+    if (e instanceof UnauthorizedError) throw e;
     Sentry.captureException(e);
     console.error(e);
     return false;
   }
 };
+
+const refreshAccessToken = async (storedRefreshToken: string): Promise<{ access_token: string; refresh_token?: string }> =>
+  request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
+    method: "POST",
+    data: {
+      grant_type: "refresh_token",
+      refresh_token: storedRefreshToken,
+      client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
+    },
+  });
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [isLoading, setIsLoading] = useState(true);
@@ -76,8 +87,33 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         const storedToken = await SecureStore.getItemAsync(accessTokenKey);
         if (storedToken) {
           setAccessToken(storedToken);
-          const creatorStatus = await fetchCreatorStatus(storedToken);
-          setIsCreator(creatorStatus);
+          try {
+            const creatorStatus = await fetchCreatorStatus(storedToken);
+            setIsCreator(creatorStatus);
+          } catch (e) {
+            if (e instanceof UnauthorizedError) {
+              const storedRefreshToken = await SecureStore.getItemAsync(refreshTokenKey);
+              if (storedRefreshToken) {
+                try {
+                  const tokenResponse = await refreshAccessToken(storedRefreshToken);
+                  await SecureStore.setItemAsync(accessTokenKey, tokenResponse.access_token);
+                  if (tokenResponse.refresh_token) await SecureStore.setItemAsync(refreshTokenKey, tokenResponse.refresh_token);
+                  setAccessToken(tokenResponse.access_token);
+                  const creatorStatus = await fetchCreatorStatus(tokenResponse.access_token);
+                  setIsCreator(creatorStatus);
+                } catch {
+                  await SecureStore.deleteItemAsync(accessTokenKey);
+                  await SecureStore.deleteItemAsync(refreshTokenKey);
+                  setAccessToken(null);
+                }
+              } else {
+                await SecureStore.deleteItemAsync(accessTokenKey);
+                setAccessToken(null);
+              }
+            } else {
+              throw e;
+            }
+          }
         }
       } catch (error) {
         Sentry.captureException(error);
@@ -154,14 +190,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       const storedRefreshToken = await SecureStore.getItemAsync(refreshTokenKey);
       if (!storedRefreshToken) throw new Error("No refresh token available");
 
-      const tokenResponse = await request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
-        method: "POST",
-        data: {
-          grant_type: "refresh_token",
-          refresh_token: storedRefreshToken,
-          client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
-        },
-      });
+      const tokenResponse = await refreshAccessToken(storedRefreshToken);
       await storeTokens(tokenResponse.access_token, tokenResponse.refresh_token);
     } catch (error) {
       Sentry.captureException(error);

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -49,7 +49,9 @@ const fetchCreatorStatus = async (token: string): Promise<boolean> => {
   }
 };
 
-const refreshAccessToken = async (storedRefreshToken: string): Promise<{ access_token: string; refresh_token?: string }> =>
+const refreshAccessToken = async (
+  storedRefreshToken: string,
+): Promise<{ access_token: string; refresh_token?: string }> =>
   request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
     method: "POST",
     data: {
@@ -97,7 +99,8 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
                 try {
                   const tokenResponse = await refreshAccessToken(storedRefreshToken);
                   await SecureStore.setItemAsync(accessTokenKey, tokenResponse.access_token);
-                  if (tokenResponse.refresh_token) await SecureStore.setItemAsync(refreshTokenKey, tokenResponse.refresh_token);
+                  if (tokenResponse.refresh_token)
+                    await SecureStore.setItemAsync(refreshTokenKey, tokenResponse.refresh_token);
                   setAccessToken(tokenResponse.access_token);
                   const creatorStatus = await fetchCreatorStatus(tokenResponse.access_token);
                   setIsCreator(creatorStatus);

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -48,8 +48,7 @@ import * as Sentry from "@sentry/react-native";
 import { UnauthorizedError } from "@/lib/request";
 import { AuthProvider, useAuth } from "@/lib/auth-context";
 
-const wrapper = ({ children }: { children: React.ReactNode }) =>
-  React.createElement(AuthProvider, null, children);
+const wrapper = ({ children }: { children: React.ReactNode }) => React.createElement(AuthProvider, null, children);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -64,9 +63,7 @@ describe("fetchCreatorStatus", () => {
     renderHook(() => useAuth(), { wrapper });
 
     await waitFor(() => {
-      expect(Sentry.captureException).not.toHaveBeenCalledWith(
-        expect.objectContaining({ name: "UnauthorizedError" }),
-      );
+      expect(Sentry.captureException).not.toHaveBeenCalledWith(expect.objectContaining({ name: "UnauthorizedError" }));
     });
   });
 
@@ -85,9 +82,7 @@ describe("fetchCreatorStatus", () => {
 
 describe("loadStoredAuth with expired token", () => {
   it("refreshes the token when fetchCreatorStatus returns UnauthorizedError", async () => {
-    mockGetItemAsync
-      .mockResolvedValueOnce("expired-token")
-      .mockResolvedValueOnce("stored-refresh-token");
+    mockGetItemAsync.mockResolvedValueOnce("expired-token").mockResolvedValueOnce("stored-refresh-token");
 
     mockRequest
       .mockRejectedValueOnce(new UnauthorizedError("Unauthorized"))
@@ -107,9 +102,7 @@ describe("loadStoredAuth with expired token", () => {
   });
 
   it("clears tokens when refresh also fails", async () => {
-    mockGetItemAsync
-      .mockResolvedValueOnce("expired-token")
-      .mockResolvedValueOnce("stored-refresh-token");
+    mockGetItemAsync.mockResolvedValueOnce("expired-token").mockResolvedValueOnce("stored-refresh-token");
 
     mockRequest
       .mockRejectedValueOnce(new UnauthorizedError("Unauthorized"))
@@ -127,9 +120,7 @@ describe("loadStoredAuth with expired token", () => {
   });
 
   it("clears access token when no refresh token is available", async () => {
-    mockGetItemAsync
-      .mockResolvedValueOnce("expired-token")
-      .mockResolvedValueOnce(null);
+    mockGetItemAsync.mockResolvedValueOnce("expired-token").mockResolvedValueOnce(null);
 
     mockRequest.mockRejectedValueOnce(new UnauthorizedError("Unauthorized"));
 

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -1,0 +1,145 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import React from "react";
+
+const mockGetItemAsync = jest.fn();
+const mockSetItemAsync = jest.fn();
+const mockDeleteItemAsync = jest.fn();
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: (...args: unknown[]) => mockGetItemAsync(...args),
+  setItemAsync: (...args: unknown[]) => mockSetItemAsync(...args),
+  deleteItemAsync: (...args: unknown[]) => mockDeleteItemAsync(...args),
+}));
+
+const mockRequest = jest.fn();
+jest.mock("@/lib/request", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+  UnauthorizedError: class extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "UnauthorizedError";
+    }
+  },
+}));
+
+jest.mock("@/lib/query-client", () => ({
+  queryClient: { clear: jest.fn() },
+}));
+
+jest.mock("@/lib/assert", () => ({
+  assertDefined: <T,>(value: T) => value,
+}));
+
+const mockReplace = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("expo-auth-session", () => ({
+  makeRedirectUri: () => "gumroadmobile://redirect",
+  useAuthRequest: () => [null, null, jest.fn()],
+  ResponseType: { Code: "code" },
+}));
+
+jest.mock("expo-web-browser", () => ({
+  maybeCompleteAuthSession: jest.fn(),
+}));
+
+import * as Sentry from "@sentry/react-native";
+import { UnauthorizedError } from "@/lib/request";
+import { AuthProvider, useAuth } from "@/lib/auth-context";
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(AuthProvider, null, children);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("fetchCreatorStatus", () => {
+  it("does not report UnauthorizedError to Sentry", async () => {
+    mockGetItemAsync.mockResolvedValueOnce("expired-token");
+    mockGetItemAsync.mockResolvedValueOnce(null);
+    mockRequest.mockRejectedValueOnce(new UnauthorizedError("Unauthorized"));
+
+    renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(Sentry.captureException).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: "UnauthorizedError" }),
+      );
+    });
+  });
+
+  it("reports non-UnauthorizedError exceptions to Sentry", async () => {
+    const networkError = new Error("Network failure");
+    mockGetItemAsync.mockResolvedValueOnce("valid-token");
+    mockRequest.mockRejectedValueOnce(networkError);
+
+    renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(Sentry.captureException).toHaveBeenCalledWith(networkError);
+    });
+  });
+});
+
+describe("loadStoredAuth with expired token", () => {
+  it("refreshes the token when fetchCreatorStatus returns UnauthorizedError", async () => {
+    mockGetItemAsync
+      .mockResolvedValueOnce("expired-token")
+      .mockResolvedValueOnce("stored-refresh-token");
+
+    mockRequest
+      .mockRejectedValueOnce(new UnauthorizedError("Unauthorized"))
+      .mockResolvedValueOnce({ access_token: "new-token", refresh_token: "new-refresh" })
+      .mockResolvedValueOnce({ products: [{ id: "1" }] });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockSetItemAsync).toHaveBeenCalledWith("gumroad_access_token", "new-token");
+    expect(mockSetItemAsync).toHaveBeenCalledWith("gumroad_refresh_token", "new-refresh");
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isCreator).toBe(true);
+  });
+
+  it("clears tokens when refresh also fails", async () => {
+    mockGetItemAsync
+      .mockResolvedValueOnce("expired-token")
+      .mockResolvedValueOnce("stored-refresh-token");
+
+    mockRequest
+      .mockRejectedValueOnce(new UnauthorizedError("Unauthorized"))
+      .mockRejectedValueOnce(new Error("Refresh failed"));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockDeleteItemAsync).toHaveBeenCalledWith("gumroad_access_token");
+    expect(mockDeleteItemAsync).toHaveBeenCalledWith("gumroad_refresh_token");
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("clears access token when no refresh token is available", async () => {
+    mockGetItemAsync
+      .mockResolvedValueOnce("expired-token")
+      .mockResolvedValueOnce(null);
+
+    mockRequest.mockRejectedValueOnce(new UnauthorizedError("Unauthorized"));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockDeleteItemAsync).toHaveBeenCalledWith("gumroad_access_token");
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Stop reporting `UnauthorizedError` to Sentry in `fetchCreatorStatus` — expired tokens are expected auth behavior, not bugs
- When `loadStoredAuth` encounters an expired token, attempt a token refresh before clearing credentials
- Extract `refreshAccessToken` as a shared helper used by both `loadStoredAuth` and `refreshTokenFn`

## Test plan
- [x] Added tests verifying `UnauthorizedError` is not sent to Sentry
- [x] Added tests verifying expired tokens trigger refresh flow
- [x] Added tests verifying failed refresh clears stored tokens
- [x] All 94 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)