### PR TITLE
Fix TypeError: attempted to use private field on non-instance

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -14,11 +14,7 @@ config.resolver.blockList = [...(config.resolver.blockList || []), /\.env\.build
 // "TypeError: attempted to use private field on non-instance" on Hermes.
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (moduleName === "@tanstack/query-core") {
-    return context.resolveRequest(
-      { ...context, unstable_conditionNames: ["require"] },
-      moduleName,
-      platform,
-    );
+    return context.resolveRequest({ ...context, unstable_conditionNames: ["require"] }, moduleName, platform);
   }
   return context.resolveRequest(context, moduleName, platform);
 };

--- a/metro.config.js
+++ b/metro.config.js
@@ -7,6 +7,22 @@ const config = getSentryExpoConfig(__dirname, {
 
 config.resolver.blockList = [...(config.resolver.blockList || []), /\.env\.build\.local$/];
 
+// Force @tanstack/query-core to resolve its legacy (CJS) build instead of the
+// modern ESM build. The modern build uses native JS private fields (#field),
+// which are incompatible with Babel's loose-mode class-properties transform
+// shipped by @react-native/babel-preset. The mismatch causes a runtime
+// "TypeError: attempted to use private field on non-instance" on Hermes.
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName === "@tanstack/query-core") {
+    return context.resolveRequest(
+      { ...context, unstable_conditionNames: ["require"] },
+      moduleName,
+      platform,
+    );
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = withUniwindConfig(config, {
   cssEntryFile: "./app/global.css",
 });

--- a/tests/metro-query-core-resolution.test.ts
+++ b/tests/metro-query-core-resolution.test.ts
@@ -3,10 +3,7 @@ import path from "path";
 
 describe("@tanstack/query-core build compatibility", () => {
   it("legacy build uses __private helpers instead of native private fields", () => {
-    const legacyPath = path.resolve(
-      __dirname,
-      "../node_modules/@tanstack/query-core/build/legacy/queryObserver.js",
-    );
+    const legacyPath = path.resolve(__dirname, "../node_modules/@tanstack/query-core/build/legacy/queryObserver.js");
     const content = fs.readFileSync(legacyPath, "utf8");
     // The legacy build uses tslib __privateGet/__privateSet helpers
     expect(content).toContain("__privateGet");
@@ -15,10 +12,7 @@ describe("@tanstack/query-core build compatibility", () => {
   });
 
   it("modern build uses native private fields (incompatible with babel loose)", () => {
-    const modernPath = path.resolve(
-      __dirname,
-      "../node_modules/@tanstack/query-core/build/modern/queryObserver.js",
-    );
+    const modernPath = path.resolve(__dirname, "../node_modules/@tanstack/query-core/build/modern/queryObserver.js");
     const content = fs.readFileSync(modernPath, "utf8");
     // The modern build uses native # private fields
     expect(content).toMatch(/this\.#[a-zA-Z]/);

--- a/tests/metro-query-core-resolution.test.ts
+++ b/tests/metro-query-core-resolution.test.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+
+describe("@tanstack/query-core build compatibility", () => {
+  it("legacy build uses __private helpers instead of native private fields", () => {
+    const legacyPath = path.resolve(
+      __dirname,
+      "../node_modules/@tanstack/query-core/build/legacy/queryObserver.js",
+    );
+    const content = fs.readFileSync(legacyPath, "utf8");
+    // The legacy build uses tslib __privateGet/__privateSet helpers
+    expect(content).toContain("__privateGet");
+    // It must NOT contain native # private field access (this.#field)
+    expect(content).not.toMatch(/this\.#[a-zA-Z]/);
+  });
+
+  it("modern build uses native private fields (incompatible with babel loose)", () => {
+    const modernPath = path.resolve(
+      __dirname,
+      "../node_modules/@tanstack/query-core/build/modern/queryObserver.js",
+    );
+    const content = fs.readFileSync(modernPath, "utf8");
+    // The modern build uses native # private fields
+    expect(content).toMatch(/this\.#[a-zA-Z]/);
+  });
+
+  it("metro.config.js overrides resolution for @tanstack/query-core", () => {
+    const configPath = path.resolve(__dirname, "../metro.config.js");
+    const content = fs.readFileSync(configPath, "utf8");
+    // Verify the resolveRequest override exists to redirect query-core
+    expect(content).toContain('moduleName === "@tanstack/query-core"');
+    expect(content).toContain('unstable_conditionNames: ["require"]');
+  });
+});


### PR DESCRIPTION
## Problem

A `TypeError: attempted to use private field on non-instance` crash occurs on Hermes in production, originating from `@babel/runtime/helpers/classPrivateFieldLooseBase` within the `@tanstack/query-core` query observer.

**Sentry:** https://gumroad-to.sentry.io/issues/7412260272/
- 1 occurrence, 1 user affected
- Device: iPhone (iOS 18.6.2)
- Release: 2026.04.10+4

## Root cause

`@tanstack/query-core` v5 ships two builds:
- **modern** (`build/modern/`): uses native JS private fields (`#field` syntax)
- **legacy** (`build/legacy/`): uses tslib `__privateGet`/`__privateSet` helpers

With `unstable_enablePackageExports: true`, Metro resolves the `import` export condition, picking the **modern** build. However, `@react-native/babel-preset` transforms private fields with `loose: true`, which uses `classPrivateFieldLooseBase` to store private state as regular properties checked via `hasOwnProperty`. This creates a mismatch: the source code has native `#field` declarations, but the runtime helper expects loose-mode property storage. When the transformed code runs on Hermes, the helper throws because the property doesn't exist on the instance as expected.

## Fix

Override Metro's `resolveRequest` to force the `require` condition for `@tanstack/query-core`, which resolves to the **legacy** CJS build that uses compatible tslib helpers instead of native private fields.

## Tests

Added `tests/metro-query-core-resolution.test.ts` that verifies:
1. The legacy build uses `__privateGet` helpers (no native private fields)
2. The modern build uses native private fields (confirming the incompatibility)
3. The metro config contains the resolution override