### PR TITLE
Fix CardTitle text clipping on iOS

### DIFF
--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -18,7 +18,7 @@ function CardHeader({ className, ...props }: ViewProps & React.RefAttributes<Vie
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<typeof Text> & React.RefAttributes<Text>) {
-  return <Text role="heading" aria-level={3} className={cn("text-lg leading-none", className)} {...props} />;
+  return <Text role="heading" aria-level={3} className={cn("text-lg leading-tight", className)} {...props} />;
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<typeof Text> & React.RefAttributes<Text>) {


### PR DESCRIPTION
## Problem

`CardTitle` used `leading-none`, which sets line-height equal to font-size (18px for text-lg). ABC Favorit's glyph height exceeds the line box, so iOS clips the tops of capitals and ascenders (take a look at Email, Full Name, Order Information, Refund). Android renders fine because it doesn't clip overflow on text containers by default. Example is found in `SaleDetailModal`

## Solution
Switched to `leading-tight` (line-height 1.25 = 22.5px) which gives the font enough room without significantly increasing the height of card title row.

---

# Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/448bdc77-a9b9-4ba3-96d3-74dd52eeda43" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e88bc224-cd24-4bd7-ba2f-8c2db1a75519" />

# After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e5161824-c042-4b25-ba3a-9cabb521b58c" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f0f68063-d6d2-4463-ac24-e8ab59f18afb" />

<!-- For UI/CSS changes, include screenshots or videos showing both states -->

<!-- Include: Mobile (light + dark) -->

---

# Test Results
<img width="310" height="97" alt="image" src="https://github.com/user-attachments/assets/a13297f8-240d-4e67-8791-e9369d30a05b" />
---

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/antiwork/gumroad-mobile/blob/main/CONTRIBUTING.md)
- [x] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
- [x] I have performed a self-review and left review comments on my PR
- [x] I have added/updated tests for my changes

---

# AI Disclosure

Model: Claude 4.6 Opus via Claude Code
Used for: Setting up local environment, understanding codebase, and testing UI iterations
Code was manually reviewed and modified by me
