### PR TITLE
Fix: Deduplicate OTA update downloads to prevent watchdog termination

### DIFF
--- a/components/use-ota-update.test.ts
+++ b/components/use-ota-update.test.ts
@@ -1,0 +1,117 @@
+import { renderHook, act, waitFor } from "@testing-library/react-native";
+import { useOTAUpdate } from "./use-ota-update";
+
+const mockCheckForUpdateAsync = jest.fn();
+const mockFetchUpdateAsync = jest.fn();
+const mockReloadAsync = jest.fn();
+
+jest.mock("expo-updates", () => ({
+  checkForUpdateAsync: (...args: unknown[]) => mockCheckForUpdateAsync(...args),
+  fetchUpdateAsync: (...args: unknown[]) => mockFetchUpdateAsync(...args),
+  reloadAsync: (...args: unknown[]) => mockReloadAsync(...args),
+}));
+
+// The hook short-circuits in __DEV__ mode. Override to false so tests exercise the real logic.
+// We need to set this before each test because jest may reset it.
+const originalDev = (globalThis as Record<string, unknown>).__DEV__;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (globalThis as Record<string, unknown>).__DEV__ = false;
+  // Reset the module-level singleton between tests by clearing the cached promise.
+  // We access it via the mock: each test starts with a fresh set of mock calls.
+});
+
+afterEach(() => {
+  (globalThis as Record<string, unknown>).__DEV__ = originalDev;
+});
+
+describe("useOTAUpdate", () => {
+  it("sets isUpdateReady when an update is available", async () => {
+    mockCheckForUpdateAsync.mockResolvedValue({ isAvailable: true });
+    mockFetchUpdateAsync.mockResolvedValue({});
+
+    const { result } = renderHook(() => useOTAUpdate());
+
+    await waitFor(() => {
+      expect(result.current.isUpdateReady).toBe(true);
+    });
+
+    expect(mockCheckForUpdateAsync).toHaveBeenCalledTimes(1);
+    expect(mockFetchUpdateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fetch when no update is available", async () => {
+    mockCheckForUpdateAsync.mockResolvedValue({ isAvailable: false });
+
+    const { result } = renderHook(() => useOTAUpdate());
+
+    await waitFor(() => {
+      expect(mockCheckForUpdateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockFetchUpdateAsync).not.toHaveBeenCalled();
+    expect(result.current.isUpdateReady).toBe(false);
+  });
+
+  it("deduplicates concurrent calls from multiple hook instances", async () => {
+    let resolveCheck!: (value: { isAvailable: boolean }) => void;
+    mockCheckForUpdateAsync.mockReturnValue(
+      new Promise((resolve) => {
+        resolveCheck = resolve;
+      }),
+    );
+    mockFetchUpdateAsync.mockResolvedValue({});
+
+    // Mount 3 hooks simultaneously (simulates multiple Screen components)
+    const hook1 = renderHook(() => useOTAUpdate());
+    const hook2 = renderHook(() => useOTAUpdate());
+    const hook3 = renderHook(() => useOTAUpdate());
+
+    // All three share the same promise, so only one check call
+    expect(mockCheckForUpdateAsync).toHaveBeenCalledTimes(1);
+
+    // Resolve the shared check
+    await act(async () => {
+      resolveCheck({ isAvailable: true });
+    });
+
+    await waitFor(() => {
+      expect(hook1.result.current.isUpdateReady).toBe(true);
+      expect(hook2.result.current.isUpdateReady).toBe(true);
+      expect(hook3.result.current.isUpdateReady).toBe(true);
+    });
+
+    // Only one download, not three
+    expect(mockFetchUpdateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismiss sets isUpdateReady to false", async () => {
+    mockCheckForUpdateAsync.mockResolvedValue({ isAvailable: true });
+    mockFetchUpdateAsync.mockResolvedValue({});
+
+    const { result } = renderHook(() => useOTAUpdate());
+
+    await waitFor(() => {
+      expect(result.current.isUpdateReady).toBe(true);
+    });
+
+    act(() => {
+      result.current.dismiss();
+    });
+
+    expect(result.current.isUpdateReady).toBe(false);
+  });
+
+  it("handles errors gracefully without crashing", async () => {
+    mockCheckForUpdateAsync.mockRejectedValue(new Error("Network failure"));
+
+    const { result } = renderHook(() => useOTAUpdate());
+
+    await waitFor(() => {
+      expect(mockCheckForUpdateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.isUpdateReady).toBe(false);
+  });
+});

--- a/components/use-ota-update.ts
+++ b/components/use-ota-update.ts
@@ -1,27 +1,52 @@
 import * as Updates from "expo-updates";
 import { useCallback, useEffect, useState } from "react";
+
+// Module-level singleton ensures only one OTA check + download runs at a time,
+// regardless of how many hook instances mount (multiple Screen components,
+// ForceUpdateScreen, etc.). This prevents parallel multi-MB asset downloads
+// from exhausting device memory and triggering a watchdog termination.
+let otaPromise: Promise<boolean> | null = null;
+
+const checkAndDownloadOnce = (): Promise<boolean> => {
+  if (otaPromise) return otaPromise;
+
+  otaPromise = (async () => {
+    try {
+      console.info("Checking for updates");
+      const update = await Updates.checkForUpdateAsync();
+      console.info("Checked for updates", update);
+      if (update.isAvailable) {
+        await Updates.fetchUpdateAsync();
+        console.info("Fetched update");
+        return true;
+      }
+      return false;
+    } catch (e) {
+      console.error("Error checking/downloading OTA update:", e);
+      return false;
+    } finally {
+      // Allow retries on subsequent mounts if this attempt failed
+      // (the promise resolves, but new callers can start fresh)
+      otaPromise = null;
+    }
+  })();
+
+  return otaPromise;
+};
+
 export const useOTAUpdate = () => {
   const [isUpdateReady, setIsUpdateReady] = useState(false);
 
   useEffect(() => {
     if (__DEV__) return;
 
-    const checkAndDownload = async () => {
-      try {
-        console.info("Checking for updates");
-        const update = await Updates.checkForUpdateAsync();
-        console.info("Checked for updates", update);
-        if (update.isAvailable) {
-          await Updates.fetchUpdateAsync();
-          setIsUpdateReady(true);
-          console.info("Fetched update");
-        }
-      } catch (e) {
-        console.error("Error checking/downloading OTA update:", e);
-      }
+    let cancelled = false;
+    checkAndDownloadOnce().then((ready) => {
+      if (!cancelled && ready) setIsUpdateReady(true);
+    });
+    return () => {
+      cancelled = true;
     };
-
-    checkAndDownload();
   }, []);
 
   const apply = useCallback(async () => {


### PR DESCRIPTION
## Problem

A [WatchdogTermination](https://gumroad-to.sentry.io/issues/7379668252/) crash was reported on an iPhone 12 Pro Max running iOS 18.3.1. The OS killed the app for overusing RAM.

## Root cause

`useOTAUpdate` is used in multiple places that mount simultaneously:
- Every `Screen` component renders an `UpdateBanner` (dashboard, library, analytics tabs all mount at once)
- `ForceUpdateScreen` has its own instance

Each hook instance independently called `checkForUpdateAsync()` + `fetchUpdateAsync()`, triggering **parallel downloads of the same ~4.5MB update bundle**. The Sentry breadcrumbs confirm two "Checking for updates" calls within 50ms of each other, both finding an available update, both downloading, and ultimately a "Failed to load all assets" error before the watchdog killed the app.

## Fix

Introduce a module-level singleton promise in `use-ota-update.ts`. When the first hook instance starts a check+download, subsequent instances share the same promise instead of starting new ones. The promise is cleared after completion so future mounts can retry if needed.

## Tests

Added `use-ota-update.test.ts` with 5 tests including one that mounts 3 hook instances simultaneously and verifies only 1 check and 1 download occur. All 94 tests pass.