### PR TITLE
Fix: Clean up HTML error responses instead of dumping raw body into Error messages

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -10,6 +10,24 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class ServerError extends Error {
+  status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ServerError";
+    this.status = status;
+  }
+}
+
+const extractErrorMessage = (body: string): string => {
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("<") || trimmed.startsWith("<?xml")) {
+    const titleMatch = trimmed.match(/<title[^>]*>([^<]+)<\/title>/i);
+    return titleMatch ? titleMatch[1].trim() : "Server returned an HTML error page";
+  }
+  return body.slice(0, 10000);
+};
+
 const REQUEST_TIMEOUT_MS = 30_000;
 
 export const request = async <T>(
@@ -45,8 +63,11 @@ export const request = async <T>(
       throw new UnauthorizedError("Unauthorized");
     }
     if (!response.ok) {
-      const error = response.status === 404 ? "Not found" : (await response.text()).slice(0, 10000);
+      const error = response.status === 404 ? "Not found" : extractErrorMessage(await response.text());
       console.info("HTTP request", { ...details, error });
+      if (response.status >= 500) {
+        throw new ServerError(response.status, `Request failed: ${response.status} ${error}`);
+      }
       throw new Error(`Request failed: ${response.status} ${error}`);
     }
     console.info("HTTP request", details);

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -68,7 +68,7 @@ describe("request", () => {
   it("throws ServerError with clean message for 530 HTML response", async () => {
     const cloudflareHtml = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html><head><title>Maintenance | Gumroad</title></head><body><h1>Site under maintenance</h1>${"<p>lots of html</p>".repeat(500)}</body></html>`;
     mockFetch.mockReturnValueOnce(htmlResponse(cloudflareHtml, 530));
-    const error = await request("https://api.example.com/test").catch((e) => e) as ServerError;
+    const error = (await request("https://api.example.com/test").catch((e) => e)) as ServerError;
     expect(error).toBeInstanceOf(ServerError);
     expect(error.status).toBe(530);
     expect(error.message).toBe("Request failed: 530 Maintenance | Gumroad");
@@ -77,7 +77,7 @@ describe("request", () => {
 
   it("throws ServerError with JSON body for 503 non-HTML response", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({ error: "service unavailable" }, 503));
-    const error = await request("https://api.example.com/test").catch((e) => e) as ServerError;
+    const error = (await request("https://api.example.com/test").catch((e) => e)) as ServerError;
     expect(error).toBeInstanceOf(ServerError);
     expect(error.status).toBe(503);
     expect(error.message).toContain('{"error":"service unavailable"}');

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -1,4 +1,4 @@
-import { request, UnauthorizedError } from "@/lib/request";
+import { request, UnauthorizedError, ServerError } from "@/lib/request";
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -27,6 +27,14 @@ const jsonResponse = (data: unknown, status = 200) =>
     text: () => Promise.resolve(JSON.stringify(data)),
   });
 
+const htmlResponse = (html: string, status: number) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.reject(new Error("not json")),
+    text: () => Promise.resolve(html),
+  });
+
 /** Returns a fetch mock that blocks until the signal is aborted, then rejects like real fetch. */
 const hangingFetch = () =>
   jest.fn(
@@ -53,8 +61,26 @@ describe("request", () => {
 
   it("throws on non-ok responses", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({ error: "bad" }, 500));
-    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 500");
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await expect(request("https://api.example.com/test")).rejects.toThrow(ServerError);
+    await expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws ServerError with clean message for 530 HTML response", async () => {
+    const cloudflareHtml = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html><head><title>Maintenance | Gumroad</title></head><body><h1>Site under maintenance</h1>${"<p>lots of html</p>".repeat(500)}</body></html>`;
+    mockFetch.mockReturnValueOnce(htmlResponse(cloudflareHtml, 530));
+    const error: ServerError = await request("https://api.example.com/test").catch((e) => e);
+    expect(error).toBeInstanceOf(ServerError);
+    expect(error.status).toBe(530);
+    expect(error.message).toBe("Request failed: 530 Maintenance | Gumroad");
+    expect(error.message).not.toContain("<html>");
+  });
+
+  it("throws ServerError with JSON body for 503 non-HTML response", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ error: "service unavailable" }, 503));
+    const error: ServerError = await request("https://api.example.com/test").catch((e) => e);
+    expect(error).toBeInstanceOf(ServerError);
+    expect(error.status).toBe(503);
+    expect(error.message).toContain('{"error":"service unavailable"}');
   });
 
   it("aborts the request after 30s timeout", async () => {

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -68,7 +68,7 @@ describe("request", () => {
   it("throws ServerError with clean message for 530 HTML response", async () => {
     const cloudflareHtml = `<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html><head><title>Maintenance | Gumroad</title></head><body><h1>Site under maintenance</h1>${"<p>lots of html</p>".repeat(500)}</body></html>`;
     mockFetch.mockReturnValueOnce(htmlResponse(cloudflareHtml, 530));
-    const error: ServerError = await request("https://api.example.com/test").catch((e) => e);
+    const error = await request("https://api.example.com/test").catch((e) => e) as ServerError;
     expect(error).toBeInstanceOf(ServerError);
     expect(error.status).toBe(530);
     expect(error.message).toBe("Request failed: 530 Maintenance | Gumroad");
@@ -77,7 +77,7 @@ describe("request", () => {
 
   it("throws ServerError with JSON body for 503 non-HTML response", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({ error: "service unavailable" }, 503));
-    const error: ServerError = await request("https://api.example.com/test").catch((e) => e);
+    const error = await request("https://api.example.com/test").catch((e) => e) as ServerError;
     expect(error).toBeInstanceOf(ServerError);
     expect(error.status).toBe(503);
     expect(error.message).toContain('{"error":"service unavailable"}');


### PR DESCRIPTION
## Summary

- **Sentry issue**: [GUMROAD-MOBILE-BY](https://gumroad-to.sentry.io/issues/7392268567/) — When the Gumroad API returns a 5xx with an HTML body (e.g. Cloudflare 530 maintenance page), the `request()` function was including up to 10,000 characters of raw HTML in the `Error` message, creating massive unreadable Sentry errors.
- For HTML responses, the error message now extracts just the `<title>` text (e.g. "Maintenance | Gumroad") instead of the full HTML body.
- Adds a `ServerError` class for 5xx responses so callers can distinguish server errors from other failures (similar to the existing `UnauthorizedError`).

## Test plan

- [x] Added test: 530 with HTML body throws `ServerError` with clean title-only message
- [x] Added test: 503 with JSON body still includes the JSON text in the error
- [x] Existing tests continue to pass (7/7 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)