### PR TITLE
Disable session replay to fix app hangs on iOS

### DIFF
--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -5,15 +5,15 @@ export const navigationIntegration = Sentry.reactNavigationIntegration({
   enableTimeToInitialDisplay: true,
 });
 
-const mobileReplay = Sentry.mobileReplayIntegration({
-  excludedViewClasses: ["ExpoVideo.VideoView"],
-});
-
 Sentry.init({
   dsn: env.EXPO_PUBLIC_SENTRY_DSN,
   tracesSampleRate: __DEV__ ? 1 : 0.1,
-  replaysSessionSampleRate: __DEV__ ? 1 : 0,
-  replaysOnErrorSampleRate: __DEV__ ? 1 : 0.1,
+  // Session replay disabled: the native SentrySessionReplay.createAndCaptureInBackground
+  // method blocks the main thread for 2000ms+, causing app hangs on iOS.
+  // See: https://github.com/getsentry/sentry-react-native/issues/4838
+  // Re-enable once the upstream fix lands in @sentry/react-native.
+  replaysSessionSampleRate: 0,
+  replaysOnErrorSampleRate: 0,
   beforeSend(event) {
     const message = event.exception?.values?.[0]?.value ?? event.exception?.values?.[0]?.type;
     if (message === "Network request failed" || message === "TypeError: Network request failed") {
@@ -24,7 +24,7 @@ Sentry.init({
     }
     return event;
   },
-  integrations: [navigationIntegration, mobileReplay],
+  integrations: [navigationIntegration],
 });
 
 export { Sentry };


### PR DESCRIPTION
## Problem

Sentry is reporting `App Hanging: App hanging for at least 2000 ms` caused by `SentrySessionReplay.createAndCaptureInBackground` blocking the main thread on iOS.

This is a [known upstream issue](https://github.com/getsentry/sentry-react-native/issues/4838) in the Sentry React Native SDK where the mobile replay integration's screenshot capture runs synchronously on the main thread.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7405456269/

## Fix

- Set `replaysSessionSampleRate` and `replaysOnErrorSampleRate` to `0` in production (they were `0` and `0.1` respectively)
- Remove the `mobileReplayIntegration` from the integrations list entirely

All other Sentry functionality (error reporting, tracing, navigation tracking) is unchanged.

Session replay can be re-enabled once the upstream fix lands in `@sentry/react-native`.

## Testing

All 103 existing tests pass.