### PR TITLE
Fix raw XML body leaking into 403 error messages

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -45,7 +45,7 @@ export const request = async <T>(
       throw new UnauthorizedError("Unauthorized");
     }
     if (!response.ok) {
-      const error = response.status === 404 ? "Not found" : (await response.text()).slice(0, 10000);
+      const error = response.status === 403 ? "Access denied" : response.status === 404 ? "Not found" : (await response.text()).slice(0, 10000);
       console.info("HTTP request", { ...details, error });
       throw new Error(`Request failed: ${response.status} ${error}`);
     }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -45,7 +45,12 @@ export const request = async <T>(
       throw new UnauthorizedError("Unauthorized");
     }
     if (!response.ok) {
-      const error = response.status === 403 ? "Access denied" : response.status === 404 ? "Not found" : (await response.text()).slice(0, 10000);
+      const error =
+        response.status === 403
+          ? "Access denied"
+          : response.status === 404
+            ? "Not found"
+            : (await response.text()).slice(0, 10000);
       console.info("HTTP request", { ...details, error });
       throw new Error(`Request failed: ${response.status} ${error}`);
     }

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -51,6 +51,24 @@ describe("request", () => {
     await expect(request("https://api.example.com/test")).rejects.toThrow(UnauthorizedError);
   });
 
+  it("throws a clean error on 403 without leaking the response body", async () => {
+    const xmlBody = '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code></Error>';
+    mockFetch.mockReturnValueOnce(
+      Promise.resolve({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(xmlBody),
+      }),
+    );
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 403 Access denied");
+  });
+
+  it("throws a clean error on 404 without leaking the response body", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({}, 404));
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 404 Not found");
+  });
+
   it("throws on non-ok responses", async () => {
     mockFetch.mockReturnValueOnce(jsonResponse({ error: "bad" }, 500));
     await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 500");


### PR DESCRIPTION
## Summary
- Handle 403 responses with a clean "Access denied" message instead of dumping the raw response body into error messages
- Prevents S3/CloudFront XML from appearing in Sentry issue titles and leaking infrastructure details (bucket names, request IDs)
- Mirrors existing handling for 401 ("Unauthorized") and 404 ("Not found")

Fixes https://gumroad-to.sentry.io/issues/7394257695/

## Test plan
- [x] Added test verifying 403 throws `Request failed: 403 Access denied` (not raw XML body)
- [x] Added test verifying 404 throws `Request failed: 404 Not found`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)