### PR TITLE
Add in-app media playback to post file list

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -58,8 +58,7 @@ export default function PostScreen() {
   const post = useInstallment(id, { purchaseId, subscriptionId, followerId });
   const purchase = usePurchase(post?.url_redirect_external_id);
   const webViewRef = useRef<BaseWebView>(null);
-  const { playAudio, pauseAudio } = useAudioPlayerSync(webViewRef);
-  const [playingAudioId, setPlayingAudioId] = useState<string | null>(null);
+  const { playAudio, pauseAudio, activeResourceId, isPlaying } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const [bodyHeight, setBodyHeight] = useState(0);
@@ -122,9 +121,8 @@ export default function PostScreen() {
 
   const handleAudioPress = async (fileId: string) => {
     try {
-      if (playingAudioId === fileId) {
+      if (activeResourceId === fileId && isPlaying) {
         await pauseAudio();
-        setPlayingAudioId(null);
         return;
       }
       if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
@@ -145,7 +143,6 @@ export default function PostScreen() {
         artwork: purchase.thumbnail_url,
         tracks,
       });
-      setPlayingAudioId(fileId);
     } catch (error) {
       Sentry.captureException(error);
     }
@@ -233,7 +230,7 @@ export default function PostScreen() {
                   <View className="flex-row gap-2 self-end">
                     {isAudio && (
                       <Button variant="outline" onPress={() => handleAudioPress(file.id)} disabled={!purchase}>
-                        <Text>{playingAudioId === file.id ? "Pause" : "Play"}</Text>
+                        <Text>{activeResourceId === file.id && isPlaying ? "Pause" : "Play"}</Text>
                       </Button>
                     )}
                     <Button

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -296,16 +296,15 @@ export default function PostScreen() {
               const [fileName, extension] = file.name.split(/\.(?=[^.]+$)/);
               const mediaType = getMediaType(file);
               return (
-                <View
-                  key={file.id}
-                  className={`flex-row items-center gap-3 p-4 ${index > 0 ? "border-t border-border" : ""}`}
-                >
-                  <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
-                  <View className="flex-1">
-                    <Text numberOfLines={1}>{fileName}</Text>
-                    {extension ? <Text>{extension.toUpperCase()}</Text> : null}
+                <View key={file.id} className={`gap-3 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
+                  <View className="flex-row items-center gap-3">
+                    <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
+                    <View className="flex-1">
+                      <Text numberOfLines={1}>{fileName}</Text>
+                      {extension ? <Text>{extension.toUpperCase()}</Text> : null}
+                    </View>
                   </View>
-                  <View className="flex-row gap-2">
+                  <View className="flex-row gap-2 self-end">
                     <Button
                       variant="outline"
                       onPress={() => handleFileDownload(file.id)}

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -11,7 +11,7 @@ import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 import { File, Paths } from "expo-file-system";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { Asset } from "expo-asset";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -23,6 +23,49 @@ import { useCSSVariable } from "uniwind";
 const formatDate = (dateString: string) => {
   const date = new Date(dateString);
   return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+};
+
+const audioExtensions = ["mp3", "m4a", "aac", "wav", "ogg", "flac"];
+const videoExtensions = ["mp4", "m4v"];
+const pdfExtensions = ["pdf"];
+
+const getFileExtension = (name: string) => name.split(/\.(?=[^.]+$)/)[1]?.toLowerCase();
+
+const isAudioFile = (file: { name: string; filegroup?: string }) => {
+  const ext = getFileExtension(file.name);
+  return file.filegroup === "audio" || (ext != null && audioExtensions.includes(ext));
+};
+
+const isVideoFile = (file: { name: string; filegroup?: string; streaming_url?: string }) => {
+  const ext = getFileExtension(file.name);
+  return file.filegroup === "video" || (ext != null && videoExtensions.includes(ext)) || !!file.streaming_url;
+};
+
+const isPdfFile = (file: { name: string }) => {
+  const ext = getFileExtension(file.name);
+  return ext != null && pdfExtensions.includes(ext);
+};
+
+type FileMediaType = "audio" | "video" | "pdf" | "other";
+
+const getMediaType = (file: { name: string; filegroup?: string; streaming_url?: string }): FileMediaType => {
+  if (isAudioFile(file)) return "audio";
+  if (isVideoFile(file)) return "video";
+  if (isPdfFile(file)) return "pdf";
+  return "other";
+};
+
+const fileIconName = (mediaType: FileMediaType) => {
+  switch (mediaType) {
+    case "audio":
+      return "music";
+    case "video":
+      return "play";
+    case "pdf":
+      return "file";
+    default:
+      return "file";
+  }
 };
 
 const downloadUrl = (urlRedirectToken: string, productFileId: string) =>
@@ -55,6 +98,7 @@ export default function PostScreen() {
     subscriptionId?: string;
     followerId?: string;
   }>();
+  const router = useRouter();
   const post = useInstallment(id, { purchaseId, subscriptionId, followerId });
   const purchase = usePurchase(post?.url_redirect_external_id);
   const webViewRef = useRef<BaseWebView>(null);
@@ -126,7 +170,7 @@ export default function PostScreen() {
         return;
       }
       if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
-      const allAudioFiles = post.files_data?.filter((f) => f.filegroup === "audio") ?? [];
+      const allAudioFiles = post.files_data?.filter(isAudioFile) ?? [];
       const tracks = allAudioFiles.map((f) => ({
         uri: downloadUrl(purchase.url_redirect_token, f.id),
         resourceId: f.id,
@@ -146,6 +190,39 @@ export default function PostScreen() {
     } catch (error) {
       Sentry.captureException(error);
     }
+  };
+
+  const handleVideoPress = (fileId: string) => {
+    if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
+    const file = post.files_data?.find((f) => f.id === fileId);
+    router.push({
+      pathname: "/video-player",
+      params: {
+        uri: downloadUrl(purchase.url_redirect_token, fileId),
+        streamingUrl: file?.streaming_url,
+        title: post.name,
+        urlRedirectId: post.url_redirect_external_id,
+        productFileId: fileId,
+        purchaseId: purchase.purchase_id,
+        initialPosition: file?.latest_media_location?.location ?? undefined,
+      },
+    });
+  };
+
+  const handlePdfPress = (fileId: string) => {
+    if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
+    const file = post.files_data?.find((f) => f.id === fileId);
+    router.push({
+      pathname: "/pdf-viewer",
+      params: {
+        uri: downloadUrl(purchase.url_redirect_token, fileId),
+        title: post.name,
+        urlRedirectId: post.url_redirect_external_id,
+        productFileId: fileId,
+        purchaseId: purchase.purchase_id,
+        initialPage: file?.latest_media_location?.location ?? undefined,
+      },
+    });
   };
 
   const handleCreatorPress = () => {
@@ -217,20 +294,30 @@ export default function PostScreen() {
           <View className="mx-4 rounded border border-border bg-background">
             {post.files_data.map((file, index) => {
               const [fileName, extension] = file.name.split(/\.(?=[^.]+$)/);
-              const isAudio = file.filegroup === "audio";
+              const mediaType = getMediaType(file);
               return (
                 <View key={file.id} className={`gap-4 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
                   <View className="flex-row items-center gap-3">
-                    <LineIcon name={isAudio ? "music" : "file"} size={20} className="text-foreground" />
+                    <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
                     <View className="flex-1">
                       <Text numberOfLines={1}>{fileName}</Text>
                       {extension ? <Text>{extension.toUpperCase()}</Text> : null}
                     </View>
                   </View>
                   <View className="flex-row gap-2 self-end">
-                    {isAudio && (
+                    {mediaType === "audio" && (
                       <Button variant="outline" onPress={() => handleAudioPress(file.id)} disabled={!purchase}>
                         <Text>{activeResourceId === file.id && isPlaying ? "Pause" : "Play"}</Text>
+                      </Button>
+                    )}
+                    {mediaType === "video" && (
+                      <Button variant="outline" onPress={() => handleVideoPress(file.id)} disabled={!purchase}>
+                        <Text>Play</Text>
+                      </Button>
+                    )}
+                    {mediaType === "pdf" && (
+                      <Button variant="outline" onPress={() => handlePdfPress(file.id)} disabled={!purchase}>
+                        <Text>View</Text>
                       </Button>
                     )}
                     <Button

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -296,7 +296,10 @@ export default function PostScreen() {
               const [fileName, extension] = file.name.split(/\.(?=[^.]+$)/);
               const mediaType = getMediaType(file);
               return (
-                <View key={file.id} className={`flex-row items-center gap-3 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
+                <View
+                  key={file.id}
+                  className={`flex-row items-center gap-3 p-4 ${index > 0 ? "border-t border-border" : ""}`}
+                >
                   <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
                   <View className="flex-1">
                     <Text numberOfLines={1}>{fileName}</Text>

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -296,30 +296,13 @@ export default function PostScreen() {
               const [fileName, extension] = file.name.split(/\.(?=[^.]+$)/);
               const mediaType = getMediaType(file);
               return (
-                <View key={file.id} className={`gap-4 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
-                  <View className="flex-row items-center gap-3">
-                    <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
-                    <View className="flex-1">
-                      <Text numberOfLines={1}>{fileName}</Text>
-                      {extension ? <Text>{extension.toUpperCase()}</Text> : null}
-                    </View>
+                <View key={file.id} className={`flex-row items-center gap-3 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
+                  <LineIcon name={fileIconName(mediaType)} size={20} className="text-foreground" />
+                  <View className="flex-1">
+                    <Text numberOfLines={1}>{fileName}</Text>
+                    {extension ? <Text>{extension.toUpperCase()}</Text> : null}
                   </View>
-                  <View className="flex-row gap-2 self-end">
-                    {mediaType === "audio" && (
-                      <Button variant="outline" onPress={() => handleAudioPress(file.id)} disabled={!purchase}>
-                        <Text>{activeResourceId === file.id && isPlaying ? "Pause" : "Play"}</Text>
-                      </Button>
-                    )}
-                    {mediaType === "video" && (
-                      <Button variant="outline" onPress={() => handleVideoPress(file.id)} disabled={!purchase}>
-                        <Text>Play</Text>
-                      </Button>
-                    )}
-                    {mediaType === "pdf" && (
-                      <Button variant="outline" onPress={() => handlePdfPress(file.id)} disabled={!purchase}>
-                        <Text>View</Text>
-                      </Button>
-                    )}
+                  <View className="flex-row gap-2">
                     <Button
                       variant="outline"
                       onPress={() => handleFileDownload(file.id)}
@@ -327,6 +310,21 @@ export default function PostScreen() {
                     >
                       {downloadingFileId === file.id ? <LoadingSpinner size="small" /> : <Text>Download</Text>}
                     </Button>
+                    {mediaType === "audio" && (
+                      <Button onPress={() => handleAudioPress(file.id)} disabled={!purchase}>
+                        <Text>{activeResourceId === file.id && isPlaying ? "Pause" : "Play"}</Text>
+                      </Button>
+                    )}
+                    {mediaType === "video" && (
+                      <Button onPress={() => handleVideoPress(file.id)} disabled={!purchase}>
+                        <Text>Watch</Text>
+                      </Button>
+                    )}
+                    {mediaType === "pdf" && (
+                      <Button onPress={() => handlePdfPress(file.id)} disabled={!purchase}>
+                        <Text>Read</Text>
+                      </Button>
+                    )}
                   </View>
                 </View>
               );

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
+import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
 import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
@@ -24,14 +25,13 @@ const formatDate = (dateString: string) => {
   return date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
 };
 
+const downloadUrl = (urlRedirectToken: string, productFileId: string) =>
+  buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`);
+
 const downloadFile = (urlRedirectToken: string, productFileId: string) =>
-  File.downloadFileAsync(
-    buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`),
-    Paths.cache,
-    {
-      idempotent: true,
-    },
-  );
+  File.downloadFileAsync(downloadUrl(urlRedirectToken, productFileId), Paths.cache, {
+    idempotent: true,
+  });
 
 const fontDataPromise = Promise.all(
   [
@@ -57,12 +57,14 @@ export default function PostScreen() {
   }>();
   const post = useInstallment(id, { purchaseId, subscriptionId, followerId });
   const purchase = usePurchase(post?.url_redirect_external_id);
+  const webViewRef = useRef<BaseWebView>(null);
+  const { playAudio, pauseAudio } = useAudioPlayerSync(webViewRef);
+  const [playingAudioId, setPlayingAudioId] = useState<string | null>(null);
   const { bottom } = useSafeAreaInsets();
   const { width } = useWindowDimensions();
   const [bodyHeight, setBodyHeight] = useState(0);
   const [downloadingFileId, setDownloadingFileId] = useState<string | null>(null);
   const [fontFaces, setFontFaces] = useState("");
-  const webViewRef = useRef<BaseWebView>(null);
 
   const [foreground, bodyBg, fontFamily] = useCSSVariable(["--color-foreground", "--color-body-bg", "--font-sans"]);
 
@@ -115,6 +117,37 @@ export default function PostScreen() {
       Alert.alert("Download Failed", error instanceof Error ? error.message : "Failed to download file");
     } finally {
       setDownloadingFileId(null);
+    }
+  };
+
+  const handleAudioPress = async (fileId: string) => {
+    try {
+      if (playingAudioId === fileId) {
+        await pauseAudio();
+        setPlayingAudioId(null);
+        return;
+      }
+      if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
+      const allAudioFiles = post.files_data?.filter((f) => f.filegroup === "audio") ?? [];
+      const tracks = allAudioFiles.map((f) => ({
+        uri: downloadUrl(purchase.url_redirect_token, f.id),
+        resourceId: f.id,
+        title: f.name ?? post.name,
+        urlRedirectId: post.url_redirect_external_id,
+        purchaseId: purchase.purchase_id,
+      }));
+      const file = allAudioFiles.find((f) => f.id === fileId);
+      await playAudio({
+        resourceId: fileId,
+        resumeAt: file?.latest_media_location?.location,
+        artist: post.creator_name,
+        artistUrl: post.creator_profile_url,
+        artwork: purchase.thumbnail_url,
+        tracks,
+      });
+      setPlayingAudioId(fileId);
+    } catch (error) {
+      Sentry.captureException(error);
     }
   };
 
@@ -187,23 +220,30 @@ export default function PostScreen() {
           <View className="mx-4 rounded border border-border bg-background">
             {post.files_data.map((file, index) => {
               const [fileName, extension] = file.name.split(/\.(?=[^.]+$)/);
+              const isAudio = file.filegroup === "audio";
               return (
                 <View key={file.id} className={`gap-4 p-4 ${index > 0 ? "border-t border-border" : ""}`}>
                   <View className="flex-row items-center gap-3">
-                    <LineIcon name="file" size={20} className="text-foreground" />
+                    <LineIcon name={isAudio ? "music" : "file"} size={20} className="text-foreground" />
                     <View className="flex-1">
                       <Text numberOfLines={1}>{fileName}</Text>
                       {extension ? <Text>{extension.toUpperCase()}</Text> : null}
                     </View>
                   </View>
-                  <Button
-                    className="self-end"
-                    variant="outline"
-                    onPress={() => handleFileDownload(file.id)}
-                    disabled={!purchase || downloadingFileId === file.id}
-                  >
-                    {downloadingFileId === file.id ? <LoadingSpinner size="small" /> : <Text>Download</Text>}
-                  </Button>
+                  <View className="flex-row gap-2 self-end">
+                    {isAudio && (
+                      <Button variant="outline" onPress={() => handleAudioPress(file.id)} disabled={!purchase}>
+                        <Text>{playingAudioId === file.id ? "Pause" : "Play"}</Text>
+                      </Button>
+                    )}
+                    <Button
+                      variant="outline"
+                      onPress={() => handleFileDownload(file.id)}
+                      disabled={!purchase || downloadingFileId === file.id}
+                    >
+                      {downloadingFileId === file.id ? <LoadingSpinner size="small" /> : <Text>Download</Text>}
+                    </Button>
+                  </View>
                 </View>
               );
             })}

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -79,6 +79,8 @@ export const setupPlayer = async () => {
 
 export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) => {
   const { accessToken } = useAuth();
+  const [activeResourceId, setActiveResourceId] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
 
   useEffect(() => {
     setAudioAccessToken(accessToken);
@@ -90,6 +92,25 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     purchaseId?: string;
     contentLength?: number;
   } | null>(null);
+
+  useEffect(() => {
+    const initFromPlayer = async () => {
+      if (!isPlayerSetup) return;
+      const activeTrack = await TrackPlayer.getActiveTrack();
+      const { state } = await TrackPlayer.getPlaybackState();
+      if (activeTrack?.id && (state === State.Playing || state === State.Buffering)) {
+        setActiveResourceId(activeTrack.id);
+        setIsPlaying(true);
+      } else if (activeTrack?.id && state === State.Paused) {
+        setActiveResourceId(activeTrack.id);
+        setIsPlaying(false);
+      } else {
+        setActiveResourceId(null);
+        setIsPlaying(false);
+      }
+    };
+    initFromPlayer();
+  }, []);
 
   const syncMediaLocation = useCallback(
     async (position: number, isEnd = false) => {
@@ -152,14 +173,21 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     }, 5000);
 
     const stateSubscription = TrackPlayer.addEventListener(Event.PlaybackState, async ({ state }) => {
-      if (state === State.Paused || state === State.Stopped) {
+      if (state === State.Playing) {
+        setIsPlaying(true);
+      } else if (state === State.Paused || state === State.Stopped) {
+        setIsPlaying(false);
         await sendAudioPlayerInfo({ isPlaying: false });
       } else if (state === State.Ended) {
+        setIsPlaying(false);
+        setActiveResourceId(null);
         await sendAudioPlayerInfo({ isPlaying: false, isEnd: true });
       }
     });
 
     const endSubscription = TrackPlayer.addEventListener(Event.PlaybackQueueEnded, async () => {
+      setIsPlaying(false);
+      setActiveResourceId(null);
       await sendAudioPlayerInfo({ isPlaying: false, isEnd: true });
     });
 
@@ -194,6 +222,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
   useEffect(() => {
     const subscription = TrackPlayer.addEventListener(Event.PlaybackActiveTrackChanged, async (event) => {
       if (event.track?.id) {
+        setActiveResourceId(event.track.id);
         const previousContext = currentAudioRef.current;
         if (previousContext && previousContext.resourceId !== event.track.id) {
           const position = event.lastPosition ?? 0;
@@ -284,5 +313,5 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     [sendAudioPlayerInfo, syncMediaLocation],
   );
 
-  return { pauseAudio, playAudio };
+  return { pauseAudio, playAudio, activeResourceId, isPlaying };
 };

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -1,5 +1,5 @@
-import { useAuth } from "@/lib/auth-context";
 import { setAudioAccessToken, setAudioContext } from "@/lib/audio-player-store";
+import { useAuth } from "@/lib/auth-context";
 import { updateMediaLocation } from "@/lib/media-location";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import TrackPlayer, { Capability, Event, RepeatMode, State } from "react-native-track-player";
@@ -93,6 +93,8 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     contentLength?: number;
   } | null>(null);
 
+  const allTracksRef = useRef<AudioTrackInfo[]>([]);
+
   useEffect(() => {
     const initFromPlayer = async () => {
       if (!isPlayerSetup) return;
@@ -107,6 +109,22 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
       } else {
         setActiveResourceId(null);
         setIsPlaying(false);
+      }
+
+      const queue = await TrackPlayer.getQueue();
+      if (queue.length > 0) {
+        allTracksRef.current = queue.map((t) => ({
+          uri: t.url?.toString() ?? "",
+          resourceId: t.id ?? "",
+          title: t.title,
+        }));
+      }
+      if (activeTrack?.id) {
+        const track = allTracksRef.current.find((t) => t.resourceId === activeTrack.id);
+        if (track) {
+          currentAudioRef.current = { ...track, contentLength: activeTrack.duration };
+          setAudioContext(currentAudioRef.current);
+        }
       }
     };
     initFromPlayer();
@@ -173,7 +191,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     }, 5000);
 
     const stateSubscription = TrackPlayer.addEventListener(Event.PlaybackState, async ({ state }) => {
-      if (state === State.Playing) {
+      if (state === State.Playing || state === State.Buffering) {
         setIsPlaying(true);
       } else if (state === State.Paused || state === State.Stopped) {
         setIsPlaying(false);
@@ -207,8 +225,6 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     await TrackPlayer.pause();
     await sendAudioPlayerInfo({ isPlaying: false });
   }, [sendAudioPlayerInfo]);
-
-  const allTracksRef = useRef<AudioTrackInfo[]>([]);
 
   const updateCurrentAudioRef = useCallback((resourceId: string, duration?: number) => {
     const track = allTracksRef.current.find((t) => t.resourceId === resourceId);


### PR DESCRIPTION
## Summary
- Post file attachments previously only showed a Download button. Now audio, video, and PDF files show an additional action button (Play, Watch, Read) to open them directly in the app.
- Audio files show Play/Pause + Download, with playback via MiniAudioPlayer and FullAudioPlayer
- Video files show Watch + Download, opening the existing video player
- PDF files show Read + Download, opening the existing PDF viewer
- Media type detection uses both server `filegroup` and file extension as fallback (mp3/m4a/aac/wav/ogg/flac for audio, mp4/m4v for video), matching the old Android app's approach so files are playable even when the server doesn't classify them
- File icons now reflect the media type (music icon for audio, play icon for video)
- `useAudioPlayerSync` now exposes reactive `activeResourceId` and `isPlaying` state synced with TrackPlayer events, so the Play/Pause button label stays in sync across the post screen, mini player, and full player

Fixes #188

## Test plan
- [ ] Open a post with an MP3 file → verify Play and Download buttons appear
- [ ] Tap Play → audio plays via mini player, button changes to Pause
- [ ] Pause from mini player or full player → button on post updates to Play
- [ ] Open a post with an MP4 file → tap Watch → video player opens
- [ ] Open a post with a PDF file → tap Read → PDF viewer opens
- [ ] Open a post with a ZIP or other file → verify only Download button appears
- [ ] Open a post with mixed file types → verify correct buttons and icons for each
- [ ] Audio file without `filegroup` but with `.mp3` extension → Play button still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
