### PR TITLE
Fix Background ANR caused by video player media session staying active

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -7,8 +7,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useVideoPlayer, VideoView } from "expo-video";
-import { useEffect, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { useEffect, useRef, useState } from "react";
+import { AppState, type AppStateStatus, StyleSheet, View } from "react-native";
 
 const fetchStreamingPlaylistUrl = async (streamingUrl: string, accessToken: string): Promise<string> =>
   (await requestAPI<{ playlist_url: string }>(streamingUrl, { accessToken })).playlist_url;
@@ -57,11 +57,34 @@ export default function VideoPlayerScreen() {
 
   const player = useVideoPlayer(videoUrl, (player) => {
     player.loop = false;
+    player.staysActiveInBackground = false;
     if (initialPosition) {
       player.currentTime = Number(initialPosition);
     }
     player.play();
   });
+
+  const wasPlayingBeforeBackgroundRef = useRef(false);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
+      if (nextState === "background" || nextState === "inactive") {
+        wasPlayingBeforeBackgroundRef.current = player.playing;
+        player.pause();
+      } else if (nextState === "active" && wasPlayingBeforeBackgroundRef.current) {
+        player.play();
+        wasPlayingBeforeBackgroundRef.current = false;
+      }
+    });
+
+    return () => subscription.remove();
+  }, [player]);
+
+  useEffect(() => {
+    return () => {
+      player.pause();
+    };
+  }, [player]);
 
   useEffect(
     () => () => {

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -1,0 +1,118 @@
+import { AppState } from "react-native";
+import { renderWithQueryClient } from "../render-with-query-client";
+
+const mockPlayer = {
+  loop: false,
+  staysActiveInBackground: true,
+  playing: true,
+  currentTime: 0,
+  play: jest.fn(),
+  pause: jest.fn(),
+};
+
+jest.mock("expo-video", () => {
+  const { View } = require("react-native");
+  return {
+    useVideoPlayer: (_source: unknown, setup?: (player: typeof mockPlayer) => void) => {
+      if (setup) setup(mockPlayer);
+      return mockPlayer;
+    },
+    VideoView: (props: Record<string, unknown>) => <View testID="video-view" {...props} />,
+  };
+});
+
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: () => ({ uri: "https://example.com/video.mp4", title: "Test Video" }),
+  Stack: { Screen: () => null },
+}));
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ accessToken: "test-token" }),
+}));
+
+jest.mock("@/lib/media-location", () => ({
+  updateMediaLocation: jest.fn(),
+}));
+
+import VideoPlayerScreen from "@/app/video-player";
+import { act } from "react";
+
+let appStateCallback: ((state: string) => void) | null = null;
+const mockRemove = jest.fn();
+
+const renderScreen = () => renderWithQueryClient(<VideoPlayerScreen />);
+
+describe("VideoPlayerScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlayer.playing = true;
+    mockPlayer.staysActiveInBackground = true;
+    mockPlayer.loop = false;
+    appStateCallback = null;
+
+    jest.spyOn(AppState, "addEventListener").mockImplementation((_type, callback) => {
+      appStateCallback = callback as (state: string) => void;
+      return { remove: mockRemove } as ReturnType<typeof AppState.addEventListener>;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("sets staysActiveInBackground to false on player setup", () => {
+    renderScreen();
+    expect(mockPlayer.staysActiveInBackground).toBe(false);
+  });
+
+  it("pauses the player when app goes to background", () => {
+    renderScreen();
+
+    act(() => {
+      appStateCallback!("background");
+    });
+
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+
+  it("resumes the player when app returns to active if it was playing", () => {
+    renderScreen();
+    mockPlayer.playing = true;
+
+    act(() => {
+      appStateCallback!("background");
+    });
+
+    act(() => {
+      appStateCallback!("active");
+    });
+
+    expect(mockPlayer.play).toHaveBeenCalled();
+  });
+
+  it("does not resume the player when app returns to active if it was not playing", () => {
+    renderScreen();
+    mockPlayer.playing = false;
+
+    act(() => {
+      appStateCallback!("background");
+    });
+
+    mockPlayer.play.mockClear();
+
+    act(() => {
+      appStateCallback!("active");
+    });
+
+    expect(mockPlayer.play).not.toHaveBeenCalled();
+  });
+
+  it("pauses the player on unmount", () => {
+    const { unmount } = renderScreen();
+    mockPlayer.pause.mockClear();
+
+    unmount();
+
+    expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Explicitly set `staysActiveInBackground = false` on the video player to prevent the media3 session service from staying active in the background
- Add an `AppState` listener to pause the player when the app is backgrounded and resume on return (if it was playing)
- Add explicit player cleanup on unmount to ensure the player is paused when navigating away

Fixes a Background ANR caused by `androidx.media3.common.util.Util.intToStringMaxRadix` in the `ExpoVideoPlaybackService` media session service.

Sentry: https://gumroad-to.sentry.io/issues/7445669840/

## Test plan

- [x] Added `tests/app/video-player.test.tsx` with 5 tests covering:
  - `staysActiveInBackground` is set to false on player setup
  - Player is paused when AppState changes to background
  - Player resumes when AppState changes to active (if was playing)
  - Player does NOT resume if it was paused before backgrounding
  - Player is paused on unmount
- [x] All 116 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)