### PR TITLE
Patch expo-font to catch CoreText NSException in font registration

### DIFF
--- a/patches/expo-font+55.0.4.patch
+++ b/patches/expo-font+55.0.4.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/expo-font/ios/FontUtils.swift b/node_modules/expo-font/ios/FontUtils.swift
+index cc376af..99b5c4e 100644
+--- a/node_modules/expo-font/ios/FontUtils.swift
++++ b/node_modules/expo-font/ios/FontUtils.swift
+@@ -1,4 +1,5 @@
+ import CoreGraphics
++import ExpoModulesCore
+ 
+ /**
+  * Queries custom native font names from the Info.plist `UIAppFonts`.
+@@ -51,8 +52,15 @@ internal func loadFont(fromUrl url: CFURL, alias: String) throws -> CGFont {
+  */
+ internal func registerFont(fontUrl: CFURL, fontFamilyAlias: String) throws {
+   var error: Unmanaged<CFError>?
++  var didRegister = true
+ 
+-  if !CTFontManagerRegisterFontsForURL(fontUrl, .process, &error), let error = error?.takeRetainedValue() {
++  // CTFontManager can throw NSInvalidArgumentException on corrupted font metadata,
++  // and Swift's try/catch cannot catch ObjC exceptions.
++  try EXUtilities.catchException {
++    didRegister = CTFontManagerRegisterFontsForURL(fontUrl, .process, &error)
++  }
++
++  if !didRegister, let error = error?.takeRetainedValue() {
+     let fontError = CTFontManagerError(rawValue: CFErrorGetCode(error))
+ 
+     switch fontError {


### PR DESCRIPTION
Fixes #216

## What

Adds a `patch-package` patch on `expo-font` (v55.0.4) that wraps the `CTFontManagerRegisterFontsForURL` call in `FontUtils.swift` with `EXUtilities.catchException { … }`. If CoreText raises an Objective-C `NSException` (e.g. `NSInvalidArgumentException` from a malformed font's internal face metadata), it's converted into a Swift-throwable `NSError` and surfaces to JS as a normal `Font.loadAsync` rejection.

## Why

Swift's `do/try/catch` cannot catch ObjC exceptions, so the original `registerFont` only handles the `CFError` out-parameter. CoreText can `@throw` an `NSException` from inside `[__NSPlaceholderSet initWithObjects:count:]` when face metadata contains a nil entry — and that escapes uncatchable, killing the app (the exact crash in the linked Sentry report).

`EXUtilities.catchException` is the existing ObjC try/catch helper in `expo-modules-core`, already used for the same purpose in `expo-background-fetch`, `expo-notifications`, and `expo-modules-core`'s own JS runtime.

## Test Results

Verified end-to-end by injecting a synthetic `NSInvalidArgumentException` (the same exception class as the Sentry crash) inside the wrapped `EXUtilities.catchException` block and rebuilding for iOS Simulator. With the patch applied, the exception is caught and surfaces in JS as a promise rejection (`Uncaught (in promise) Error: The operation couldn't be completed. (NSInvalidArgumentException error 0.)`). The app process keeps running. Without the patch, the same exception is fatal.

Reproducing the original Sentry crash requires the specific corrupted font file from the affected user's device. The synthetic test exercises the identical exception class through the native call path.

---

This PR was implemented with AI assistance using Claude Opus 4.7.