### PR TITLE
Fix RuntimeException: Get page pdf document null

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -42,10 +42,12 @@ export default function PdfViewerScreen() {
 
   const switchViewMode = (mode: "single" | "continuous") => {
     // Unmount the PDF component first to let the native rendering thread finish
-    // before the document is closed, avoiding IllegalStateException: Already closed
+    // before the document is closed, avoiding IllegalStateException: Already closed.
+    // Use a 100ms delay before remounting to give the native view time to fully
+    // release resources, preventing "Get page pdf document null" RuntimeException.
     setPdfMounted(false);
     setViewMode(mode);
-    requestAnimationFrame(() => setPdfMounted(true));
+    setTimeout(() => setPdfMounted(true), 100);
   };
 
   useEffect(
@@ -101,7 +103,7 @@ export default function PdfViewerScreen() {
               <TouchableOpacity onPress={() => setShowTocModal(true)} className="p-2">
                 <SolidIcon name="book-content" size={24} className="text-accent" />
               </TouchableOpacity>
-              <TouchableOpacity onPress={() => setShowViewModeModal(true)} className="p-2">
+              <TouchableOpacity testID="view-mode-button" onPress={() => setShowViewModeModal(true)} className="p-2">
                 {viewMode === "continuous" ? (
                   <LineIcon name="move-vertical" size={24} className="text-accent" />
                 ) : (

--- a/patches/react-native-pdf+7.0.4.patch
+++ b/patches/react-native-pdf+7.0.4.patch
@@ -1,0 +1,116 @@
+diff --git a/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfView.java b/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfView.java
+index e9a1d16..4ec1a94 100644
+--- a/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfView.java
++++ b/node_modules/react-native-pdf/android/src/main/java/org/wonday/pdf/PdfView.java
+@@ -65,6 +65,7 @@ import com.google.gson.Gson;
+ import org.wonday.pdf.events.TopChangeEvent;
+ 
+ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompleteListener,OnErrorListener,OnTapListener,OnDrawListener,OnPageScrollListener, LinkHandler {
++    private boolean hasError = false;
+     private int page = 1;               // start from 1
+     private boolean horizontal = false;
+     private float scale = 1;
+@@ -150,25 +151,31 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
+ 
+     @Override
+     public void loadComplete(int numberOfPages) {
+-        SizeF pageSize = getPageSize(0);
+-        float width = pageSize.getWidth();
+-        float height = pageSize.getHeight();
++        try {
++            SizeF pageSize = getPageSize(0);
++            float width = pageSize.getWidth();
++            float height = pageSize.getHeight();
+ 
+-        this.zoomTo(this.scale);
+-        WritableMap event = Arguments.createMap();
++            this.zoomTo(this.scale);
++            WritableMap event = Arguments.createMap();
+ 
+-        //create a new json Object for the TableOfContents
+-        Gson gson = new Gson();
+-        event.putString("message", "loadComplete|"+numberOfPages+"|"+width+"|"+height+"|"+gson.toJson(this.getTableOfContents()));
++            //create a new json Object for the TableOfContents
++            Gson gson = new Gson();
++            event.putString("message", "loadComplete|"+numberOfPages+"|"+width+"|"+height+"|"+gson.toJson(this.getTableOfContents()));
+ 
+-        ThemedReactContext context = (ThemedReactContext) getContext();
+-        EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
+-        int surfaceId = UIManagerHelper.getSurfaceId(this);
++            ThemedReactContext context = (ThemedReactContext) getContext();
++            EventDispatcher dispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, getId());
++            int surfaceId = UIManagerHelper.getSurfaceId(this);
+ 
+-        TopChangeEvent tce = new TopChangeEvent(surfaceId, getId(), event);
++            TopChangeEvent tce = new TopChangeEvent(surfaceId, getId(), event);
+ 
+-        if (dispatcher != null) {
+-            dispatcher.dispatchEvent(tce);
++            if (dispatcher != null) {
++                dispatcher.dispatchEvent(tce);
++            }
++        } catch (Exception e) {
++            Log.e("PdfView", "Error in loadComplete", e);
++            onError(e);
++            return;
+         }
+         //        ReactContext reactContext = (ReactContext)this.getContext();
+ //        reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(
+@@ -183,6 +190,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
+ 
+     @Override
+     public void onError(Throwable t){
++        this.hasError = true;
+         WritableMap event = Arguments.createMap();
+         if (t.getMessage().contains("Password required or incorrect password")) {
+             event.putString("message", "error|Password required or incorrect password.");
+@@ -285,8 +293,14 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
+     @Override
+     protected void onAttachedToWindow() {
+         super.onAttachedToWindow();
+-        if (this.isRecycled())
+-            this.drawPdf();
++        if (this.isRecycled()) {
++            try {
++                this.drawPdf();
++            } catch (Exception e) {
++                Log.e("PdfView", "Error re-drawing recycled PDF", e);
++                onError(e);
++            }
++        }
+     }
+ 
+     private int getPdfPageCount(File pdfFile) throws IOException {
+@@ -301,6 +315,7 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
+ 
+     public void drawPdf() {
+         showLog(format("drawPdf path:%s %s", this.path, this.page));
++        this.hasError = false;
+ 
+         if (this.path != null){
+ 
+@@ -370,6 +385,24 @@ public class PdfView extends PDFView implements OnPageChangeListener,OnLoadCompl
+                 configurator.onTap(this);
+             }
+ 
++            // Install an uncaught exception handler to catch RuntimeExceptions from the
++            // pdfium rendering thread (e.g., "Get page pdf document null" when the native
++            // document handle is null due to failed initialization or race conditions).
++            final Thread.UncaughtExceptionHandler previousHandler = Thread.getDefaultUncaughtExceptionHandler();
++            Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
++                if (throwable instanceof RuntimeException
++                        && throwable.getMessage() != null
++                        && throwable.getMessage().contains("pdf document null")) {
++                    Log.e("PdfView", "Caught null document crash on rendering thread", throwable);
++                    new Handler(Looper.getMainLooper()).post(() -> onError(throwable));
++                    return;
++                }
++                // Re-throw all other exceptions to the previous handler
++                if (previousHandler != null) {
++                    previousHandler.uncaughtException(thread, throwable);
++                }
++            });
++
+             configurator.load();
+         }
+     }

--- a/tests/app/pdf-viewer.test.tsx
+++ b/tests/app/pdf-viewer.test.tsx
@@ -2,7 +2,13 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 
 jest.mock("expo-router", () => ({
   useLocalSearchParams: () => ({ uri: "https://example.com/test.pdf", title: "Test PDF" }),
-  Stack: { Screen: () => null },
+  Stack: {
+    Screen: ({ options }: any) => {
+      const { View } = require("react-native");
+      const headerRight = options?.headerRight?.();
+      return <View testID="stack-screen">{headerRight}</View>;
+    },
+  },
 }));
 
 jest.mock("expo-sharing", () => ({
@@ -23,7 +29,18 @@ jest.mock("@/lib/media-location", () => ({
   updateMediaLocation: jest.fn(),
 }));
 
+jest.mock("@/components/ui/sheet", () => {
+  const { View, Text } = require("react-native");
+  return {
+    Sheet: ({ children, open }: any) => (open ? <View>{children}</View> : null),
+    SheetContent: ({ children }: any) => <View>{children}</View>,
+    SheetHeader: ({ children }: any) => <View>{children}</View>,
+    SheetTitle: ({ children }: any) => <Text>{children}</Text>,
+  };
+});
+
 let mockOnError: ((e: unknown) => void) | null = null;
+let mockPdfProps: Record<string, unknown> | null = null;
 
 jest.mock("react-native-pdf", () => {
   const { forwardRef } = require("react");
@@ -32,6 +49,7 @@ jest.mock("react-native-pdf", () => {
     __esModule: true,
     default: forwardRef((props: Record<string, unknown>, _ref: unknown) => {
       mockOnError = props.onError as any;
+      mockPdfProps = props;
       return <View testID="pdf-component" />;
     }),
   };
@@ -42,7 +60,13 @@ import { act } from "react";
 
 describe("PdfViewerScreen", () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     mockOnError = null;
+    mockPdfProps = null;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it("shows error view with Try Again button when PDF fails to load", () => {
@@ -71,5 +95,32 @@ describe("PdfViewerScreen", () => {
 
     expect(screen.getByTestId("pdf-component")).toBeTruthy();
     expect(screen.queryByText("Try Again")).toBeNull();
+  });
+
+  it("unmounts PDF and remounts after a delay when switching view mode", () => {
+    render(<PdfViewerScreen />);
+
+    expect(screen.getByTestId("pdf-component")).toBeTruthy();
+
+    // Open the view mode sheet
+    fireEvent.press(screen.getByTestId("view-mode-button"));
+
+    // Now "Continuous" option should be visible in the sheet
+    fireEvent.press(screen.getByText("Continuous"));
+
+    // PDF should be unmounted immediately during the switch
+    expect(screen.queryByTestId("pdf-component")).toBeNull();
+
+    // PDF should not remount until the timeout fires
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(screen.queryByTestId("pdf-component")).toBeNull();
+
+    // After 100ms, PDF should remount
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    expect(screen.getByTestId("pdf-component")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Patches `react-native-pdf` (via `patch-package`) to catch `RuntimeException: Get page pdf document null` from the pdfium native rendering thread and route it through the `onError` callback instead of crashing the app
- Wraps `loadComplete` and `onAttachedToWindow` in try-catch to handle null document errors during page size queries and recycled view re-draws
- Installs an `UncaughtExceptionHandler` that intercepts the "pdf document null" crash from the rendering thread and dispatches it to `onError` on the main thread
- Changes `switchViewMode` in `pdf-viewer.tsx` from `requestAnimationFrame` to `setTimeout(100ms)` to give the native view time to release resources before remounting, reducing the race condition window

## Context
Sentry issue: https://gumroad-to.sentry.io/issues/7397559312/

The crash occurs in `io.legere.pdfiumandroid.PdfDocument.nativeLoadPage` when the native PDF document handle is null. This can happen when:
1. A PDF fails to initialize properly (corrupted file, incomplete download)
2. A race condition during view mode switching where the old native view's rendering thread tries to load pages after the document has been torn down

The existing `AlreadyClosedBehavior.IGNORE` config handles the "already closed" case but not the "never opened" case.

## Test plan
- [x] Added test verifying PDF unmounts immediately on view mode switch and remounts only after 100ms delay
- [x] Existing error/retry tests still pass
- [ ] Manual test: open a PDF, rapidly switch between Single Page and Continuous modes
- [ ] Manual test: open a corrupted/invalid PDF URL and verify error view appears instead of crash
- [ ] Verify on Android that the Sentry crash no longer reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)