### PR TITLE
Fix background ANR in ReadableNativeMap.getLocalMap on Android

### DIFF
--- a/components/use-revenue-widget.tsx
+++ b/components/use-revenue-widget.tsx
@@ -26,23 +26,15 @@ type WidgetData = {
   hasError: boolean;
 };
 
-let iosWidgetPromise: Promise<typeof import("@/components/revenue-widget")> | null = null;
-
-const getIOSWidget = () => {
-  if (!iosWidgetPromise) {
-    iosWidgetPromise = import("@/components/revenue-widget");
-  }
-  return iosWidgetPromise;
-};
-
-const updateIOSWidget = async (data: WidgetData) => {
-  const { default: RevenueWidget } = await getIOSWidget();
-  RevenueWidget.updateSnapshot(data);
+const updateIOSWidget = (data: WidgetData) => {
+  const RevenueWidget =
+    require("@/components/revenue-widget") as typeof import("@/components/revenue-widget");
+  RevenueWidget.default.updateSnapshot(data);
 };
 
 const updateAndroidWidget = async (data: WidgetData) => {
-  const { requestWidgetUpdate } = await import("react-native-android-widget");
-  const { RevenueWidgetAndroid } = await import("@/components/revenue-widget-android");
+  const { requestWidgetUpdate } = require("react-native-android-widget") as typeof import("react-native-android-widget");
+  const { RevenueWidgetAndroid } = require("@/components/revenue-widget-android") as typeof import("@/components/revenue-widget-android");
   await requestWidgetUpdate({
     widgetName: "RevenueWidget",
     renderWidget: () => (
@@ -93,13 +85,17 @@ const fetchRevenueTotals = async (accessToken: string) => {
 };
 
 TaskManager.defineTask(BACKGROUND_FETCH_TASK, async () => {
-  const accessToken = await SecureStore.getItemAsync("gumroad_access_token");
-  if (!accessToken) {
-    updateWidgetLoggedOut();
+  if (Platform.OS !== "ios") {
     return BackgroundFetch.BackgroundFetchResult.NoData;
   }
 
   try {
+    const accessToken = await SecureStore.getItemAsync("gumroad_access_token");
+    if (!accessToken) {
+      updateWidgetLoggedOut();
+      return BackgroundFetch.BackgroundFetchResult.NoData;
+    }
+
     const data = await fetchRevenueTotals(accessToken);
     updateWidgetWithData(data);
     return BackgroundFetch.BackgroundFetchResult.NewData;
@@ -147,7 +143,6 @@ export const useRevenueWidget = () => {
   }, [data, error, accessToken, isAuthLoading]);
 
   useEffect(() => {
-    if (Platform.OS === "ios") getIOSWidget();
     registerBackgroundFetch();
   }, []);
 };

--- a/tests/components/use-revenue-widget-task.test.ts
+++ b/tests/components/use-revenue-widget-task.test.ts
@@ -1,0 +1,135 @@
+import { Platform } from "react-native";
+import * as BackgroundFetch from "expo-background-fetch";
+import * as SecureStore from "expo-secure-store";
+
+let taskCallback: () => Promise<BackgroundFetch.BackgroundFetchResult>;
+
+jest.mock("expo-task-manager", () => ({
+  defineTask: jest.fn((_: string, cb: () => Promise<number>) => {
+    taskCallback = cb;
+  }),
+  isTaskRegisteredAsync: jest.fn(),
+}));
+
+jest.mock("expo-background-fetch", () => ({
+  BackgroundFetchResult: {
+    NewData: 2,
+    NoData: 1,
+    Failed: 3,
+  },
+  registerTaskAsync: jest.fn(),
+}));
+
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(),
+}));
+
+const mockUpdateSnapshot = jest.fn();
+jest.mock("@/components/revenue-widget", () => ({
+  __esModule: true,
+  default: { updateSnapshot: mockUpdateSnapshot },
+}));
+
+const mockRequestWidgetUpdate = jest.fn();
+jest.mock("react-native-android-widget", () => ({
+  __esModule: true,
+  requestWidgetUpdate: mockRequestWidgetUpdate,
+}));
+
+jest.mock("@/components/revenue-widget-android", () => ({
+  __esModule: true,
+  RevenueWidgetAndroid: () => null,
+}));
+
+const mockFetchRevenueTotals = jest.fn();
+jest.mock("@/lib/request", () => ({
+  buildApiUrl: jest.fn((path: string) => `https://api.gumroad.com/${path}`),
+  request: (...args: unknown[]) => mockFetchRevenueTotals(...args),
+  useAPIRequest: jest.fn(),
+}));
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: jest.fn(() => ({ accessToken: null, isLoading: false })),
+}));
+
+const mockGetItemAsync = SecureStore.getItemAsync as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+beforeAll(() => {
+  jest.isolateModules(() => {
+    require("@/components/use-revenue-widget");
+  });
+});
+
+describe("background fetch task", () => {
+  it("bails out early on Android with NoData", async () => {
+    const originalOS = Platform.OS;
+    (Platform as any).OS = "android";
+
+    const result = await taskCallback();
+
+    expect(result).toBe(BackgroundFetch.BackgroundFetchResult.NoData);
+    expect(mockGetItemAsync).not.toHaveBeenCalled();
+
+    (Platform as any).OS = originalOS;
+  });
+
+  it("returns NoData when no access token on iOS", async () => {
+    const originalOS = Platform.OS;
+    (Platform as any).OS = "ios";
+    mockGetItemAsync.mockResolvedValue(null);
+
+    const result = await taskCallback();
+
+    expect(result).toBe(BackgroundFetch.BackgroundFetchResult.NoData);
+
+    (Platform as any).OS = originalOS;
+  });
+
+  it("returns NewData on successful fetch on iOS", async () => {
+    const originalOS = Platform.OS;
+    (Platform as any).OS = "ios";
+    mockGetItemAsync.mockResolvedValue("test-token");
+    mockFetchRevenueTotals.mockResolvedValue({
+      day: { formatted_revenue: "$10" },
+      week: { formatted_revenue: "$50" },
+      month: { formatted_revenue: "$200" },
+      year: { formatted_revenue: "$2000" },
+    });
+
+    const result = await taskCallback();
+
+    expect(result).toBe(BackgroundFetch.BackgroundFetchResult.NewData);
+    expect(mockUpdateSnapshot).toHaveBeenCalled();
+
+    (Platform as any).OS = originalOS;
+  });
+
+  it("returns Failed when fetch throws on iOS", async () => {
+    const originalOS = Platform.OS;
+    (Platform as any).OS = "ios";
+    mockGetItemAsync.mockResolvedValue("test-token");
+    mockFetchRevenueTotals.mockRejectedValue(new Error("network error"));
+
+    const result = await taskCallback();
+
+    expect(result).toBe(BackgroundFetch.BackgroundFetchResult.Failed);
+
+    (Platform as any).OS = originalOS;
+  });
+
+  it("returns Failed when SecureStore throws on iOS", async () => {
+    const originalOS = Platform.OS;
+    (Platform as any).OS = "ios";
+    mockGetItemAsync.mockRejectedValue(new Error("secure store error"));
+
+    const result = await taskCallback();
+
+    expect(result).toBe(BackgroundFetch.BackgroundFetchResult.Failed);
+
+    (Platform as any).OS = originalOS;
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a background ANR (`ApplicationNotResponding`) triggered by `ReadableNativeMap.getLocalMap` when the `revenue-widget-update` background fetch task runs on Android
- The task was defined globally via `TaskManager.defineTask` but background fetch was only registered on iOS — Android could still invoke the task if the OS scheduled it, causing the React Native bridge to block
- **1 occurrence, 1 user affected**

## Changes
- Add platform guard at the top of the background fetch task callback to bail out immediately on Android with `NoData`
- Wrap the entire task body in try/catch so errors in `SecureStore.getItemAsync` or widget updates don't go unhandled
- Replace dynamic `import()` with lazy `require()` for widget modules to avoid bridge initialization issues when backgrounded
- Add tests covering the platform guard, success/error paths, and SecureStore failures

## Sentry issue
https://gumroad-to.sentry.io/issues/7441183701/

## Test plan
- [x] All 116 existing tests pass
- [x] 5 new tests for the background fetch task callback
- [ ] Verify on Android device that widget still updates when app is foregrounded
- [ ] Verify on iOS device that background fetch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)