### PR TITLE
Add .easignore for local build

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,44 @@
+# Same as .gitignore except that google-services.json is NOT ignored
+
+# dependencies
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+build-*
+
+# Native
+.kotlin/
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+
+app-example
+
+# generated native folders
+/ios
+/android


### PR DESCRIPTION
Expo build uses `.gitignore` by default to exclude files, but we need to include the gitignored Google Services JSON in the bundle.