### PR TITLE
Suppress AbortError from media location sync in Sentry

### DIFF
--- a/lib/media-location.ts
+++ b/lib/media-location.ts
@@ -41,6 +41,10 @@ export const updateMediaLocation = async ({
   } catch (error) {
     // Log but don't throw - media location sync is non-critical
     console.warn("Failed to update media location:", error);
-    Sentry.captureException(error);
+    // AbortError is expected when requests timeout (e.g. poor connectivity)
+    // during periodic background sync - no need to report to Sentry
+    if (!(error instanceof DOMException && error.name === "AbortError")) {
+      Sentry.captureException(error);
+    }
   }
 };

--- a/tests/lib/media-location.test.ts
+++ b/tests/lib/media-location.test.ts
@@ -1,0 +1,95 @@
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const mockCaptureException = jest.fn();
+jest.mock("@sentry/react-native", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+jest.mock("@/lib/env", () => ({
+  env: {
+    EXPO_PUBLIC_MOBILE_TOKEN: "test-token",
+    EXPO_PUBLIC_GUMROAD_API_URL: "https://api.example.com",
+  },
+}));
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+  AppState: { addEventListener: jest.fn(() => ({ remove: jest.fn() })) },
+}));
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+  QueryClient: jest.fn(),
+}));
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: jest.fn(() => ({ accessToken: "test" })),
+}));
+
+import { updateMediaLocation } from "@/lib/media-location";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const defaultParams = {
+  urlRedirectId: "redirect-1",
+  productFileId: "file-1",
+  location: 42,
+  accessToken: "token-abc",
+};
+
+const jsonResponse = (status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve("{}"),
+  });
+
+describe("updateMediaLocation", () => {
+  it("does not report AbortError to Sentry", async () => {
+    const abortError = new DOMException("Aborted", "AbortError");
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    await updateMediaLocation(defaultParams);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("reports non-AbortError exceptions to Sentry", async () => {
+    const networkError = new Error("Network request failed");
+    mockFetch.mockRejectedValueOnce(networkError);
+
+    await updateMediaLocation(defaultParams);
+
+    expect(mockCaptureException).toHaveBeenCalledWith(networkError);
+  });
+
+  it("does not throw on failure (non-critical sync)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(updateMediaLocation(defaultParams)).resolves.toBeUndefined();
+  });
+
+  it("skips the request when accessToken is null", async () => {
+    await updateMediaLocation({ ...defaultParams, accessToken: null });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends the correct payload", async () => {
+    mockFetch.mockReturnValueOnce(jsonResponse());
+
+    await updateMediaLocation(defaultParams);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("mobile/media_locations"),
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"url_redirect_id":"redirect-1"'),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

`AbortError: Aborted` ([GUMROAD-MOBILE-KS](https://gumroad-to.sentry.io/issues/7414389782/)) is being reported to Sentry from the periodic media location sync during video playback. The `updateMediaLocation` function fires every 5 seconds and uses a 30-second request timeout via `AbortController`. On slow connections these requests timeout, generating `AbortError` exceptions that get captured by Sentry even though:

1. Media location sync is explicitly non-critical (the catch block already swallows the error)
2. `AbortError` from timeouts is expected behavior, not a bug

## Fix

Filter `AbortError` (specifically `DOMException` with name `AbortError`) from `Sentry.captureException` in `updateMediaLocation`. The error is still logged via `console.warn` for debugging. All other exception types continue to be reported.

## Tests

Added `tests/lib/media-location.test.ts` with 5 tests covering:
- AbortError is **not** reported to Sentry ✅
- Other errors **are** reported to Sentry ✅
- Errors don't propagate (non-critical sync) ✅
- No request when accessToken is null ✅
- Correct payload structure ✅