### PR TITLE
Remove Sentry user feedback and link to contact form instead

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -10,8 +10,6 @@ import { useUser } from "@/components/use-user";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
-import { flushReplayBuffer } from "@/lib/sentry";
-import { showFeedbackWidget } from "@sentry/react-native";
 import { BottomTabBar } from "@react-navigation/bottom-tabs";
 import * as Application from "expo-application";
 import Constants from "expo-constants";
@@ -110,8 +108,7 @@ const SettingsSheet = () => {
 
   const handleSendFeedback = () => {
     setSettingsOpen(false);
-    flushReplayBuffer();
-    showFeedbackWidget();
+    safeOpenURL(`${env.EXPO_PUBLIC_GUMROAD_URL}/help?new_ticket=1`);
   };
 
   return (

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -24,10 +24,7 @@ Sentry.init({
     }
     return event;
   },
-  integrations: [
-    navigationIntegration,
-    mobileReplay,
-  ],
+  integrations: [navigationIntegration, mobileReplay],
 });
 
 export { Sentry };

--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/react-native";
-import { NATIVE } from "@sentry/react-native/dist/js/wrapper";
 import { env } from "@/lib/env";
 
 export const navigationIntegration = Sentry.reactNavigationIntegration({
@@ -28,34 +27,7 @@ Sentry.init({
   integrations: [
     navigationIntegration,
     mobileReplay,
-    Sentry.feedbackIntegration({
-      colorScheme: "system",
-      themeLight: {
-        background: "#ffffff",
-        foreground: "#000000",
-        accentBackground: "#ff90e8",
-        accentForeground: "#000000",
-        border: "#000000",
-      },
-      themeDark: {
-        background: "#000000",
-        foreground: "#dedede",
-        accentBackground: "#ff90e8",
-        accentForeground: "#000000",
-        border: "#555555",
-      },
-    }),
   ],
 });
-
-Sentry.getClient()?.on("beforeSendFeedback", (feedbackEvent) => {
-  // Make sure we attach the session replay (available because replaysOnErrorSampleRate is 1, but not currently enabled in the React Native SDK for feedback)
-  const replayId = mobileReplay.getReplayId();
-  if (replayId && feedbackEvent.contexts?.feedback) {
-    feedbackEvent.contexts.feedback.replay_id = replayId;
-  }
-});
-
-export const flushReplayBuffer = () => NATIVE.captureReplay(false);
 
 export { Sentry };


### PR DESCRIPTION
Removes the Sentry user feedback form and makes the button link to open a new ticket on the Gumroad website.

It was useful during the release but it's a separate place to check, so going forward it'll be easier to just keep everything in Helper.

## Before (see https://github.com/antiwork/gumroad-mobile/pull/100)

<img width="393" height="852" alt="image" src="https://github.com/user-attachments/assets/6237bf21-0bbf-4745-b4ea-47121f0317e9" />

## After

https://github.com/user-attachments/assets/bc5a0c78-b508-4bba-8d3e-2f109b628180
