### PR TITLE
Fix: Retry transient 502/503/504 errors in request()

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -62,7 +62,7 @@ export const request = async <T>(
       if (!response.ok) {
         if (RETRYABLE_STATUS_CODES.includes(response.status) && attempt < MAX_RETRIES) {
           console.info("HTTP request (retrying)", { ...details, attempt: attempt + 1 });
-          await sleep(INITIAL_BACKOFF_MS * 2 ** attempt, options?.signal);
+          await sleep(INITIAL_BACKOFF_MS * 2 ** attempt, options?.signal ?? undefined);
           continue;
         }
 

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -11,6 +11,18 @@ export class UnauthorizedError extends Error {
 }
 
 const REQUEST_TIMEOUT_MS = 30_000;
+const RETRYABLE_STATUS_CODES = [502, 503, 504];
+const MAX_RETRIES = 2;
+const INITIAL_BACKOFF_MS = 500;
+
+const sleep = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const id = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(id);
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    });
+  });
 
 export const request = async <T>(
   url: string,
@@ -18,48 +30,60 @@ export const request = async <T>(
 ): Promise<T> => {
   const body = options?.data ? JSON.stringify(options.data) : options?.body;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  if (options?.signal) options.signal.addEventListener("abort", () => controller.abort());
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    if (options?.signal) options.signal.addEventListener("abort", () => controller.abort());
 
-  try {
-    const response = await fetch(url, {
-      ...options,
-      headers: {
-        "Content-Type": "application/json",
-        ...options?.headers,
-      },
-      body,
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          "Content-Type": "application/json",
+          ...options?.headers,
+        },
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
 
-    const details = {
-      // Including the token in the logged URL makes Sentry exclude the whole string. We can remove this when we use the public API
-      url: url.replace(env.EXPO_PUBLIC_MOBILE_TOKEN, "[filtered]"),
-      method: options?.method ?? "GET",
-      status: response.status,
-    };
-    if (response.status === 401) {
+      const details = {
+        // Including the token in the logged URL makes Sentry exclude the whole string. We can remove this when we use the public API
+        url: url.replace(env.EXPO_PUBLIC_MOBILE_TOKEN, "[filtered]"),
+        method: options?.method ?? "GET",
+        status: response.status,
+      };
+
+      if (response.status === 401) {
+        console.info("HTTP request", details);
+        throw new UnauthorizedError("Unauthorized");
+      }
+
+      if (!response.ok) {
+        if (RETRYABLE_STATUS_CODES.includes(response.status) && attempt < MAX_RETRIES) {
+          console.info("HTTP request (retrying)", { ...details, attempt: attempt + 1 });
+          await sleep(INITIAL_BACKOFF_MS * 2 ** attempt, options?.signal);
+          continue;
+        }
+
+        const error =
+          response.status === 403
+            ? "Access denied"
+            : response.status === 404
+              ? "Not found"
+              : (await response.text()).slice(0, 10000);
+        console.info("HTTP request", { ...details, error });
+        throw new Error(`Request failed: ${response.status} ${error}`);
+      }
       console.info("HTTP request", details);
-      throw new UnauthorizedError("Unauthorized");
+      if (options?.skipResponseBody) return undefined as T;
+      return response.json();
+    } finally {
+      clearTimeout(timeoutId);
     }
-    if (!response.ok) {
-      const error =
-        response.status === 403
-          ? "Access denied"
-          : response.status === 404
-            ? "Not found"
-            : (await response.text()).slice(0, 10000);
-      console.info("HTTP request", { ...details, error });
-      throw new Error(`Request failed: ${response.status} ${error}`);
-    }
-    console.info("HTTP request", details);
-    if (options?.skipResponseBody) return undefined as T;
-    return response.json();
-  } finally {
-    clearTimeout(timeoutId);
   }
+
+  throw new Error("Unreachable");
 };
 
 export const buildApiUrl = (path: string) => {

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -98,9 +98,7 @@ describe("request", () => {
   });
 
   it("retries on 504 and succeeds on retry", async () => {
-    mockFetch
-      .mockReturnValueOnce(jsonResponse("Gateway Timeout", 504))
-      .mockReturnValueOnce(jsonResponse({ ok: true }));
+    mockFetch.mockReturnValueOnce(jsonResponse("Gateway Timeout", 504)).mockReturnValueOnce(jsonResponse({ ok: true }));
     const promise = request("https://api.example.com/test");
     await jest.advanceTimersByTimeAsync(500);
     const result = await promise;

--- a/tests/lib/request.test.ts
+++ b/tests/lib/request.test.ts
@@ -75,6 +75,89 @@ describe("request", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("retries on 502 and succeeds on retry", async () => {
+    mockFetch
+      .mockReturnValueOnce(jsonResponse("<html>Bad Gateway</html>", 502))
+      .mockReturnValueOnce(jsonResponse({ ok: true }));
+    const promise = request("https://api.example.com/test");
+    await jest.advanceTimersByTimeAsync(500);
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 503 and succeeds on retry", async () => {
+    mockFetch
+      .mockReturnValueOnce(jsonResponse("Service Unavailable", 503))
+      .mockReturnValueOnce(jsonResponse({ ok: true }));
+    const promise = request("https://api.example.com/test");
+    await jest.advanceTimersByTimeAsync(500);
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 504 and succeeds on retry", async () => {
+    mockFetch
+      .mockReturnValueOnce(jsonResponse("Gateway Timeout", 504))
+      .mockReturnValueOnce(jsonResponse({ ok: true }));
+    const promise = request("https://api.example.com/test");
+    await jest.advanceTimersByTimeAsync(500);
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after all retries are exhausted for 502", async () => {
+    mockFetch
+      .mockReturnValueOnce(jsonResponse("<html>Bad Gateway</html>", 502))
+      .mockReturnValueOnce(jsonResponse("<html>Bad Gateway</html>", 502))
+      .mockReturnValueOnce(jsonResponse("<html>Bad Gateway</html>", 502));
+    const promise = request("https://api.example.com/test").catch((e: Error) => e);
+    await jest.advanceTimersByTimeAsync(1500);
+    const error = await promise;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch("Request failed: 502");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses exponential backoff between retries", async () => {
+    mockFetch
+      .mockReturnValueOnce(jsonResponse("", 502))
+      .mockReturnValueOnce(jsonResponse("", 502))
+      .mockReturnValueOnce(jsonResponse({ ok: true }));
+    const promise = request("https://api.example.com/test");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(499);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(999);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const result = await promise;
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("does not retry 400 errors", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ error: "bad request" }, 400));
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 400");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry 401 errors", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({}, 401));
+    await expect(request("https://api.example.com/test")).rejects.toThrow(UnauthorizedError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry 500 errors", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse({ error: "internal" }, 500));
+    await expect(request("https://api.example.com/test")).rejects.toThrow("Request failed: 500");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts the request after 30s timeout", async () => {
     const mock = hangingFetch();
     mockFetch.mockImplementation(mock);


### PR DESCRIPTION
## Summary
- Adds retry logic with exponential backoff (500ms, 1000ms) for transient HTTP errors (502, 503, 504) in `lib/request.ts`
- Retries up to 2 times (3 total attempts) before throwing; non-transient errors (400, 401, 403, 404, 500) are not retried
- Each retry gets a fresh `AbortController` so per-attempt timeouts work correctly

**Sentry issue:** https://gumroad-to.sentry.io/issues/7398831937/
Sentry event count: 1 occurrence (first seen), minimal user impact so far.

## Test plan
- [x] Verified 502, 503, 504 are retried and succeed on retry
- [x] Verified error is thrown after all retries exhausted
- [x] Verified non-transient errors (400, 401, 500) are NOT retried
- [x] Verified exponential backoff timing (500ms then 1000ms)
- [x] All 116 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)