### PR TITLE
Fix SecurityException crash when third-party app denies Custom Tab launch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "eslint-config-expo": "~55.0.0",
         "jest": "^29",
         "jest-expo": "~55.0.11",
+        "patch-package": "^8.0.1",
         "postcss": "^8.5.6",
         "prettier": "^3.7.4",
         "prettier-plugin-tailwindcss": "^0.7.2",
@@ -5785,6 +5786,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -9698,6 +9706,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -9771,6 +9789,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -12348,6 +12391,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12365,6 +12428,39 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -12391,6 +12487,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -13930,6 +14036,75 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/path-exists": {
@@ -16365,6 +16540,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tmpl": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "eslint-config-expo": "~55.0.0",
     "jest": "^29",
     "jest-expo": "~55.0.11",
+    "patch-package": "^8.0.1",
     "postcss": "^8.5.6",
     "prettier": "^3.7.4",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/patches/expo-web-browser+55.0.10.patch
+++ b/patches/expo-web-browser+55.0.10.patch
@@ -1,0 +1,55 @@
+diff --git a/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/BrowserProxyActivity.kt b/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/BrowserProxyActivity.kt
+index c30da17..10d0300 100644
+--- a/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/BrowserProxyActivity.kt
++++ b/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/BrowserProxyActivity.kt
+@@ -47,7 +47,17 @@ class BrowserProxyActivity : Activity() {
+     customTabsIntentData.extras?.let { customTabsIntent.intent.putExtras(it) }
+     customTabsIntentData.`package`?.let { customTabsIntent.intent.`package` = it }
+ 
+-    customTabsIntent.launchUrl(this, url.toUri())
++    try {
++      customTabsIntent.launchUrl(this, url.toUri())
++    } catch (e: SecurityException) {
++      try {
++        val fallbackIntent = Intent(Intent.ACTION_VIEW, url.toUri())
++        startActivity(fallbackIntent)
++      } catch (e2: Exception) {
++        finish()
++        return
++      }
++    }
+ 
+     instance = WeakReference(this)
+     hasLaunchedCustomTab = true
+diff --git a/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsActivitiesHelper.kt b/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsActivitiesHelper.kt
+index c1169b2..8be1610 100644
+--- a/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsActivitiesHelper.kt
++++ b/node_modules/expo-web-browser/android/src/main/java/expo/modules/webbrowser/CustomTabsActivitiesHelper.kt
+@@ -63,7 +63,12 @@ internal class CustomTabsActivitiesHelper(
+     val url = tabsIntent.intent.data ?: throw NoUrlProvidedException()
+ 
+     if (!options.shouldCreateTask) {
+-      tabsIntent.launchUrl(currentActivity, url)
++      try {
++        tabsIntent.launchUrl(currentActivity, url)
++      } catch (e: SecurityException) {
++        val fallbackIntent = Intent(Intent.ACTION_VIEW, url)
++        currentActivity.startActivity(fallbackIntent)
++      }
+       return
+     }
+ 
+@@ -90,7 +95,12 @@ internal class CustomTabsActivitiesHelper(
+       tabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
+     }
+ 
+-    tabsIntent.launchUrl(currentActivity, url)
++    try {
++      tabsIntent.launchUrl(currentActivity, url)
++    } catch (e: SecurityException) {
++      val fallbackIntent = Intent(Intent.ACTION_VIEW, url)
++      currentActivity.startActivity(fallbackIntent)
++    }
+   }
+ 
+ // endregion

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -3,9 +3,10 @@ import { renderHook, waitFor } from "@testing-library/react-native";
 import * as AuthSession from "expo-auth-session";
 import React from "react";
 
-import { AuthProvider } from "@/lib/auth-context";
+import { AuthProvider, useAuth } from "@/lib/auth-context";
 import { request } from "@/lib/request";
 import * as SecureStore from "expo-secure-store";
+import { Alert } from "react-native";
 
 jest.mock("expo-auth-session");
 jest.mock("expo-secure-store", () => ({
@@ -112,5 +113,32 @@ describe("fetchCreatorStatus Sentry reporting", () => {
     await waitFor(() => {
       expect(Sentry.captureException).toHaveBeenCalledWith(networkError);
     });
+  });
+});
+
+describe("login error handling", () => {
+  it("shows an alert instead of crashing when promptAsync throws", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    const mockPromptAsync = jest.fn().mockRejectedValue(new Error("SecurityException: Permission Denial"));
+
+    mockUseAuthRequest.mockReturnValue([{ codeVerifier: "test-verifier" }, null, mockPromptAsync]);
+    mockGetItemAsync.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => <AuthProvider>{children}</AuthProvider>,
+    });
+
+    await waitFor(() => {
+      expect(result.current.login).toBeDefined();
+    });
+
+    (Sentry.captureException as jest.Mock).mockClear();
+
+    await result.current.login();
+
+    expect(alertSpy).toHaveBeenCalledWith("No browser found", "Please install a web browser to log in.");
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Patches `expo-web-browser` native Android code to catch `SecurityException` thrown when a third-party Custom Tabs handler (e.g. OPay) registers unexported activities, preventing a crash on `launchUrl()`
- Wraps all three `launchUrl` call sites in `CustomTabsActivitiesHelper.kt` and `BrowserProxyActivity.kt` with try-catch, falling back to a plain `ACTION_VIEW` intent
- Adds `patch-package` as a devDependency to persist the native patch across installs
- Adds a JS-level test verifying the auth login flow catches browser launch errors and shows a user-friendly alert instead of crashing

## Test plan
- [ ] Verify the patch applies cleanly on fresh `npm install` (postinstall script runs `patch-package`)
- [ ] Test OAuth login flow on Android with a device that has a third-party Custom Tabs handler
- [ ] Test OAuth login flow on Android with Chrome as the default browser (happy path)
- [ ] Test OAuth login flow on iOS (unaffected, should still work)
- [ ] Confirm `npx jest` passes all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)