### PR TITLE
Build without EAS

### DIFF
--- a/.claude/commands/build-app.md
+++ b/.claude/commands/build-app.md
@@ -49,11 +49,9 @@ Argument: platform — one of "ios", "android", or "both" (default: "both")
 
 ### 1b. Check build tool prerequisites
 
-1. **EAS CLI**: Must be installed globally (`npm install -g eas-cli`) and logged in. If not logged in, have the user run `! eas login --sso`. The Expo project is under the `anti-work` org — the user must be a member.
+1. **Xcode**: Required for iOS builds. Verify with `xcodebuild -version`. The user must be signed into an Apple Developer account in Xcode (Settings → Accounts) with access to the team matching `$APPLE_TEAM_ID`.
 
-2. **Fastlane**: Required for iOS builds (EAS uses it for signing/archiving). Install with `arch -arm64 brew install fastlane` if missing.
-
-3. **JDK 17+**: Required for Android builds (Gradle 9 needs it). If `$JAVA_HOME` is not already pointing to a JDK 17 install, install it with `arch -arm64 brew install openjdk@17` and symlink:
+2. **JDK 17+**: Required for Android builds (Gradle 9 needs it). If `$JAVA_HOME` is not already pointing to a JDK 17 install, install it with `arch -arm64 brew install openjdk@17` and symlink:
 
    ```
    sudo ln -sfn /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
@@ -65,7 +63,7 @@ Argument: platform — one of "ios", "android", or "both" (default: "both")
    export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
    ```
 
-4. **Android SDK**: Required for local Android builds. Install Android Studio (`arch -arm64 brew install --cask android-studio`), open it once to complete the setup wizard, then set:
+3. **Android SDK**: Required for local Android builds. Install Android Studio (`arch -arm64 brew install --cask android-studio`), open it once to complete the setup wizard, then set:
    ```
    export ANDROID_HOME=~/Library/Android/sdk
    ```
@@ -91,25 +89,85 @@ rm -rf $TMPDIR/haste-map-* $TMPDIR/metro-cache
 
 ### 4. Build
 
-First, run `npm install` then `npm run rebuild` to regenerate the native directories.
+First, source the env file and run `npm install` then `npm run rebuild` to regenerate the native directories:
+
+```
+set -a && source .env.build.local && set +a
+npm install
+npm run rebuild
+```
 
 Next, determine which platforms to build based on the argument (default: both).
 
-For each platform, run the build command with env vars and JDK set:
+#### iOS
+
+1. Generate an `ExportOptions.plist` for the archive export, replacing `$APPLE_TEAM_ID` with the value in `.env.build.local`:
+
+   ```
+   cat > /tmp/ExportOptions.plist << EOF
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+       <key>method</key>
+       <string>app-store</string>
+       <key>teamID</key>
+       <string>$APPLE_TEAM_ID</string>
+       <key>signingStyle</key>
+       <string>automatic</string>
+       <key>destination</key>
+       <string>export</string>
+       <key>uploadSymbols</key>
+       <true/>
+   </dict>
+   </plist>
+   EOF
+   ```
+
+2. Archive the app:
+
+   ```
+   set -a && source .env.build.local && set +a
+   xcodebuild -workspace ios/Gumroad.xcworkspace \
+     -scheme Gumroad \
+     -configuration Release \
+     -archivePath ios/build/Gumroad.xcarchive \
+     archive \
+     DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+     -allowProvisioningUpdates
+   ```
+
+3. Export the archive to an `.ipa`:
+
+   ```
+   xcodebuild -exportArchive \
+     -archivePath ios/build/Gumroad.xcarchive \
+     -exportOptionsPlist /tmp/ExportOptions.plist \
+     -exportPath ios/build/export \
+     -allowProvisioningUpdates
+   ```
+
+   The `.ipa` will be at `ios/build/export/Gumroad.ipa`.
+
+IMPORTANT: The archive step may take a while. Run it with a generous timeout (10 minutes).
+
+#### Android
+
+Build a release `.aab` (Android App Bundle):
 
 ```
 export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
 export PATH="$JAVA_HOME/bin:$PATH"
 export ANDROID_HOME=~/Library/Android/sdk
 set -a && source .env.build.local && set +a
-npx dotenv-flow -- eas build --platform <platform> --profile production --local --non-interactive
+cd android && ./gradlew bundleRelease && cd ..
 ```
 
-where `<platform>` is `ios` or `android`.
+The `.aab` will be at `android/app/build/outputs/bundle/release/app-release.aab`.
 
 IMPORTANT: This command may take a while. Run it with a generous timeout (10 minutes).
 
-The build command outputs the path to the built artifact (`.ipa` for iOS, `.aab` for Android). Capture this path from the output.
+#### Parallel builds
 
 If building both platforms, run them in parallel using a single background bash command that spawns both builds concurrently (using `&` and `wait`). Note: parallel builds are memory-intensive — the memory limit is already increased by the `gradle-memory` plugin but if an Android build fails with `OutOfMemoryError: Metaspace` you may need to increase it further.
 

--- a/.claude/commands/build-app.md
+++ b/.claude/commands/build-app.md
@@ -30,16 +30,14 @@ Argument: platform — one of "ios", "android", or "both" (default: "both")
 
 3. Write the env vars to `.env.build.local` in the project root (overwrite if it exists).
 
-4. Download the `google-services.json` attachment from the same 1Password item:
+4. Download file attachments from the same 1Password item. Find each file's attachment ID from the `files` array, then download them. Skip any file that already exists in the project root.
 
-   ```
-   op item get "gumroad-mobile .env.build.local - build credentials for Expo mobile app" --format=json
-   ```
-
-   Find the file attachment ID from the `files` array, then download it:
+   - `google-services.json`
+   - `upload-keystore.jks`
 
    ```
    op read "op://Engineering/<item-id>/<file-id>" > google-services.json
+   op read "op://Engineering/<item-id>/<file-id>" > upload-keystore.jks
    ```
 
 5. Source the env file:
@@ -49,7 +47,7 @@ Argument: platform — one of "ios", "android", or "both" (default: "both")
 
 ### 1b. Check build tool prerequisites
 
-1. **Xcode**: Required for iOS builds. Verify with `xcodebuild -version`. The user must be signed into an Apple Developer account in Xcode (Settings → Accounts) with access to the team matching `$APPLE_TEAM_ID`.
+1. **Xcode**: Required for iOS builds. Verify with `xcodebuild -version`. The user must be signed into an Apple Developer account in Xcode (Settings → Accounts) with access to the team matching `$EXPO_APPLE_TEAM_ID`.
 
 2. **JDK 17+**: Required for Android builds (Gradle 9 needs it). If `$JAVA_HOME` is not already pointing to a JDK 17 install, install it with `arch -arm64 brew install openjdk@17` and symlink:
 
@@ -101,7 +99,7 @@ Next, determine which platforms to build based on the argument (default: both).
 
 #### iOS
 
-1. Generate an `ExportOptions.plist` for the archive export, replacing `$APPLE_TEAM_ID` with the value in `.env.build.local`:
+1. Generate an `ExportOptions.plist` for the archive export, replacing `$EXPO_APPLE_TEAM_ID` with the value in `.env.build.local`:
 
    ```
    cat > /tmp/ExportOptions.plist << EOF
@@ -112,7 +110,7 @@ Next, determine which platforms to build based on the argument (default: both).
        <key>method</key>
        <string>app-store</string>
        <key>teamID</key>
-       <string>$APPLE_TEAM_ID</string>
+       <string>$EXPO_APPLE_TEAM_ID</string>
        <key>signingStyle</key>
        <string>automatic</string>
        <key>destination</key>
@@ -133,7 +131,7 @@ Next, determine which platforms to build based on the argument (default: both).
      -configuration Release \
      -archivePath ios/build/Gumroad.xcarchive \
      archive \
-     DEVELOPMENT_TEAM="$APPLE_TEAM_ID" \
+     DEVELOPMENT_TEAM="$EXPO_APPLE_TEAM_ID" \
      -allowProvisioningUpdates
    ```
 
@@ -153,15 +151,77 @@ IMPORTANT: The archive step may take a while. Run it with a generous timeout (10
 
 #### Android
 
-Build a release `.aab` (Android App Bundle):
+Since `npm run rebuild` regenerates the `android/` directory, the following steps must be done after the rebuild above.
 
-```
-export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
-export PATH="$JAVA_HOME/bin:$PATH"
-export ANDROID_HOME=~/Library/Android/sdk
-set -a && source .env.build.local && set +a
-cd android && ./gradlew bundleRelease && cd ..
-```
+1. Copy the keystore into the Android project:
+
+   ```
+   cp upload-keystore.jks android/app/upload-keystore.jks
+   ```
+
+2. Edit `android/app/build.gradle` to configure release signing. Add a `release` block inside `signingConfigs`:
+
+   ```groovy
+   release {
+       storeFile file('upload-keystore.jks')
+       storePassword System.env.ANDROID_KEYSTORE_PASSWORD
+       keyAlias System.env.ANDROID_KEY_ALIAS
+       keyPassword System.env.ANDROID_KEY_PASSWORD
+   }
+   ```
+
+   Then change the `release` build type's `signingConfig` from `signingConfigs.debug` to `signingConfigs.release`.
+
+3. Increment the `versionCode` in `android/app/build.gradle`. The rebuild always resets it to `1`, but Google Play rejects duplicate version codes.
+
+   Set up Google Play API access (if not already done):
+
+   a. Check if `gcloud` CLI is installed. If not: `arch -arm64 brew install google-cloud-sdk`. Have the user sign in with `! gcloud auth login` if needed.
+
+   b. Check if `play-store-key.json` exists in the project root. If not, set one up:
+
+      ```
+      gcloud iam service-accounts list
+      ```
+
+      Find the email for "Play Console Service Account". If none exists, prompt the user to create it and give it publishing permission in Google Play Console (Setup → API access).
+
+      ```
+      gcloud iam service-accounts keys create play-store-key.json --iam-account=<SERVICE_ACCOUNT_EMAIL>
+      ```
+
+   Then query the Google Play Publishing API for the highest existing version code:
+
+   ```
+   gcloud auth activate-service-account --key-file=play-store-key.json
+   ACCESS_TOKEN=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/androidpublisher)
+
+   EDIT_ID=$(curl -s -X POST \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{}' | jq -r '.id')
+
+   MAX_VERSION_CODE=$(curl -s \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/bundles" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" | jq '[.bundles[].versionCode] | max')
+
+   curl -s -X DELETE \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID" \
+     -H "Authorization: Bearer $ACCESS_TOKEN"
+   ```
+
+   Edit `android/app/build.gradle` to set `versionCode` to `MAX_VERSION_CODE + 1`.
+
+4. Build a release `.aab` (Android App Bundle):
+
+   ```
+   export JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home
+   export PATH="$JAVA_HOME/bin:$PATH"
+   export ANDROID_HOME=~/Library/Android/sdk
+   set -a && source .env.build.local && set +a
+   cd android && ./gradlew bundleRelease && cd ..
+   ```
 
 The `.aab` will be at `android/app/build/outputs/bundle/release/app-release.aab`.
 

--- a/.claude/commands/submit-app.md
+++ b/.claude/commands/submit-app.md
@@ -41,28 +41,55 @@ Use a generous timeout (5 minutes).
 
 #### Android
 
-Upload the `.aab` to Google Play using `fastlane supply`.
+Upload the `.aab` to Google Play using the Publishing API directly.
 
-1. Check if `fastlane` is installed. If not, install it (`brew install fastlane`).
-2. Check if `gcloud` CLI is installed. If not, install it (`arch -arm64 brew install google-cloud-sdk`). Have the user sign in with `! gcloud auth login` if needed.
-3. Check if `play-store-key.json` exists in the project root. If not, set one up using `gcloud`:
+`gcloud` and `play-store-key.json` should already be set up from `/build-app`. If not, follow the Google Play API access setup in `/build-app` step 4.3.
 
+1. Get an OAuth2 access token from the service account:
    ```
-   gcloud iam service-accounts list
-   ```
-
-   Find the email for "Play Console Service Account". If none exists, prompt the user to create it and give it publishing permission in Google Play Console (Setup → API access).
-
-   ```
-   gcloud iam service-accounts keys create play-store-key.json --iam-account=<SERVICE_ACCOUNT_EMAIL>
+   gcloud auth activate-service-account --key-file=play-store-key.json
+   ACCESS_TOKEN=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/androidpublisher)
    ```
 
-4. Upload to the internal test track:
+2. Create an edit:
    ```
-   fastlane supply --aab <path-to-aab> --track internal --json_key play-store-key.json --package_name $ANDROID_BUNDLE_NAME --skip_upload_metadata --skip_upload_changelogs --skip_upload_images --skip_upload_screenshots
+   EDIT_ID=$(curl -s -X POST \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{}' | jq -r '.id')
    ```
 
-Use a generous timeout (5 minutes) for each command.
+3. Upload the `.aab`:
+   ```
+   curl -X POST \
+     "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/bundles?uploadType=media" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "Content-Type: application/octet-stream" \
+     --data-binary @<path-to-aab>
+   ```
+
+4. Assign the upload to the internal track:
+   ```
+   VERSION_CODE=$(curl -s \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/bundles" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" | jq -r '.bundles[-1].versionCode')
+
+   curl -X PUT \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/tracks/internal" \
+     -H "Authorization: Bearer $ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "{\"track\":\"internal\",\"releases\":[{\"versionCodes\":[\"$VERSION_CODE\"],\"status\":\"completed\"}]}"
+   ```
+
+5. Commit the edit:
+   ```
+   curl -X POST \
+     "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/${ANDROID_BUNDLE_NAME}/edits/${EDIT_ID}:commit" \
+     -H "Authorization: Bearer $ACCESS_TOKEN"
+   ```
+
+Use a generous timeout (5 minutes) for the upload step. Check each API response for errors before proceeding to the next step.
 
 Tell the user the internal test release is live and how to promote it to production in Google Play Console.
 

--- a/.claude/commands/submit-app.md
+++ b/.claude/commands/submit-app.md
@@ -46,12 +46,14 @@ Upload the `.aab` to Google Play using the Publishing API directly.
 `gcloud` and `play-store-key.json` should already be set up from `/build-app`. If not, follow the Google Play API access setup in `/build-app` step 4.3.
 
 1. Get an OAuth2 access token from the service account:
+
    ```
    gcloud auth activate-service-account --key-file=play-store-key.json
    ACCESS_TOKEN=$(gcloud auth print-access-token --scopes=https://www.googleapis.com/auth/androidpublisher)
    ```
 
 2. Create an edit:
+
    ```
    EDIT_ID=$(curl -s -X POST \
      "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits" \
@@ -61,6 +63,7 @@ Upload the `.aab` to Google Play using the Publishing API directly.
    ```
 
 3. Upload the `.aab`:
+
    ```
    curl -X POST \
      "https://androidpublisher.googleapis.com/upload/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/bundles?uploadType=media" \
@@ -70,6 +73,7 @@ Upload the `.aab` to Google Play using the Publishing API directly.
    ```
 
 4. Assign the upload to the internal track:
+
    ```
    VERSION_CODE=$(curl -s \
      "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/$ANDROID_BUNDLE_NAME/edits/$EDIT_ID/bundles" \

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Use the Claude Code slash commands `/build-app` and `/submit-app` to build and s
 ### Prerequisites
 
 - **1Password CLI**: Credentials are fetched automatically from 1Password. Install with `arch -arm64 brew install 1password-cli`, enable the desktop app integration (Settings → Developer → CLI), and sign in with `op signin`.
-- **EAS CLI**: Install globally with `npm install -g eas-cli` and log in with `eas login --sso`. You must be a member of the `anti-work` Expo org.
-- **Fastlane**: Required for iOS code signing. Install with `arch -arm64 brew install fastlane`.
+- 1. **Xcode**: Required for iOS builds. The user must be signed into an Apple Developer account in Xcode (Settings → Accounts) with access to the correct team.
 - **JDK 17+**: Required for Android builds (Gradle 9). Install with `arch -arm64 brew install openjdk@17`, then symlink:
   ```bash
   sudo ln -sfn /opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk


### PR DESCRIPTION
Switches to using XCode and Android Studio directly to build, so that people don't need Expo accounts and team access.

Also removes the `fastlane` dependency by using the Google Play API directly.