### PR TITLE
Fix app hang in SDAnimatedImageView progressiveAnimatedCoderForImage:

### DIFF
--- a/patches/expo-image+55.0.6.patch
+++ b/patches/expo-image+55.0.6.patch
@@ -1,0 +1,15 @@
+diff --git a/node_modules/expo-image/ios/ImageView.swift b/node_modules/expo-image/ios/ImageView.swift
+index adcf377..9bc3480 100644
+--- a/node_modules/expo-image/ios/ImageView.swift
++++ b/node_modules/expo-image/ios/ImageView.swift
+@@ -122,6 +122,10 @@ public final class ImageView: ExpoView {
+     sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+     sdImageView.layer.masksToBounds = false
+ 
++    // Disable progressive animated image loading to prevent main-thread hangs
++    // in -[SDAnimatedImageView progressiveAnimatedCoderForImage:]
++    sdImageView.shouldIncrementalLoad = false
++
+     // Apply trilinear filtering to smooth out mis-sized images.
+     sdImageView.layer.magnificationFilter = .trilinear
+     sdImageView.layer.minificationFilter = .trilinear


### PR DESCRIPTION
## Problem

Sentry reported an app hang (2000ms+) with the culprit `-[SDAnimatedImageView progressiveAnimatedCoderForImage:]`. This method runs on the main thread inside SDWebImage when `SDAnimatedImageView` tries to find a progressive animated coder for an incoming image.

**Sentry issue:** https://gumroad-to.sentry.io/issues/7447257042/

## Root Cause

expo-image uses `SDAnimatedImageView` with `shouldIncrementalLoad` defaulting to `true`. This enables progressive animated image loading, which calls `progressiveAnimatedCoderForImage:` synchronously on the main thread. For certain images, this coder lookup is expensive enough to trigger the 2000ms watchdog.

## Fix

Added a patch-package patch for expo-image that sets `sdImageView.shouldIncrementalLoad = false` during `ImageView` initialization. This disables progressive animated loading entirely.

**Trade-off:** Images won't render partial frames while downloading. This is invisible in practice since we load small thumbnails and profile pictures that download quickly.

## Testing

- All 111 tests pass (14 suites)