### PR TITLE
Fix JSApplicationIllegalArgumentException: animated node race condition on startup

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from "@/lib/auth-context";
-import { Redirect } from "expo-router";
+import { useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
 
@@ -7,6 +7,7 @@ SplashScreen.preventAutoHideAsync();
 
 export default function Index() {
   const { isLoading, isAuthenticated, isCreator } = useAuth();
+  const router = useRouter();
 
   useEffect(() => {
     if (!isLoading) {
@@ -14,13 +15,24 @@ export default function Index() {
     }
   }, [isLoading]);
 
-  if (isLoading) {
-    return null;
-  }
+  useEffect(() => {
+    if (isLoading) return;
 
-  if (!isAuthenticated) {
-    return <Redirect href="/login" />;
-  }
+    // Defer navigation to the next frame so react-native-screens can finish
+    // registering its onTransitionProgress Animated.event on the current screen.
+    // Without this, on low-end Android devices the NativeAnimatedModule may try
+    // to add events to a view that has already been removed from the Fabric tree,
+    // causing: "addAnimatedEventToView: Animated node with tag [N] does not exist"
+    const id = requestAnimationFrame(() => {
+      if (!isAuthenticated) {
+        router.replace("/login");
+      } else {
+        router.replace(isCreator ? "/(tabs)/dashboard" : "/(tabs)/library");
+      }
+    });
 
-  return <Redirect href={isCreator ? "/(tabs)/dashboard" : "/(tabs)/library"} />;
+    return () => cancelAnimationFrame(id);
+  }, [isLoading, isAuthenticated, isCreator, router]);
+
+  return null;
 }

--- a/components/ui/loading-spinner.tsx
+++ b/components/ui/loading-spinner.tsx
@@ -2,7 +2,14 @@ import rainbowSvg from "@/assets/images/loading-rainbow.svg";
 import { Image } from "expo-image";
 import { useEffect } from "react";
 import { View, ViewProps } from "react-native";
-import Animated, { Easing, useAnimatedStyle, useSharedValue, withRepeat, withTiming } from "react-native-reanimated";
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
 
 const AnimatedImage = Animated.createAnimatedComponent(Image);
 
@@ -15,6 +22,9 @@ export const LoadingSpinner = ({ size = "large", ...props }: LoadingSpinnerProps
 
   useEffect(() => {
     rotation.value = withRepeat(withTiming(360, { duration: 1000, easing: Easing.linear }), -1, false);
+    return () => {
+      cancelAnimation(rotation);
+    };
   }, [rotation]);
 
   const animatedStyle = useAnimatedStyle(() => ({

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -37,6 +37,7 @@ jest.mock("react-native-reanimated", () => {
     withTiming: (v: unknown) => v,
     withSpring: (v: unknown) => v,
     withRepeat: (v: unknown) => v,
+    cancelAnimation: jest.fn(),
     withSequence: (...args: unknown[]) => args[0],
     withDelay: (_: unknown, v: unknown) => v,
     Easing: { inOut: jest.fn(), in: jest.fn(), out: jest.fn(), bezier: jest.fn() },

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -1,0 +1,101 @@
+import { render, act } from "@testing-library/react-native";
+
+const mockReplace = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+jest.mock("expo-splash-screen", () => ({
+  preventAutoHideAsync: jest.fn(),
+  hideAsync: jest.fn(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+import Index from "@/app/index";
+
+describe("Index", () => {
+  let rafCallbacks: Array<() => void>;
+  let originalRAF: typeof globalThis.requestAnimationFrame;
+  let originalCAF: typeof globalThis.cancelAnimationFrame;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rafCallbacks = [];
+    originalRAF = globalThis.requestAnimationFrame;
+    originalCAF = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = jest.fn((cb: FrameRequestCallback) => {
+      rafCallbacks.push(() => cb(0));
+      return rafCallbacks.length;
+    }) as unknown as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = jest.fn();
+  });
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRAF;
+    globalThis.cancelAnimationFrame = originalCAF;
+  });
+
+  it("returns null while loading", () => {
+    mockUseAuth.mockReturnValue({ isLoading: true, isAuthenticated: false, isCreator: false });
+    const { toJSON } = render(<Index />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("returns null after loading (no Redirect component)", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: true });
+    const { toJSON } = render(<Index />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it("does not navigate synchronously", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: false, isCreator: false });
+    render(<Index />);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("navigates to /login for unauthenticated users after requestAnimationFrame", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: false, isCreator: false });
+    render(<Index />);
+
+    act(() => {
+      rafCallbacks.forEach((cb) => cb());
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/login");
+  });
+
+  it("navigates to /(tabs)/dashboard for creators", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: true });
+    render(<Index />);
+
+    act(() => {
+      rafCallbacks.forEach((cb) => cb());
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/dashboard");
+  });
+
+  it("navigates to /(tabs)/library for non-creators", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
+    render(<Index />);
+
+    act(() => {
+      rafCallbacks.forEach((cb) => cb());
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+  });
+
+  it("cancels animation frame on unmount", () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: true });
+    const { unmount } = render(<Index />);
+
+    unmount();
+
+    expect(globalThis.cancelAnimationFrame).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a crash on low-end Android devices where `NativeAnimatedNodesManager` throws `JSApplicationIllegalArgumentException: addAnimatedEventToView: Animated node with tag [N] does not exist` during startup navigation.

**Sentry:** https://gumroad-to.sentry.io/issues/7449002858/
**Stats:** 1 occurrence, 1 user affected, first seen 2026-04-29
**Device:** Redmi A1, Android 12
**Estimated support tickets:** 0 (fatal crash before user interaction)

## Root cause

`react-native-screens` registers `Animated.event` with `useNativeDriver: true` for `onTransitionProgress` on every native stack screen. When `app/index.tsx` renders `<Redirect>` synchronously after auth finishes loading, the screen unmounts before the native animated module finishes processing the batched `addAnimatedEventToView` command — a race condition that manifests on low-end devices.

## Changes

- **`app/index.tsx`**: Replace synchronous `<Redirect>` with `router.replace()` inside a `useEffect`, deferred by one frame via `requestAnimationFrame`. This gives the native animated module time to process its queue before the view is removed.
- **`components/ui/loading-spinner.tsx`**: Add `cancelAnimation` cleanup to the rotation `useEffect` to prevent animation leaks on unmount.
- **`jest.setup.ts`**: Add `cancelAnimation` to the reanimated mock.
- **`tests/app/index.test.tsx`**: New test suite verifying deferred navigation behavior, correct routing based on auth state, and cleanup on unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)