### PR TITLE
Fix EXC_BREAKPOINT crash in RCTUITextField caretRectForPosition:

### DIFF
--- a/patches/react-native+0.83.4.patch
+++ b/patches/react-native+0.83.4.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+index 6e9c384..43647b6 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+@@ -363,7 +363,7 @@ - (void)_updatePlaceholder
+ 
+ - (CGRect)caretRectForPosition:(UITextPosition *)position
+ {
+-  if (_caretHidden) {
++  if (_caretHidden || !position) {
+     return CGRectZero;
+   }
+ 
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+index 377f41e..78ee103 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+@@ -213,7 +213,7 @@ - (void)removeDictationResultPlaceholder:(id)placeholder willInsertResult:(BOOL)
+ 
+ - (CGRect)caretRectForPosition:(UITextPosition *)position
+ {
+-  if (_caretHidden) {
++  if (_caretHidden || !position) {
+     return CGRectZero;
+   }
+ 

--- a/tests/components/text-input-smoke.test.tsx
+++ b/tests/components/text-input-smoke.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react-native";
+import { TextInput } from "react-native";
+
+describe("TextInput smoke test", () => {
+  it("renders without crashing", () => {
+    render(<TextInput testID="text-input" placeholder="Enter text" />);
+    expect(screen.getByTestId("text-input")).toBeTruthy();
+  });
+
+  it("renders with a value", () => {
+    render(<TextInput testID="text-input" value="hello" />);
+    expect(screen.getByDisplayValue("hello")).toBeTruthy();
+  });
+
+  it("renders multiline without crashing", () => {
+    render(<TextInput testID="text-input" multiline placeholder="Enter text" />);
+    expect(screen.getByTestId("text-input")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds nil guard for the `position` parameter in `caretRectForPosition:` overrides in both `RCTUITextField.mm` and `RCTUITextView.mm`
- When `position` is nil, UIKit's internal implementation calls `CFRelease()` on NULL, causing an `EXC_BREAKPOINT` crash
- Applied via `patch-package` for react-native@0.83.4

## Details
- **Sentry**: https://gumroad-to.sentry.io/issues/7447733179/
- **Occurrences**: 1 (first seen 2026-04-28)
- **Users affected**: ~1
- **Estimated support tickets**: 0

## Test plan
- [x] Added TextInput smoke tests (single-line and multiline) that render without crashing
- [ ] Verify patch applies cleanly on fresh `npm install` (`npx patch-package` runs in postinstall)
- [ ] QA text input fields across the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)