### PR TITLE
Fix OutOfMemoryError: add response size guard

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -11,6 +11,7 @@ export class UnauthorizedError extends Error {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_SIZE = 50 * 1024 * 1024; // 50 MB
 
 export const request = async <T>(
   url: string,
@@ -33,6 +34,14 @@ export const request = async <T>(
       signal: controller.signal,
     });
     clearTimeout(timeoutId);
+
+    const contentLength = Number(response.headers.get("Content-Length"));
+    if (contentLength > MAX_RESPONSE_SIZE) {
+      controller.abort();
+      throw new Error(
+        `Response too large (${Math.round(contentLength / 1024 / 1024)} MB). Aborting to prevent out-of-memory crash.`,
+      );
+    }
 
     const details = {
       // Including the token in the logged URL makes Sentry exclude the whole string. We can remove this when we use the public API

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -19,10 +19,11 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-const jsonResponse = (data: unknown, status = 200) =>
+const jsonResponse = (data: unknown, status = 200, headers?: Record<string, string>) =>
   Promise.resolve({
     ok: status >= 200 && status < 300,
     status,
+    headers: new Headers(headers),
     json: () => Promise.resolve(data),
     text: () => Promise.resolve(JSON.stringify(data)),
   });
@@ -68,6 +69,19 @@ describe("request", () => {
     const error = await promise;
     expect(error).toBeInstanceOf(DOMException);
     expect((error as DOMException).name).toBe("AbortError");
+  });
+
+  it("throws when Content-Length exceeds 50 MB", async () => {
+    const oversized = String(51 * 1024 * 1024);
+    mockFetch.mockReturnValueOnce(jsonResponse({ id: 1 }, 200, { "Content-Length": oversized }));
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Response too large");
+  });
+
+  it("allows responses under 50 MB", async () => {
+    const small = String(1024);
+    mockFetch.mockReturnValueOnce(jsonResponse({ id: 1 }, 200, { "Content-Length": small }));
+    const result = await request("https://api.example.com/test");
+    expect(result).toEqual({ id: 1 });
   });
 
   it("respects an external abort signal", async () => {


### PR DESCRIPTION
## Summary

- Adds a 50 MB response size guard in `lib/request.ts` that checks the `Content-Length` header before reading the response body
- If the response exceeds the limit, the request is aborted via `AbortController` and a descriptive error is thrown
- This prevents the React Native networking bridge from base64-encoding enormous responses (the native layer encodes response bodies to bridge them to JS), which caused OOM crashes on Android

**Root cause:** React Native's networking layer calls `Base64.encodeToString` on the full response body before passing it to JavaScript. A ~163 MB response triggered a `java.lang.OutOfMemoryError: Failed to allocate a 171423608 byte allocation` in `StringFactory.newStringFromBytes`. The guard also protects the error path (`response.text()`) which previously read the entire body before slicing.

## Test plan

- [x] Added test: response with Content-Length over 50 MB throws "Response too large" error
- [x] Added test: normal-sized responses with Content-Length header still work
- [x] All existing tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)