### PR TITLE
Fix RuntimeException: MediaSession ID must be unique in MusicService

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "e2e:ios:run": "maestro test -p ios -e APP_ID=$IOS_BUNDLE_NAME",
     "e2e:android": "dotenv-flow -- npm run e2e:android:run",
     "e2e:android:run": "maestro test -p android -e APP_ID=$ANDROID_BUNDLE_NAME",
-    "eas": "dotenv-flow eas --"
+    "eas": "dotenv-flow eas --",
+    "postinstall": "patch-package"
   },
   "jest": {
     "preset": "jest-expo",
@@ -71,6 +72,7 @@
     "expo-video": "~55.0.11",
     "expo-web-browser": "~55.0.10",
     "expo-widgets": "^55.0.8",
+    "patch-package": "^8.0.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.4",

--- a/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
+++ b/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+index b495b5a..15739da 100644
+--- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
++++ b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+@@ -53,6 +53,7 @@ import kotlinx.coroutines.*
+ import kotlinx.coroutines.flow.flow
+ import timber.log.Timber
+ import java.util.concurrent.TimeUnit
++import java.util.UUID
+ import kotlin.system.exitProcess
+ 
+ @OptIn(UnstableApi::class)
+@@ -97,6 +98,20 @@ class MusicService : HeadlessJsMediaService() {
+                 return "RNTP-${element.className}:${element.methodName}"
+             }
+         })
++        if (::mediaSession.isInitialized) {
++            try {
++                mediaSession.release()
++            } catch (e: Exception) {
++                Timber.w(e, "Failed to release previous MediaSession")
++            }
++        }
++        if (::fakePlayer.isInitialized) {
++            try {
++                fakePlayer.release()
++            } catch (e: Exception) {
++                Timber.w(e, "Failed to release previous fakePlayer")
++            }
++        }
+         fakePlayer = ExoPlayer.Builder(this).build()
+         val openAppIntent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
+             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+@@ -107,6 +122,7 @@ class MusicService : HeadlessJsMediaService() {
+         mediaSession = MediaLibrarySession.Builder(this, fakePlayer,
+             InnerMediaSessionCallback()
+         )
++            .setId(UUID.randomUUID().toString())
+             .setBitmapLoader(CacheBitmapLoader(CoilBitmapLoader(this)))
+             // https://github.com/androidx/media/issues/1218
+             .setSessionActivity(


### PR DESCRIPTION
## Summary

- Fixes Sentry issue where `MusicService.onCreate()` crashes with `RuntimeException: Unable to create service ... IllegalStateException: Session ID must be unique` when the service is recreated (e.g. after a crash via `START_STICKY`)
- Patches `react-native-track-player` to release any existing `MediaSession`/`ExoPlayer` before recreating, and uses a unique UUID-based session ID to prevent collisions with stale system session records
- Adds `patch-package` for managing native library patches

## Test plan

- [ ] Build and run the Android app
- [ ] Play audio, then force-kill the app process (e.g. via `adb shell am force-stop`)
- [ ] Verify the service restarts without crashing
- [ ] Verify audio playback and notification controls still work correctly after restart
- [ ] Verify no regression on normal audio playback flow

Sentry: https://gumroad-to.sentry.io/issues/7385627159/

🤖 Generated with [Claude Code](https://claude.com/claude-code)