### PR TITLE
Replace react-native Image with expo-image to fix main thread hang

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -13,12 +13,12 @@ import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import { cn } from "@/lib/utils";
+import { Image } from "expo-image";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useMemo, useRef } from "react";
 import {
   Alert,
   FlatList,
-  Image,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Pressable,
@@ -32,7 +32,7 @@ import * as Sentry from "@sentry/react-native";
 const CarouselItem = ({ item, onPress }: { item: Purchase; onPress: () => void }) => (
   <TouchableOpacity onPress={onPress} className="size-50 overflow-hidden rounded">
     {item.thumbnail_url ? (
-      <Image source={{ uri: item.thumbnail_url }} className="absolute inset-0" resizeMode="cover" />
+      <Image source={{ uri: item.thumbnail_url }} className="absolute inset-0" contentFit="cover" />
     ) : (
       <View className="absolute inset-0 items-center justify-center bg-muted">
         <Text className="text-4xl">📦</Text>
@@ -241,7 +241,7 @@ export default function Index() {
                     className={cn("flex-row items-center gap-4", isFilterLoading && "opacity-50")}
                   >
                     {item.thumbnail_url ? (
-                      <Image source={{ uri: item.thumbnail_url }} className="size-17 bg-muted" resizeMode="cover" />
+                      <Image source={{ uri: item.thumbnail_url }} className="size-17 bg-muted" contentFit="cover" />
                     ) : (
                       <View className="size-17 items-center justify-center bg-muted">
                         <Text className="text-2xl">📦</Text>

--- a/components/dashboard/sale-item.tsx
+++ b/components/dashboard/sale-item.tsx
@@ -1,6 +1,7 @@
 import { SalePurchase } from "@/components/dashboard/use-sales-analytics";
 import { Text } from "@/components/ui/text";
-import { Image, TouchableOpacity, View } from "react-native";
+import { Image } from "expo-image";
+import { TouchableOpacity, View } from "react-native";
 import { Badge } from "../ui/badge";
 
 interface SaleItemProps {
@@ -11,7 +12,7 @@ interface SaleItemProps {
 export const SaleItem = ({ sale, onPress }: SaleItemProps) => (
   <TouchableOpacity onPress={onPress} className="flex-row items-center gap-3 border-b border-border bg-background pr-4">
     {sale.product_thumbnail_url ? (
-      <Image source={{ uri: sale.product_thumbnail_url }} className="size-16 bg-body-bg" resizeMode="cover" />
+      <Image source={{ uri: sale.product_thumbnail_url }} className="size-16 bg-body-bg" contentFit="cover" />
     ) : (
       <View className="size-16 items-center justify-center bg-body-bg">
         <Text className="text-lg">📦</Text>


### PR DESCRIPTION
## Problem

Sentry reports app hanging for 2000ms+ caused by `-[RCTUIImageViewAnimated displayDidRefresh:]`. React Native's built-in `Image` component runs expensive frame refresh logic on the main thread via CADisplayLink.

**Sentry:** https://gumroad-to.sentry.io/issues/7437651565/

## Fix

Two files still imported `Image` from `react-native` instead of `expo-image`:
- `app/(tabs)/library.tsx` — thumbnails and creator profile pictures
- `components/dashboard/sale-item.tsx` — product thumbnails

Replaced with `Image` from `expo-image`, which decodes images off the main thread using native SDImage/Glide. Also updated `resizeMode="cover"` to `contentFit="cover"` (expo-image API).

All 111 tests pass.