### PR TITLE
Fix misleading 404 when server redirects to /login

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -33,6 +33,10 @@ export const request = async <T>(
     console.info("HTTP request", details);
     throw new UnauthorizedError("Unauthorized");
   }
+  if (response.redirected && new URL(response.url).pathname === "/login") {
+    console.info("HTTP request", details);
+    throw new UnauthorizedError("Unauthorized");
+  }
   if (!response.ok) {
     const error = response.status === 404 ? "Not found" : (await response.text()).slice(0, 10000);
     console.info("HTTP request", { ...details, error });

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -1,0 +1,60 @@
+import { request, UnauthorizedError } from "@/lib/request";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("request", () => {
+  it("throws UnauthorizedError when response is redirected to /login", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      redirected: true,
+      url: "https://api.gumroad.com/login",
+      headers: new Headers(),
+    });
+
+    await expect(request("https://api.gumroad.com/api/endpoint")).rejects.toThrow(UnauthorizedError);
+  });
+
+  it("throws generic error for non-redirected 404", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      redirected: false,
+      url: "https://api.gumroad.com/api/endpoint",
+      headers: new Headers(),
+    });
+
+    await expect(request("https://api.gumroad.com/api/endpoint")).rejects.toThrow("Request failed: 404 Not found");
+  });
+
+  it("throws UnauthorizedError for 401 responses", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      redirected: false,
+      url: "https://api.gumroad.com/api/endpoint",
+      headers: new Headers(),
+    });
+
+    await expect(request("https://api.gumroad.com/api/endpoint")).rejects.toThrow(UnauthorizedError);
+  });
+
+  it("returns parsed JSON for successful responses", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      redirected: false,
+      url: "https://api.gumroad.com/api/endpoint",
+      headers: new Headers(),
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    const result = await request("https://api.gumroad.com/api/endpoint");
+    expect(result).toEqual({ success: true });
+  });
+});


### PR DESCRIPTION
## Summary
- Detect when the Gumroad API redirects unauthenticated requests to `/login` (302 → 404) and throw `UnauthorizedError` instead of the confusing "Request failed: 404 Not found" error
- Added unit tests for the `request()` function covering the redirect detection, standard 401, generic 404, and success cases

## Test plan
- [x] All 99 existing tests pass
- [x] New tests verify `UnauthorizedError` is thrown for redirected-to-login responses
- [x] New tests verify non-redirected 404s still throw the generic error

Fixes GUMROAD-MOBILE-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)