### PR TITLE
Fix ClassCastException in MusicModule.onServiceConnected

### DIFF
--- a/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
+++ b/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
@@ -32,6 +32,26 @@ index 60b6871..1b89d31 100644
              .build()
      }
  
+diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+index 13a6c60..42a8fc8 100644
+--- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
++++ b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+@@ -75,7 +75,14 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
+         launchInScope {
+             // If a binder already exists, don't get a new one
+             if (!::musicService.isInitialized) {
+-                val binder: MusicService.MusicBinder = service as MusicService.MusicBinder
++                // FIX: Guard against cross-process BinderProxy which cannot be cast to MusicBinder.
++                // This can happen during service recreation or process death and causes a
++                // ClassCastException crash. Log and return early instead of crashing.
++                if (service !is MusicService.MusicBinder) {
++                    Timber.w("onServiceConnected received unexpected binder type: ${service.javaClass.name}")
++                    return@launchInScope
++                }
++                val binder: MusicService.MusicBinder = service
+                 musicService = binder.service
+                 musicService.setupPlayer(playerOptions)
+                 playerSetUpPromise?.resolve(null)
 diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
 index b495b5a..15739da 100644
 --- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt

--- a/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
+++ b/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
@@ -19,7 +19,7 @@ index 60b6871..1b89d31 100644
 +            try {
 +                session.release()
 +            } catch (e: Exception) {
-+                // Log but don't crash on cleanup failure
++                Timber.w(e, "Failed to release media session during cleanup")
 +            }
 +        }
 +        // FIX: Use UUID-based session ID to prevent "Session ID must be unique" crash
@@ -46,6 +46,7 @@ index 13a6c60..42a8fc8 100644
 +                // ClassCastException crash. Log and return early instead of crashing.
 +                if (service !is MusicService.MusicBinder) {
 +                    Timber.w("onServiceConnected received unexpected binder type: ${service.javaClass.name}")
++                    playerSetUpPromise?.reject("service_error", "Unexpected binder type", null)
 +                    return@launchInScope
 +                }
 +                val binder: MusicService.MusicBinder = service


### PR DESCRIPTION
## Summary
- fixes the Sentry crash in `MusicModule.onServiceConnected`
- explains the root cause: unsafe cast of a cross-process `BinderProxy` to `MusicService.MusicBinder`
- returns early after a Timber warning instead of crashing when Android hands back an unexpected binder

## Sentry
- https://gumroad-to.sentry.io/issues/7432751175/

## Root cause
`onServiceConnected` assumed the returned `IBinder` was always an in-process `MusicService.MusicBinder`. During service recreation, process death, or cross-process binding, Android can instead return a `BinderProxy`, and the direct cast throws `ClassCastException`.

## Fix
Add a safe type check before accessing the binder. If the binder is not a `MusicService.MusicBinder`, log a warning with Timber and `return@launchInScope` so the app does not crash.