### PR TITLE
Fix app hang: defer WebView mount until after navigation transitions

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -14,6 +14,7 @@ import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { Asset } from "expo-asset";
+import { useDeferredMount } from "@/hooks/use-deferred-mount";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, Pressable, ScrollView, useWindowDimensions, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -109,6 +110,7 @@ export default function PostScreen() {
   const [downloadingFileId, setDownloadingFileId] = useState<string | null>(null);
   const [fontFaces, setFontFaces] = useState("");
 
+  const webViewReady = useDeferredMount();
   const [foreground, bodyBg, fontFamily] = useCSSVariable(["--color-foreground", "--color-body-bg", "--font-sans"]);
 
   useEffect(() => {
@@ -263,7 +265,7 @@ export default function PostScreen() {
             </View>
           </Pressable>
 
-          {htmlContent && (
+          {htmlContent && webViewReady && (
             <View style={{ height: bodyHeight, marginTop: 16 }}>
               <BaseWebView
                 ref={webViewRef}

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -13,6 +13,7 @@ import { buildApiUrl } from "@/lib/request";
 import { File, Paths } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
+import { useDeferredMount } from "@/hooks/use-deferred-mount";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as Sentry from "@sentry/react-native";
 import { Alert, View } from "react-native";
@@ -72,6 +73,7 @@ export default function DownloadScreen() {
 
   const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
+  const webViewReady = useDeferredMount();
 
   useEffect(() => {
     if (purchase) addRecentPurchase(purchase);
@@ -207,7 +209,12 @@ export default function DownloadScreen() {
   return (
     <Screen>
       <Stack.Screen options={{ title: purchase?.name ?? "" }} />
-      <StyledWebView
+      {!webViewReady ? (
+        <View className="flex-1 items-center justify-center bg-body-bg">
+          <LoadingSpinner size="large" />
+        </View>
+      ) : null}
+      {webViewReady ? <StyledWebView
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"
@@ -218,7 +225,7 @@ export default function DownloadScreen() {
         originWhitelist={["*"]}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
         onMessage={handleMessage}
-      />
+      /> : null}
       {isDownloading && (
         <View className="absolute inset-0 items-center justify-center bg-black/50">
           <LoadingSpinner size="large" />

--- a/tests/hooks/use-deferred-mount.test.ts
+++ b/tests/hooks/use-deferred-mount.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from "@testing-library/react-native";
+import { InteractionManager } from "react-native";
+import { useDeferredMount } from "@/hooks/use-deferred-mount";
+
+describe("useDeferredMount", () => {
+  it("starts as not ready", () => {
+    // Prevent InteractionManager from resolving immediately
+    const spy = jest.spyOn(InteractionManager, "runAfterInteractions").mockReturnValue({
+      then: () => ({ done: () => {} }),
+      cancel: jest.fn(),
+    } as any);
+
+    const { result } = renderHook(() => useDeferredMount());
+    expect(result.current).toBe(false);
+
+    spy.mockRestore();
+  });
+
+  it("becomes ready after interactions complete", () => {
+    let callback: (() => void) | undefined;
+    const spy = jest.spyOn(InteractionManager, "runAfterInteractions").mockImplementation((fn: any) => {
+      callback = fn;
+      return { then: () => ({ done: () => {} }), cancel: jest.fn() } as any;
+    });
+
+    const { result } = renderHook(() => useDeferredMount());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      callback?.();
+    });
+    expect(result.current).toBe(true);
+
+    spy.mockRestore();
+  });
+
+  it("cancels interaction handle on unmount", () => {
+    const cancelMock = jest.fn();
+    const spy = jest.spyOn(InteractionManager, "runAfterInteractions").mockReturnValue({
+      then: () => ({ done: () => {} }),
+      cancel: cancelMock,
+    } as any);
+
+    const { unmount } = renderHook(() => useDeferredMount());
+    unmount();
+    expect(cancelMock).toHaveBeenCalled();
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Problem

Sentry reported an app hang of 2000+ ms caused by `-[RNCWKProcessPoolManager sharedProcessPool]`. The first `WKProcessPool` allocation in `react-native-webview` is expensive and was happening synchronously on the main thread during screen mount, blocking UI for 2+ seconds.

Both `PostScreen` (`app/post/[id].tsx`) and `DownloadScreen` (`app/purchase/[token].tsx`) render `WebView` immediately on mount, triggering this.

## Fix

Used the existing `useDeferredMount` hook (already in the codebase at `hooks/use-deferred-mount.ts`) to delay WebView rendering until after navigation transitions complete via `InteractionManager.runAfterInteractions`. This moves the expensive `WKProcessPool` init off the critical path.

- **PostScreen**: WebView content only renders after `webViewReady` is true
- **DownloadScreen**: Shows a loading spinner until `webViewReady`, then mounts the WebView

## Tests

Added `tests/hooks/use-deferred-mount.test.ts` covering:
- Starts as not ready
- Becomes ready after interactions complete
- Cancels interaction handle on unmount

All 114 tests pass.

Sentry: https://gumroad-to.sentry.io/issues/7429078868/