### PR TITLE
Fix ActivityNotFoundException crash on devices without a browser

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -9,6 +9,7 @@ import { Text } from "@/components/ui/text";
 import { useUser } from "@/components/use-user";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
+import { safeOpenURL } from "@/lib/open-url";
 import { flushReplayBuffer } from "@/lib/sentry";
 import { showFeedbackWidget } from "@sentry/react-native";
 import { BottomTabBar } from "@react-navigation/bottom-tabs";
@@ -17,7 +18,7 @@ import Constants from "expo-constants";
 import { Tabs } from "expo-router";
 import * as Updates from "expo-updates";
 import { createContext, useContext, useRef, useState } from "react";
-import { Alert, Linking, Pressable, TouchableOpacity, View } from "react-native";
+import { Alert, Pressable, TouchableOpacity, View } from "react-native";
 import { useCSSVariable, useResolveClassNames } from "uniwind";
 
 interface SearchContextValue {
@@ -105,7 +106,7 @@ const SettingsSheet = () => {
   };
 
   const handleDeleteAccount = () => {
-    Linking.openURL(`${env.EXPO_PUBLIC_GUMROAD_URL}/settings/advanced`);
+    safeOpenURL(`${env.EXPO_PUBLIC_GUMROAD_URL}/settings/advanced`);
   };
 
   const handleSendFeedback = () => {

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -6,13 +6,14 @@ import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
+import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { useCallback, useRef, useState } from "react";
-import { Alert, Linking, Pressable, ScrollView, useWindowDimensions, View } from "react-native";
+import { Alert, Pressable, ScrollView, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView as BaseWebView } from "react-native-webview";
 import { useCSSVariable } from "uniwind";
@@ -83,11 +84,11 @@ export default function PostScreen() {
   };
 
   const handleCreatorPress = () => {
-    if (post?.creator_profile_url) Linking.openURL(post.creator_profile_url);
+    if (post?.creator_profile_url) safeOpenURL(post.creator_profile_url);
   };
 
   const handleCtaPress = () => {
-    if (post?.call_to_action_url) Linking.openURL(post.call_to_action_url);
+    if (post?.call_to_action_url) safeOpenURL(post.call_to_action_url);
   };
 
   if (!post) {

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -8,13 +8,14 @@ import { useAddRecentPurchase } from "@/components/library/use-recent-products";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
+import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as Sentry from "@sentry/react-native";
-import { Alert, Linking, View } from "react-native";
+import { Alert, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
 
@@ -86,7 +87,7 @@ export default function DownloadScreen() {
         !/^https?:\/\//.test(request.url)
       )
         return true;
-      Linking.openURL(request.url);
+      safeOpenURL(request.url);
       return false;
     },
     [url],

--- a/components/dashboard/refund-form.tsx
+++ b/components/dashboard/refund-form.tsx
@@ -6,7 +6,7 @@ import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
-import * as Linking from "expo-linking";
+import { safeOpenURL } from "@/lib/open-url";
 import { useState } from "react";
 import { Keyboard, Alert as NativeAlert, TextInput, View } from "react-native";
 import { useCSSVariable } from "uniwind";
@@ -138,7 +138,7 @@ export const RefundForm = ({ sale, onRefundSuccess }: { sale: SaleDetail; onRefu
               Going forward, Gumroad does not return the payment processor fees when a payment is refunded.{" "}
               <Text
                 className="text-sm text-blue-700 underline dark:text-blue-300"
-                onPress={() => Linking.openURL(REFUND_FEE_HELP_URL)}
+                onPress={() => safeOpenURL(REFUND_FEE_HELP_URL)}
               >
                 Learn more
               </Text>

--- a/components/force-update-screen.tsx
+++ b/components/force-update-screen.tsx
@@ -6,7 +6,7 @@ import { Text } from "@/components/ui/text";
 import { useOTAUpdate } from "@/components/use-ota-update";
 import { type UpdateRequirement } from "@/components/use-minimum-version";
 import Constants from "expo-constants";
-import * as Linking from "expo-linking";
+import { safeOpenURL } from "@/lib/open-url";
 import { Platform, View } from "react-native";
 import { useUniwind } from "uniwind";
 import { LoadingSpinner } from "./ui/loading-spinner";
@@ -22,7 +22,7 @@ const NativeUpdateContent = () => (
     <Button
       variant="accent"
       onPress={() => {
-        if (appStoreUrl) Linking.openURL(appStoreUrl);
+        if (appStoreUrl) safeOpenURL(appStoreUrl);
       }}
     >
       <Text>Update Now</Text>

--- a/components/full-audio-player.tsx
+++ b/components/full-audio-player.tsx
@@ -1,8 +1,9 @@
 import { LineIcon, SolidIcon } from "@/components/icon";
 import { StyledImage } from "@/components/styled";
 import { Text } from "@/components/ui/text";
+import { safeOpenURL } from "@/lib/open-url";
 import { useCallback, useEffect, useState } from "react";
-import { Linking, Modal, TouchableOpacity, View } from "react-native";
+import { Modal, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import TrackPlayer, {
   RepeatMode,
@@ -172,7 +173,7 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             {activeTrack.artist && (
               <TouchableOpacity
                 disabled={!activeTrack.artistUrl}
-                onPress={() => activeTrack.artistUrl && Linking.openURL(activeTrack.artistUrl)}
+                onPress={() => activeTrack.artistUrl && safeOpenURL(activeTrack.artistUrl)}
               >
                 <Text className="mt-1 text-center text-base text-muted-foreground" numberOfLines={1}>
                   {activeTrack.artist}

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "expo-router";
 import * as SecureStore from "expo-secure-store";
 import * as WebBrowser from "expo-web-browser";
 import React, { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
+import { Alert } from "react-native";
 
 const authorizationEndpoint = `${env.EXPO_PUBLIC_GUMROAD_URL}/oauth/mobile_pre_authorization/new`;
 const tokenEndpoint = `${env.EXPO_PUBLIC_GUMROAD_URL}/oauth/token`;
@@ -140,7 +141,14 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   }, [response, redirectUri, authRequest?.codeVerifier, storeTokens]);
 
   const login = useCallback(async () => {
-    if (authRequest) await promptAsync();
+    if (authRequest) {
+      try {
+        await promptAsync();
+      } catch (error) {
+        console.warn("Login browser error:", error);
+        Alert.alert("No browser found", "Please install a web browser to log in.");
+      }
+    }
   }, [authRequest, promptAsync]);
 
   const logout = useCallback(async () => {

--- a/lib/open-url.ts
+++ b/lib/open-url.ts
@@ -1,0 +1,16 @@
+import { Alert, Linking } from "react-native";
+
+export const safeOpenURL = async (url: string): Promise<boolean> => {
+  try {
+    const canOpen = await Linking.canOpenURL(url);
+    if (!canOpen) {
+      Alert.alert("No browser found", "Please install a web browser to continue.");
+      return false;
+    }
+    await Linking.openURL(url);
+    return true;
+  } catch {
+    Alert.alert("No browser found", "Please install a web browser to continue.");
+    return false;
+  }
+};

--- a/tests/lib/open-url.test.ts
+++ b/tests/lib/open-url.test.ts
@@ -1,0 +1,56 @@
+import { Alert, Linking } from "react-native";
+import { safeOpenURL } from "@/lib/open-url";
+
+jest.spyOn(Alert, "alert");
+jest.spyOn(Linking, "canOpenURL");
+jest.spyOn(Linking, "openURL");
+
+const mockCanOpenURL = Linking.canOpenURL as jest.Mock;
+const mockOpenURL = Linking.openURL as jest.Mock;
+const mockAlert = Alert.alert as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOpenURL.mockResolvedValue(true);
+});
+
+describe("safeOpenURL", () => {
+  it("opens the URL when a browser is available", async () => {
+    mockCanOpenURL.mockResolvedValue(true);
+
+    const result = await safeOpenURL("https://example.com");
+
+    expect(result).toBe(true);
+    expect(Linking.openURL).toHaveBeenCalledWith("https://example.com");
+    expect(Alert.alert).not.toHaveBeenCalled();
+  });
+
+  it("shows an alert and does not open the URL when no browser is available", async () => {
+    mockCanOpenURL.mockResolvedValue(false);
+
+    const result = await safeOpenURL("https://example.com");
+
+    expect(result).toBe(false);
+    expect(Linking.openURL).not.toHaveBeenCalled();
+    expect(Alert.alert).toHaveBeenCalledWith("No browser found", "Please install a web browser to continue.");
+  });
+
+  it("shows an alert when canOpenURL throws", async () => {
+    mockCanOpenURL.mockRejectedValue(new Error("fail"));
+
+    const result = await safeOpenURL("https://example.com");
+
+    expect(result).toBe(false);
+    expect(Alert.alert).toHaveBeenCalledWith("No browser found", "Please install a web browser to continue.");
+  });
+
+  it("shows an alert when openURL throws", async () => {
+    mockCanOpenURL.mockResolvedValue(true);
+    mockOpenURL.mockRejectedValue(new Error("ActivityNotFoundException"));
+
+    const result = await safeOpenURL("https://example.com");
+
+    expect(result).toBe(false);
+    expect(Alert.alert).toHaveBeenCalledWith("No browser found", "Please install a web browser to continue.");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `safeOpenURL` utility (`lib/open-url.ts`) that checks `Linking.canOpenURL()` before opening and shows a user-friendly Alert if no browser is available
- Wraps `promptAsync()` in the auth login flow with try-catch to handle `ActivityNotFoundException` gracefully (logged as warning, not sent to Sentry)
- Replaces all bare `Linking.openURL()` calls across 6 files with `safeOpenURL()`

## Context
Sentry reports `RuntimeException: Unable to start activity ComponentInfo{...BrowserProxyActivity}: android.content.ActivityNotFoundException` on Android devices with no browser installed. This affects the OAuth login flow (via `expo-web-browser`) and all in-app URL opens.

## Test plan
- [ ] Verify all existing tests pass (`npx jest` — 99 tests, 10 suites)
- [ ] New tests in `tests/lib/open-url.test.ts` cover: browser available, browser unavailable, `canOpenURL` throws, `openURL` throws
- [ ] Test on Android device/emulator without a default browser to confirm Alert appears instead of crash
- [ ] Test OAuth login flow on device without browser shows "No browser found" alert
- [ ] Test normal URL opening (creator profile, CTA, help links, app store) still works on devices with a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)