### PR TITLE
Fix app hanging in ImageView.maybeRenderLocalAsset

### DIFF
--- a/patches/expo-image+55.0.6.patch
+++ b/patches/expo-image+55.0.6.patch
@@ -1,11 +1,11 @@
 diff --git a/node_modules/expo-image/ios/ImageView.swift b/node_modules/expo-image/ios/ImageView.swift
-index adcf377..9bc3480 100644
+index adcf377..combined 100644
 --- a/node_modules/expo-image/ios/ImageView.swift
 +++ b/node_modules/expo-image/ios/ImageView.swift
 @@ -122,6 +122,10 @@ public final class ImageView: ExpoView {
      sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
      sdImageView.layer.masksToBounds = false
- 
+
 +    // Disable progressive animated image loading to prevent main-thread hangs
 +    // in -[SDAnimatedImageView progressiveAnimatedCoderForImage:]
 +    sdImageView.shouldIncrementalLoad = false
@@ -13,3 +13,84 @@ index adcf377..9bc3480 100644
      // Apply trilinear filtering to smooth out mis-sized images.
      sdImageView.layer.magnificationFilter = .trilinear
      sdImageView.layer.minificationFilter = .trilinear
+@@ -189,25 +193,25 @@ public final class ImageView: ExpoView {
+     context[ImageView.contentFitKey] = contentFit
+
+     // Do it here so we don't waste resources trying to fetch from a remote URL
+-    if maybeRenderLocalAsset(from: source) {
+-      return
+-    }
++    maybeRenderLocalAsset(from: source) { [weak self] in
++      guard let self else { return }
+
+-    // Render SF Symbols directly without going through SDWebImage to preserve symbol properties
+-    if source.isSFSymbol {
+-      renderSFSymbol(from: source)
+-      return
+-    }
++      // Render SF Symbols directly without going through SDWebImage to preserve symbol properties
++      if source.isSFSymbol {
++        self.renderSFSymbol(from: source)
++        return
++      }
+
+-    onLoadStart([:])
++      self.onLoadStart([:])
+
+-    pendingOperation = imageManager.loadImage(
+-      with: source.uri,
+-      options: loadingOptions,
+-      context: context,
+-      progress: imageLoadProgress(_:_:_:),
+-      completed: imageLoadCompleted(_:_:_:_:_:_:)
+-    )
++      self.pendingOperation = self.imageManager.loadImage(
++        with: source.uri,
++        options: self.loadingOptions,
++        context: context,
++        progress: self.imageLoadProgress(_:_:_:),
++        completed: self.imageLoadCompleted(_:_:_:_:_:_:)
++      )
++    }
+   }
+
+   // MARK: - Loading
+@@ -346,23 +350,30 @@ public final class ImageView: ExpoView {
+     onDisplay()
+   }
+
+-  private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
++  private func maybeRenderLocalAsset(from source: ImageSource, fallback: @escaping () -> Void) {
+     let path: String? = {
+-      // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
+-      // It also crashes with EXC_BREAKPOINT when parsing data:image uris
+-      // manually drop the leading slash below iOS 16
+       if let path = source.uri?.path {
+         return String(path.dropFirst())
+       }
+       return nil
+     }()
+
+-    if let path, !path.isEmpty, let local = UIImage(named: path) {
+-      renderSourceImage(local)
+-      return true
++    guard let path, !path.isEmpty else {
++      fallback()
++      return
+     }
+
+-    return false
++    DispatchQueue.global(qos: .userInitiated).async { [weak self] in
++      let local = UIImage(named: path)
++      DispatchQueue.main.async {
++        guard let self else { return }
++        if let local {
++          self.renderSourceImage(local)
++        } else {
++          fallback()
++        }
++      }
++    }
+   }
+
+   // MARK: - Placeholder


### PR DESCRIPTION
## Summary

- Fixes [Sentry GUMROAD-MOBILE-18](https://gumroad-to.sentry.io/issues/7441133668/) — "App Hanging: App hanging for at least 2000 ms"
- Root cause: `expo-image` v55.0.6's `ImageView.swift` calls `UIImage(named:)` synchronously on the main thread inside `maybeRenderLocalAsset()`, blocking for 2+ seconds during image I/O and decoding
- Adds a `patch-package` patch that moves `UIImage(named:)` to a background queue (`DispatchQueue.global(qos: .userInitiated)`) and dispatches back to the main thread for rendering, falling through to SDWebImage async loading when no local asset is found

## Test plan

- [x] All 111 unit tests pass
- [x] Patch applies cleanly via `npx patch-package`
- [ ] Manual smoke test: verify images load correctly in the app
- [ ] Verify no main-thread hangs in Sentry after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)