### PR TITLE
Fix ClassCastException in MusicModule.onServiceConnected

### DIFF
--- a/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
+++ b/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
@@ -32,6 +32,26 @@ index 60b6871..1b89d31 100644
              .build()
      }
  
+diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+index 13a6c60..42a8fc8 100644
+--- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
++++ b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/module/MusicModule.kt
+@@ -75,7 +75,14 @@ class MusicModule(reactContext: ReactApplicationContext) : NativeTrackPlayerSpec
+         launchInScope {
+             // If a binder already exists, don't get a new one
+             if (!::musicService.isInitialized) {
+-                val binder: MusicService.MusicBinder = service as MusicService.MusicBinder
++                // FIX: Guard against cross-process BinderProxy which cannot be cast to MusicBinder.
++                // This can happen during service recreation or process death and causes a
++                // ClassCastException crash. Log and return early instead of crashing.
++                if (service !is MusicService.MusicBinder) {
++                    Timber.w("onServiceConnected received unexpected binder type: ${service.javaClass.name}")
++                    return@launchInScope
++                }
++                val binder: MusicService.MusicBinder = service
+                 musicService = binder.service
+                 musicService.setupPlayer(playerOptions)
+                 playerSetUpPromise?.resolve(null)
 diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
 index b495b5a..15739da 100644
 --- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt


### PR DESCRIPTION
## Summary

Fixes a production crash reported in Sentry: [Sentry issue 7432751175](https://gumroad-to.sentry.io/issues/7432751175/)

```
ClassCastException: android.os.BinderProxy cannot be cast to
com.doublesymmetry.trackplayer.service.MusicService$MusicBinder
```

## Root cause

In `react-native-track-player`'s `MusicModule.onServiceConnected`, the `IBinder` returned by Android's service binding is unsafely cast:

```kotlin
val binder: MusicService.MusicBinder = service as MusicService.MusicBinder
```

Normally this works because the service binds in-process and returns the local `MusicBinder`. However, Android can return a cross-process `BinderProxy` in several scenarios — e.g. service recreation after process death, or when the bound service ends up in a different process. Casting `BinderProxy` to `MusicBinder` throws `ClassCastException` and crashes the app.

## Fix

Patch `react-native-track-player` via `patch-package` to add a type check before the cast. If the received binder is not a `MusicService.MusicBinder`, log a warning and return early from the coroutine instead of crashing. The bound flag is not set, so subsequent player API calls reject with `player_not_initialized` (the existing safe path) rather than crashing.

```kotlin
if (service !is MusicService.MusicBinder) {
    Timber.w("onServiceConnected received unexpected binder type: ${service.javaClass.name}")
    return@launchInScope
}
val binder: MusicService.MusicBinder = service
```

The method body is inside a `launchInScope` coroutine, so early return is safe.

## Test plan

- [ ] App builds on Android
- [ ] Audio playback still works end-to-end (setup, play, pause, skip)
- [ ] Monitor Sentry for the `ClassCastException` after release

---

AI disclosure: PR drafted with assistance from Claude.