### PR TITLE
Fix last read location not updating after going back

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -10,6 +10,7 @@ import { updateMediaLocation } from "@/lib/media-location";
 import { File, Paths } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as Sentry from "@sentry/react-native";
+import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useEffect, useRef, useState } from "react";
 import { Dimensions, Platform, StyleSheet, TouchableOpacity, View } from "react-native";
@@ -27,6 +28,7 @@ export default function PdfViewerScreen() {
     initialPage?: string;
   }>();
   const { accessToken } = useAuth();
+  const queryClient = useQueryClient();
   const pdfRef = useRef<PdfRef>(null);
   const [currentPage, setCurrentPage] = useState(initialPage ? Number(initialPage) : 1);
   const currentPageRef = useRefToLatest(currentPage);
@@ -76,8 +78,9 @@ export default function PdfViewerScreen() {
         location: currentPageRef.current,
         accessToken,
       });
+      void queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] });
     },
-    [urlRedirectId, productFileId, purchaseId, currentPageRef, accessToken],
+    [urlRedirectId, productFileId, purchaseId, currentPageRef, accessToken, queryClient],
   );
 
   const handlePageSelect = (page: number) => {

--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -77,8 +77,7 @@ export default function PdfViewerScreen() {
         // We deliberately use the latest value of the ref for the latest media location
         location: currentPageRef.current,
         accessToken,
-      });
-      void queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] });
+      }).then(() => queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] }));
     },
     [urlRedirectId, productFileId, purchaseId, currentPageRef, accessToken, queryClient],
   );

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -75,8 +75,7 @@ export default function VideoPlayerScreen() {
 
         location: currentPositionRef.current,
         accessToken,
-      });
-      void queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] });
+      }).then(() => queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] }));
     },
     [urlRedirectId, productFileId, purchaseId, currentPositionRef, accessToken, queryClient],
   );

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -3,6 +3,7 @@ import { useRefToLatest } from "@/components/use-ref-to-latest";
 import { useAuth } from "@/lib/auth-context";
 import { updateMediaLocation } from "@/lib/media-location";
 import { requestAPI } from "@/lib/request";
+import { useQueryClient } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useVideoPlayer, VideoView } from "expo-video";
@@ -24,6 +25,7 @@ export default function VideoPlayerScreen() {
     initialPosition?: string;
   }>();
 
+  const queryClient = useQueryClient();
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [currentPosition, setCurrentPosition] = useState(initialPosition ? Number(initialPosition) : 0);
@@ -74,8 +76,9 @@ export default function VideoPlayerScreen() {
         location: currentPositionRef.current,
         accessToken,
       });
+      void queryClient.invalidateQueries({ queryKey: ["purchase", urlRedirectId] });
     },
-    [urlRedirectId, productFileId, purchaseId, currentPositionRef, accessToken],
+    [urlRedirectId, productFileId, purchaseId, currentPositionRef, accessToken, queryClient],
   );
 
   useEffect(() => {

--- a/tests/app/pdf-viewer.test.tsx
+++ b/tests/app/pdf-viewer.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { renderWithQueryClient } from "../render-with-query-client";
 
 jest.mock("expo-router", () => ({
   useLocalSearchParams: () => ({ uri: "https://example.com/test.pdf", title: "Test PDF" }),
@@ -44,13 +45,15 @@ jest.mock("react-native-pdf", () => {
 import PdfViewerScreen from "@/app/pdf-viewer";
 import { act } from "react";
 
+const renderWithProviders = () => renderWithQueryClient(<PdfViewerScreen />);
+
 describe("PdfViewerScreen", () => {
   beforeEach(() => {
     mockOnError = null;
   });
 
   it("shows error view with Try Again button when PDF fails to load", () => {
-    render(<PdfViewerScreen />);
+    renderWithProviders();
 
     expect(screen.getByTestId("pdf-component")).toBeTruthy();
     expect(screen.queryByText("Try Again")).toBeNull();
@@ -65,7 +68,7 @@ describe("PdfViewerScreen", () => {
   });
 
   it("re-mounts PDF component when Try Again is pressed", () => {
-    render(<PdfViewerScreen />);
+    renderWithProviders();
 
     act(() => {
       mockOnError!(new Error("ENOENT"));

--- a/tests/components/dashboard/refund-form.test.tsx
+++ b/tests/components/dashboard/refund-form.test.tsx
@@ -1,7 +1,7 @@
 import { RefundForm } from "@/components/dashboard/refund-form";
 import { SaleDetail } from "@/components/dashboard/use-sales-analytics";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { fireEvent, screen } from "@testing-library/react-native";
+import { renderWithQueryClient } from "../../render-with-query-client";
 import { act } from "react";
 import { Alert as NativeAlert } from "react-native";
 
@@ -44,14 +44,8 @@ const makeSale = (overrides: Partial<SaleDetail> = {}): SaleDetail => ({
   ...overrides,
 });
 
-const renderWithProviders = (sale: SaleDetail, onRefundSuccess?: () => void) => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <RefundForm sale={sale} onRefundSuccess={onRefundSuccess} />
-    </QueryClientProvider>,
-  );
-};
+const renderWithProviders = (sale: SaleDetail, onRefundSuccess?: () => void) =>
+  renderWithQueryClient(<RefundForm sale={sale} onRefundSuccess={onRefundSuccess} />);
 
 const pressRefundAndConfirm = () => {
   const alertSpy = jest.spyOn(NativeAlert, "alert");

--- a/tests/render-with-query-client.tsx
+++ b/tests/render-with-query-client.tsx
@@ -1,0 +1,8 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, type RenderOptions } from "@testing-library/react-native";
+import type { ReactElement } from "react";
+
+export const renderWithQueryClient = (ui: ReactElement, options?: RenderOptions) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>, options);
+};


### PR DESCRIPTION
Fixes an issue with https://github.com/antiwork/gumroad-mobile/pull/171 where opening a PDF, jumping to a different page, going back to the product, and going back into the same PDF would not work correctly - the purchase API call would not reload and therefore it wouldn't detect the updated last read page.

This makes sure the API is refetched when you navigate back to the purchase page, so the next time you go into that PDF it will use the most up to date location.