### PR TITLE
Fix NullPointerException in RNWidgetImageProvider.deleteImages

### DIFF
--- a/patches/react-native-android-widget+0.20.1.patch
+++ b/patches/react-native-android-widget+0.20.1.patch
@@ -1,15 +1,18 @@
 diff --git a/node_modules/react-native-android-widget/android/src/main/java/com/reactnativeandroidwidget/RNWidgetImageProvider.java b/node_modules/react-native-android-widget/android/src/main/java/com/reactnativeandroidwidget/RNWidgetImageProvider.java
-index 1234567..abcdefg 100644
+index 6b487ca..8e0903b 100644
 --- a/node_modules/react-native-android-widget/android/src/main/java/com/reactnativeandroidwidget/RNWidgetImageProvider.java
 +++ b/node_modules/react-native-android-widget/android/src/main/java/com/reactnativeandroidwidget/RNWidgetImageProvider.java
-@@ -76,8 +76,9 @@ public class RNWidgetImageProvider extends ContentProvider {
+@@ -76,9 +76,11 @@ public class RNWidgetImageProvider extends ContentProvider {
  
      private static void deleteImages(Context context, String prefix) {
          File folder = getFolderWithImages(context);
 -        File[] files = folder.listFiles(pathname -> pathname.getName().startsWith(prefix));
 +        if (!folder.exists()) return;
  
+-        for (File f : Objects.requireNonNull(files)) {
 +        File[] files = folder.listFiles(pathname -> pathname.getName().startsWith(prefix));
-         for (File f : Objects.requireNonNull(files)) {
++        if (files == null) return;
++        for (File f : files) {
              f.delete();
          }
+     }


### PR DESCRIPTION
## Problem

`NullPointerException` crash in `java.util.Objects.throwNullPointerException`, triggered from `RNWidgetImageProvider.deleteImages()` in the Android widget image cleanup path.

**Sentry:** https://gumroad-to.sentry.io/issues/7448415790/
**Occurrences:** 1 (first seen 2026-04-29)
**Estimated affected users/month:** Low (new issue, 1 occurrence so far)
**Estimated support tickets/month:** 0

## Root cause

`File.listFiles()` can return `null` even when the folder exists (e.g., permission issues, race conditions, or if the path isn't actually a directory). The previous patch (from an earlier fix) added a `folder.exists()` guard but still wrapped the result in `Objects.requireNonNull(files)`, which throws `NullPointerException` when `listFiles()` returns `null`.

## Fix

Replace `Objects.requireNonNull(files)` with an early `if (files == null) return;`, removing the crash path entirely. The widget cleanup simply becomes a no-op when the file listing fails, which is the correct behavior (nothing to clean up).

## Testing

- All 111 existing tests pass
- Patch applies cleanly via `patch-package`