### PR TITLE
Reduce maxBreadcrumbs to 30 to prevent main-thread app hang

### DIFF
--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -8,6 +8,11 @@ export const navigationIntegration = Sentry.reactNavigationIntegration({
 Sentry.init({
   dsn: env.EXPO_PUBLIC_SENTRY_DSN,
   tracesSampleRate: __DEV__ ? 1 : 0.1,
+  // Reduce from default 100 to 30 to prevent main-thread hangs.
+  // SentryCrashScopeObserver serializes all breadcrumbs to JSON on the main
+  // thread via addEscapedString, which blocks for 2000ms+ with 100 breadcrumbs.
+  // See: https://gumroad-to.sentry.io/issues/7435371854/
+  maxBreadcrumbs: 30,
   // Session replay disabled: the native SentrySessionReplay.createAndCaptureInBackground
   // method blocks the main thread for 2000ms+, causing app hangs on iOS.
   // See: https://github.com/getsentry/sentry-react-native/issues/4838


### PR DESCRIPTION
## Problem

Sentry's `SentryCrashScopeObserver` serializes all breadcrumbs to a JSON C-string on the main thread every time a new breadcrumb is added. With the default 100 breadcrumbs, `addEscapedString` blocks the main thread for 2000ms+, triggering an App Hanging watchdog event.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7435371854/
**Occurrences (7-day):** 1
**Occurrences (14-day):** 1
**Estimated users affected/month:** Low (single occurrence so far)
**Estimated support tickets/month:** 0

## Root cause

The call chain is:
1. `SentryBreadcrumbTracker.trackApplicationNotifications` fires on a UIKit notification (main thread)
2. `SentryHub.addBreadcrumb:` → `SentryScope.addBreadcrumb:`
3. `SentryCrashScopeObserver.addSerializedBreadcrumb:` → `toJSONEncodedCString:`
4. `SentryCrashJSONCodec.encode:` iterates all breadcrumbs, calling `encodeObject` → `sentrycrashjson_addStringElement` → `addQuotedEscapedString` → `addEscapedString`

With 100 breadcrumbs (the default), this serialization takes 2000ms+ on the main thread.

This is a known performance issue in the Sentry SDK's crash scope observer path. Session replay was already disabled for a similar main-thread blocking issue (see existing comment in `sentry.ts`).

## Fix

Set `maxBreadcrumbs: 30` to keep useful debugging context while keeping JSON serialization time well under the 2-second hang threshold.

## Testing

This is a configuration-only change. 30 breadcrumbs is sufficient for debugging crashes and still provides meaningful context.