### PR TITLE
Fix picture-in-picture permissions

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -77,7 +77,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     "expo-updates",
     "expo-secure-store",
     "expo-web-browser",
-    "expo-video",
+    [
+      "expo-video",
+      {
+        supportsPictureInPicture: true,
+      },
+    ],
     "expo-image",
     "expo-sharing",
     [


### PR DESCRIPTION
We have this enabled in the video component props but need this flag in config as well to add the correct permissions to the iOS project.