### PR TITLE
Fix push notification deep linking

### DIFF
--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -56,6 +56,21 @@ const getExpoPushToken = async () => {
   return tokenData.data;
 };
 
+const handleNotificationResponse = (
+  response: Notifications.NotificationResponse,
+  router: ReturnType<typeof useRouter>,
+) => {
+  const data = response.notification.request.content.data as Record<string, string> | undefined;
+  if (!data?.installment_id) return;
+
+  const params = new URLSearchParams();
+  if (data.purchase_id) params.set("purchaseId", data.purchase_id);
+  else if (data.subscription_id) params.set("subscriptionId", data.subscription_id);
+  else if (data.follower_id) params.set("followerId", data.follower_id);
+  const query = params.toString();
+  router.push(`/post/${data.installment_id}${query ? `?${query}` : ""}` as any);
+};
+
 export const usePushNotifications = () => {
   const { accessToken, isAuthenticated } = useAuth();
   const router = useRouter();
@@ -75,16 +90,12 @@ export const usePushNotifications = () => {
   }, [isAuthenticated, accessToken]);
 
   useEffect(() => {
-    notificationResponseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      const data = response.notification.request.content.data as Record<string, string> | undefined;
-      if (!data?.installment_id) return;
+    Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (response) handleNotificationResponse(response, router);
+    });
 
-      const params = new URLSearchParams();
-      if (data.purchase_id) params.set("purchaseId", data.purchase_id);
-      else if (data.subscription_id) params.set("subscriptionId", data.subscription_id);
-      else if (data.follower_id) params.set("followerId", data.follower_id);
-      const query = params.toString();
-      router.push(`/post/${data.installment_id}${query ? `?${query}` : ""}` as any);
+    notificationResponseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
+      handleNotificationResponse(response, router);
     });
 
     return () => {


### PR DESCRIPTION
When the app does a cold start from a push notification, the handler hasn't mounted when the notification event happens. We need to explicitly check whether the app was started from a notification as well.