### PR TITLE
Fix PDF hyperlinks and indicator tap-through

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -16,6 +16,7 @@ import { useEffect, useRef, useState } from "react";
 import { Dimensions, Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import Pdf, { PdfRef, TableContent } from "react-native-pdf";
 import { cn } from "@/lib/utils";
+import { safeOpenURL } from "@/lib/open-url";
 import { Button } from "@/components/ui/button";
 
 export default function PdfViewerScreen() {
@@ -153,6 +154,7 @@ export default function PdfViewerScreen() {
           trustAllCerts={false}
           fitPolicy={0}
           enablePaging={viewMode === "single"}
+          enableAnnotationRendering
           horizontal={viewMode === "single"}
           page={initialPage ? Number(initialPage) : 1}
           onLoadComplete={(numberOfPages, _path, _size, toc) => {
@@ -160,6 +162,7 @@ export default function PdfViewerScreen() {
             setTableOfContents(toc ?? []);
           }}
           onPageChanged={(page) => setCurrentPage(page)}
+          onPressLink={(url) => safeOpenURL(url)}
           onError={(error) => {
             Sentry.captureException(error);
             console.error("PDF Error:", error);

--- a/components/page-indicator.tsx
+++ b/components/page-indicator.tsx
@@ -44,6 +44,7 @@ export const PageIndicator = ({
 
   return (
     <View
+      pointerEvents="box-none"
       className="absolute right-0 left-0 items-center"
       style={{
         bottom:

--- a/lib/open-url.ts
+++ b/lib/open-url.ts
@@ -1,16 +1,28 @@
 import { Alert, Linking } from "react-native";
 
+const isHttpUrl = (url: string) => /^https?:\/\//i.test(url);
+
+const showFallbackAlert = (url: string) => {
+  if (isHttpUrl(url)) {
+    Alert.alert("No browser found", "Please install a web browser to continue.");
+  } else {
+    Alert.alert("Couldn't open link", "No app is available to handle this link.");
+  }
+};
+
 export const safeOpenURL = async (url: string): Promise<boolean> => {
   try {
-    const canOpen = await Linking.canOpenURL(url);
-    if (!canOpen) {
-      Alert.alert("No browser found", "Please install a web browser to continue.");
-      return false;
+    if (isHttpUrl(url)) {
+      const canOpen = await Linking.canOpenURL(url);
+      if (!canOpen) {
+        showFallbackAlert(url);
+        return false;
+      }
     }
     await Linking.openURL(url);
     return true;
   } catch {
-    Alert.alert("No browser found", "Please install a web browser to continue.");
+    showFallbackAlert(url);
     return false;
   }
 };


### PR DESCRIPTION
Fixes #198

## What

Hyperlinks inside PDFs are tappable again, and tapping the area around the bottom page indicator no longer gets swallowed by its full-width wrapper.

## Why

Two regressions from the Apr 9-10 PDF navigation update:

- The `Pdf` component's `onPressLink` defaulted to a no-op, so tapping a link did nothing. Wired it up to the existing `safeOpenURL` helper.
- The `PageIndicator` is positioned absolutely across the full bottom of the screen. Its outer wrapper was intercepting touches in the empty space beside the chip, blocking page swipes and link taps that landed near the bottom of the page. Setting `pointerEvents="box-none"` lets touches fall through everywhere except on the chip itself.

Also set `enableAnnotationRendering` explicitly. The library default is already `true`, but the flag is explicit because the link-rendering layer is the surface this fix depends on.

## Test Results

https://github.com/user-attachments/assets/0f30cb55-6f5a-41b8-a8a4-f5ec2f1e43a7

---

This PR was implemented with AI assistance using Claude Opus 4.7.