### PR TITLE
Fix NSInternalInconsistencyException in PDF viewer single-page mode

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -9,7 +9,7 @@ import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as Sentry from "@sentry/react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Dimensions, FlatList, Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import Pdf, { PdfRef, TableContent } from "react-native-pdf";
 import { cn } from "@/lib/utils";
@@ -49,6 +49,25 @@ export default function PdfViewerScreen() {
   const [pdfMounted, setPdfMounted] = useState(true);
   const [pdfError, setPdfError] = useState(false);
   const [pdfKey, setPdfKey] = useState(0);
+  const [scrollLocked, setScrollLocked] = useState(false);
+  const scrollLockTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  // In single-page mode, briefly disable scroll after each page change to prevent
+  // UIPageViewController's NSInternalInconsistencyException when rapid interactions
+  // trigger concurrent page animations.
+  const handlePageChanged = useCallback(
+    (page: number) => {
+      setCurrentPage(page);
+      if (viewMode === "single") {
+        setScrollLocked(true);
+        clearTimeout(scrollLockTimer.current);
+        scrollLockTimer.current = setTimeout(() => setScrollLocked(false), 350);
+      }
+    },
+    [viewMode],
+  );
+
+  useEffect(() => () => clearTimeout(scrollLockTimer.current), []);
 
   const switchViewMode = (mode: "single" | "continuous") => {
     // Unmount the PDF component first to let the native rendering thread finish
@@ -152,12 +171,13 @@ export default function PdfViewerScreen() {
           fitPolicy={0}
           enablePaging={viewMode === "single"}
           horizontal={viewMode === "single"}
+          scrollEnabled={!scrollLocked}
           page={initialPage ? Number(initialPage) : 1}
           onLoadComplete={(numberOfPages, _path, _size, toc) => {
             setTotalPages(numberOfPages);
             setTableOfContents(toc ?? []);
           }}
-          onPageChanged={(page) => setCurrentPage(page)}
+          onPageChanged={handlePageChanged}
           onError={(error) => {
             Sentry.captureException(error);
             console.error("PDF Error:", error);

--- a/tests/app/pdf-viewer.test.tsx
+++ b/tests/app/pdf-viewer.test.tsx
@@ -24,6 +24,8 @@ jest.mock("@/lib/media-location", () => ({
 }));
 
 let mockOnError: ((e: unknown) => void) | null = null;
+let mockOnPageChanged: ((page: number) => void) | null = null;
+let lastPdfProps: Record<string, unknown> = {};
 
 jest.mock("react-native-pdf", () => {
   const { forwardRef } = require("react");
@@ -32,6 +34,8 @@ jest.mock("react-native-pdf", () => {
     __esModule: true,
     default: forwardRef((props: Record<string, unknown>, _ref: unknown) => {
       mockOnError = props.onError as any;
+      mockOnPageChanged = props.onPageChanged as any;
+      lastPdfProps = props;
       return <View testID="pdf-component" />;
     }),
   };
@@ -42,7 +46,14 @@ import { act } from "react";
 
 describe("PdfViewerScreen", () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     mockOnError = null;
+    mockOnPageChanged = null;
+    lastPdfProps = {};
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("shows error view with Try Again button when PDF fails to load", () => {
@@ -71,5 +82,26 @@ describe("PdfViewerScreen", () => {
 
     expect(screen.getByTestId("pdf-component")).toBeTruthy();
     expect(screen.queryByText("Try Again")).toBeNull();
+  });
+
+  it("temporarily disables scroll after page change in single-page mode", () => {
+    render(<PdfViewerScreen />);
+
+    expect(lastPdfProps.scrollEnabled).toBe(true);
+    expect(lastPdfProps.enablePaging).toBe(true);
+
+    act(() => {
+      mockOnPageChanged!(2);
+    });
+
+    // Scroll should be locked immediately after page change
+    expect(lastPdfProps.scrollEnabled).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+
+    // Scroll should be re-enabled after the cooldown
+    expect(lastPdfProps.scrollEnabled).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a fatal crash (`NSInternalInconsistencyException: Failed to determine navigation direction for scroll`) in the PDF viewer when users rapidly interact during single-page mode page transitions
- Adds a 350ms scroll cooldown after each page change to prevent `UIPageViewController`'s concurrent animation bug
- Sentry: https://gumroad-to.sentry.io/issues/7394880597/

## How it works
In single-page mode, `enablePaging={true}` creates a native `UIPageViewController` which crashes when a new page animation starts while one is already in-flight. The fix uses react-native-pdf's `scrollEnabled` prop to temporarily disable scroll interaction after each page transition completes, preventing rapid successive gestures from triggering concurrent animations.

## Test plan
- [x] Existing tests pass
- [x] New test: verifies scroll is disabled after page change and re-enabled after cooldown
- [ ] Manual: open a PDF in single-page mode, rapidly tap/swipe through pages — no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)