### PR TITLE
WIP: add web platform support

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -32,7 +32,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     googleServicesFile: "./google-services.json",
   },
   web: {
-    output: "static",
+    output: "single",
     favicon: "./assets/images/favicon.png",
   },
   plugins: [

--- a/lib/context-menu-web-stub.tsx
+++ b/lib/context-menu-web-stub.tsx
@@ -1,0 +1,14 @@
+import { View, ViewProps } from "react-native";
+
+type Props = ViewProps & {
+  actions?: unknown;
+  onPress?: unknown;
+  dropdownMenuMode?: boolean;
+  previewBackgroundColor?: string;
+};
+
+const ContextMenu = ({ children, actions: _actions, onPress: _onPress, dropdownMenuMode: _d, previewBackgroundColor: _p, ...rest }: Props) => (
+  <View {...rest}>{children}</View>
+);
+
+export default ContextMenu;

--- a/lib/react-native-pdf-web-stub.tsx
+++ b/lib/react-native-pdf-web-stub.tsx
@@ -1,0 +1,28 @@
+import { forwardRef, useImperativeHandle } from "react";
+
+export type TableContent = { title: string; pageIdx: number; children?: TableContent[] };
+
+export type PdfRef = {
+  setPage: (page: number) => void;
+};
+
+type PdfProps = {
+  source: { uri: string };
+  style?: React.CSSProperties | Record<string, unknown>;
+  onLoadComplete?: (numberOfPages: number, path: string, size: { width: number; height: number }, toc?: TableContent[]) => void;
+  onPageChanged?: (page: number, numberOfPages: number) => void;
+  onError?: (error: unknown) => void;
+};
+
+const Pdf = forwardRef<PdfRef, PdfProps>(({ source, style }, ref) => {
+  useImperativeHandle(ref, () => ({ setPage: () => {} }), []);
+  return (
+    <iframe
+      src={source.uri}
+      style={{ border: "none", width: "100%", height: "100%", ...(style as React.CSSProperties) }}
+      title="PDF"
+    />
+  );
+});
+
+export default Pdf;

--- a/lib/track-player-web-stub.ts
+++ b/lib/track-player-web-stub.ts
@@ -1,0 +1,75 @@
+const noop = async () => {};
+const noopSync = () => {};
+const emptyArray = async () => [];
+const zeroProgress = async () => ({ position: 0, duration: 0, buffered: 0 });
+const nullAsync = async () => null;
+
+const TrackPlayer = {
+  setupPlayer: noop,
+  updateOptions: noop,
+  registerPlaybackService: noopSync,
+  add: noop,
+  reset: noop,
+  play: noop,
+  pause: noop,
+  stop: noop,
+  seekTo: noop,
+  skip: noop,
+  skipToNext: noop,
+  skipToPrevious: noop,
+  setRate: noop,
+  setRepeatMode: noop,
+  getRate: async () => 1,
+  getActiveTrack: nullAsync,
+  getActiveTrackIndex: nullAsync,
+  getPlaybackState: async () => ({ state: "none" }),
+  getProgress: zeroProgress,
+  getQueue: emptyArray,
+  addEventListener: () => ({ remove: noopSync }),
+};
+
+export const Event = {
+  PlaybackState: "playback-state",
+  PlaybackQueueEnded: "playback-queue-ended",
+  PlaybackActiveTrackChanged: "playback-active-track-changed",
+  RemotePlay: "remote-play",
+  RemotePause: "remote-pause",
+  RemoteStop: "remote-stop",
+  RemoteNext: "remote-next",
+  RemotePrevious: "remote-previous",
+  RemoteJumpForward: "remote-jump-forward",
+  RemoteJumpBackward: "remote-jump-backward",
+} as const;
+
+export const State = {
+  None: "none",
+  Ready: "ready",
+  Playing: "playing",
+  Paused: "paused",
+  Stopped: "stopped",
+  Buffering: "buffering",
+  Loading: "loading",
+  Ended: "ended",
+} as const;
+
+export const Capability = {
+  Play: "play",
+  Pause: "pause",
+  Stop: "stop",
+  SkipToNext: "skip-to-next",
+  SkipToPrevious: "skip-to-previous",
+  JumpForward: "jump-forward",
+  JumpBackward: "jump-backward",
+} as const;
+
+export const RepeatMode = {
+  Off: 0,
+  Track: 1,
+  Queue: 2,
+} as const;
+
+export const useActiveTrack = () => null;
+export const usePlaybackState = () => ({ state: State.None });
+export const useProgress = () => ({ position: 0, duration: 0, buffered: 0 });
+
+export default TrackPlayer;

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { withUniwindConfig } = require("uniwind/metro");
 const { getSentryExpoConfig } = require("@sentry/react-native/metro");
 
@@ -7,6 +8,10 @@ const config = getSentryExpoConfig(__dirname, {
 
 config.resolver.blockList = [...(config.resolver.blockList || []), /\.env\.build\.local$/];
 
+const trackPlayerWebStub = path.resolve(__dirname, "lib/track-player-web-stub.ts");
+const reactNativePdfWebStub = path.resolve(__dirname, "lib/react-native-pdf-web-stub.tsx");
+const contextMenuWebStub = path.resolve(__dirname, "lib/context-menu-web-stub.tsx");
+
 // Force @tanstack/query-core to resolve its legacy (CJS) build instead of the
 // modern ESM build. The modern build uses native JS private fields (#field),
 // which are incompatible with Babel's loose-mode class-properties transform
@@ -15,6 +20,15 @@ config.resolver.blockList = [...(config.resolver.blockList || []), /\.env\.build
 config.resolver.resolveRequest = (context, moduleName, platform) => {
   if (moduleName === "@tanstack/query-core") {
     return context.resolveRequest({ ...context, unstable_conditionNames: ["require"] }, moduleName, platform);
+  }
+  if (platform === "web" && moduleName === "react-native-track-player") {
+    return { type: "sourceFile", filePath: trackPlayerWebStub };
+  }
+  if (platform === "web" && moduleName === "react-native-pdf") {
+    return { type: "sourceFile", filePath: reactNativePdfWebStub };
+  }
+  if (platform === "web" && moduleName === "react-native-context-menu-view") {
+    return { type: "sourceFile", filePath: contextMenuWebStub };
   }
   return context.resolveRequest(context, moduleName, platform);
 };

--- a/modules/pdf-thumbnail/index.ts
+++ b/modules/pdf-thumbnail/index.ts
@@ -6,9 +6,23 @@ type ThumbnailResult = {
   height: number;
 };
 
-const PdfThumbnailModule = requireNativeModule<{
+type PdfThumbnailNative = {
   generate(filePath: string, page: number, quality: number): Promise<ThumbnailResult>;
-}>("PdfThumbnail");
+};
 
-export const generateThumbnail = (filePath: string, page: number, quality = 80): Promise<ThumbnailResult> =>
-  PdfThumbnailModule.generate(filePath, page, Math.min(Math.max(quality, 0), 100));
+let cached: PdfThumbnailNative | null | undefined;
+const getModule = (): PdfThumbnailNative | null => {
+  if (cached !== undefined) return cached;
+  try {
+    cached = requireNativeModule<PdfThumbnailNative>("PdfThumbnail");
+  } catch {
+    cached = null;
+  }
+  return cached;
+};
+
+export const generateThumbnail = (filePath: string, page: number, quality = 80): Promise<ThumbnailResult> => {
+  const mod = getModule();
+  if (!mod) return Promise.reject(new Error("PdfThumbnail native module is not available"));
+  return mod.generate(filePath, page, Math.min(Math.max(quality, 0), 100));
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "expo-font": "~55.0.4",
         "expo-haptics": "~55.0.9",
         "expo-image": "~55.0.6",
+        "expo-linear-gradient": "~55.0.13",
         "expo-linking": "~55.0.9",
         "expo-notifications": "~55.0.14",
         "expo-router": "~55.0.8",
@@ -8865,6 +8866,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-55.0.13.tgz",
+      "integrity": "sha512-Qz2T4jpkA15RIk29DBqI1TwW+8O9AN8MyC4TJPbh/5UnihH0yNNz3waplUO8Szh5OZ3czTGvtPQU4ysF3RDxwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "expo-font": "~55.0.4",
     "expo-haptics": "~55.0.9",
     "expo-image": "~55.0.6",
+    "expo-linear-gradient": "~55.0.13",
     "expo-linking": "~55.0.9",
     "expo-notifications": "~55.0.14",
     "expo-router": "~55.0.8",


### PR DESCRIPTION
## Summary
Draft — picking this up Monday. Gets \`npm run web\` bundling and serving so the app can be tested in a browser.

- Switch web output from \`static\` to \`single\` (SPA) in \`app.config.ts\` so Expo Router doesn't server-render every route, which crashes on modules that eagerly touch \`expo-file-system\`.
- On web, alias native-only deps to local stubs via the Metro resolver:
  - \`react-native-pdf\` → iframe-based stub using the browser PDF viewer
  - \`react-native-track-player\` → no-op API surface with valid Event/State/Capability/RepeatMode enums
  - \`react-native-context-menu-view\` → passthrough View
- Install \`expo-linear-gradient\` so \`react-native-gifted-charts\` resolves a gradient package on web.
- Defer \`requireNativeModule\` in \`modules/pdf-thumbnail\` and catch failures — the JS-only module was added without iOS/Android implementations, so it was crashing at startup.

## Not done yet
- [ ] Sign-in flow verified on web (OAuth redirect behavior)
- [ ] Audio playback (TrackPlayer is stubbed to no-ops)
- [ ] PDF thumbnails (stubbed renderer, no thumbnail generation)
- [ ] Wire up \`.env\` for pointing at production (needs prod client ID + mobile token) — depends on #209
- [ ] Full smoke test of main flows in browser

## Test plan
- [ ] \`npm run web\` starts Metro and bundles without error
- [ ] \`http://localhost:8081\` returns HTTP 200 and the app mounts
- [ ] iOS and Android builds still work (stubs are web-only via resolver)