### PR TITLE
Fix Background ANR caused by ExoPlayer polling in background

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -8,7 +8,7 @@ import * as Sentry from "@sentry/react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useVideoPlayer, VideoView } from "expo-video";
 import { useEffect, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { AppState, StyleSheet, View } from "react-native";
 
 const fetchStreamingPlaylistUrl = async (streamingUrl: string, accessToken: string): Promise<string> =>
   (await requestAPI<{ playlist_url: string }>(streamingUrl, { accessToken })).playlist_url;
@@ -84,6 +84,7 @@ export default function VideoPlayerScreen() {
     if (!player || !urlRedirectId || !productFileId) return;
 
     const interval = setInterval(() => {
+      if (AppState.currentState !== "active") return;
       const position = player.currentTime;
       setCurrentPosition(position);
 

--- a/components/track-player-service.ts
+++ b/components/track-player-service.ts
@@ -1,6 +1,7 @@
 import { getAudioAccessToken, getAudioContext } from "@/lib/audio-player-store";
 import { updateMediaLocation } from "@/lib/media-location";
 import TrackPlayer, { Event, State } from "react-native-track-player";
+import { AppState } from "react-native";
 import { isPlayerInitialized } from "./use-audio-player-sync";
 
 const syncCurrentPosition = async (isEnd = false) => {
@@ -58,6 +59,7 @@ export const playbackService = async () => {
 
   setInterval(async () => {
     if (!isPlayerInitialized()) return;
+    if (AppState.currentState !== "active") return;
     try {
       const { state } = await TrackPlayer.getPlaybackState();
       if (state === State.Playing) {

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -2,6 +2,7 @@ import { setAudioAccessToken, setAudioContext } from "@/lib/audio-player-store";
 import { useAuth } from "@/lib/auth-context";
 import { updateMediaLocation } from "@/lib/media-location";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { AppState } from "react-native";
 import TrackPlayer, { Capability, Event, RepeatMode, State } from "react-native-track-player";
 import type { WebView } from "react-native-webview";
 import { getStoredLoopEnabled, getStoredPlaybackSpeed } from "./full-audio-player";
@@ -184,6 +185,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
         console.warn("Audio polling called before player setup");
         return;
       }
+      if (AppState.currentState !== "active") return;
       const { state } = await TrackPlayer.getPlaybackState();
       if (state === State.Playing) {
         await sendAudioPlayerInfo({ isPlaying: true });


### PR DESCRIPTION
## Problem

Sentry reported a **Background ANR** in `ExoPlayerImpl.getCurrentTimeline` ([Sentry issue](https://gumroad-to.sentry.io/issues/7438937672/)).

Three separate `setInterval` polling loops fire every 5 seconds to sync playback position:
- `track-player-service.ts` — calls `TrackPlayer.getPlaybackState()`
- `use-audio-player-sync.ts` — calls `TrackPlayer.getPlaybackState()` + `getProgress()`
- `video-player.tsx` — reads `player.currentTime` and calls `updateMediaLocation`

When the app moves to the background, these intervals continue running. The underlying ExoPlayer calls (particularly `getCurrentTimeline()`) can block on the main looper, exceeding the Android background ANR threshold.

## Fix

Added an `AppState.currentState !== "active"` guard to each polling interval so they skip execution when the app is not in the foreground. This is a minimal, safe change — media playback continues normally when the app returns to the foreground, and the track-player service's event-driven callbacks (remote play/pause/stop) still work in the background.

## Changes
- `components/track-player-service.ts` — skip polling when backgrounded
- `components/use-audio-player-sync.ts` — skip polling when backgrounded
- `app/video-player.tsx` — skip polling when backgrounded