### PR TITLE
Fix missing native PdfThumbnail module implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,7 @@ app-example
 /android
 /modules/*/ios
 !/modules/pdf-thumbnail/ios
+!/modules/pdf-thumbnail/ios/**
 /modules/*/android
 !/modules/pdf-thumbnail/android
+!/modules/pdf-thumbnail/android/**

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,6 @@ app-example
 /ios
 /android
 /modules/*/ios
+!/modules/pdf-thumbnail/ios
 /modules/*/android
+!/modules/pdf-thumbnail/android

--- a/modules/pdf-thumbnail/android/build.gradle
+++ b/modules/pdf-thumbnail/android/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'com.gumroad'
+version = '1.0.0'
+
+android {
+  namespace "expo.modules.pdfthumbnail"
+  defaultConfig {
+    versionCode 1
+    versionName '1.0.0'
+  }
+}

--- a/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
+++ b/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
@@ -23,35 +23,44 @@ class PdfThumbnailModule : Module() {
       }
 
       val descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
-      val renderer = PdfRenderer(descriptor)
+      try {
+        val renderer = PdfRenderer(descriptor)
+        try {
+          if (page < 0 || page >= renderer.pageCount) {
+            throw CodedException("ERR_PDF_PAGE", "Page $page not found in PDF", null)
+          }
 
-      if (page < 0 || page >= renderer.pageCount) {
-        renderer.close()
+          val pdfPage = renderer.openPage(page)
+          try {
+            val width = pdfPage.width
+            val height = pdfPage.height
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+            try {
+              bitmap.eraseColor(Color.WHITE)
+              pdfPage.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+
+              val outputFile = File(context.cacheDir, "pdf_thumb_${UUID.randomUUID()}.jpg")
+              FileOutputStream(outputFile).use { stream ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+              }
+
+              mapOf(
+                "uri" to Uri.fromFile(outputFile).toString(),
+                "width" to width,
+                "height" to height
+              )
+            } finally {
+              bitmap.recycle()
+            }
+          } finally {
+            pdfPage.close()
+          }
+        } finally {
+          renderer.close()
+        }
+      } finally {
         descriptor.close()
-        throw CodedException("ERR_PDF_PAGE", "Page $page not found in PDF", null)
       }
-
-      val pdfPage = renderer.openPage(page)
-      val width = pdfPage.width
-      val height = pdfPage.height
-      val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-      bitmap.eraseColor(Color.WHITE)
-      pdfPage.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-      pdfPage.close()
-      renderer.close()
-      descriptor.close()
-
-      val outputFile = File(context.cacheDir, "pdf_thumb_${UUID.randomUUID()}.jpg")
-      FileOutputStream(outputFile).use { stream ->
-        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
-      }
-      bitmap.recycle()
-
-      mapOf(
-        "uri" to Uri.fromFile(outputFile).toString(),
-        "width" to width,
-        "height" to height
-      )
     }
   }
 

--- a/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
+++ b/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
@@ -1,0 +1,75 @@
+package expo.modules.pdfthumbnail
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.pdf.PdfRenderer
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+class PdfThumbnailModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("PdfThumbnail")
+
+    AsyncFunction("generate") Coroutine { filePath: String, page: Int, quality: Int ->
+      val file = resolveFile(filePath)
+      if (!file.exists()) {
+        throw CodedException("ERR_PDF_OPEN", "Could not open PDF at $filePath", null)
+      }
+
+      val descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+      val renderer = PdfRenderer(descriptor)
+
+      if (page < 0 || page >= renderer.pageCount) {
+        renderer.close()
+        descriptor.close()
+        throw CodedException("ERR_PDF_PAGE", "Page $page not found in PDF", null)
+      }
+
+      val pdfPage = renderer.openPage(page)
+      val width = pdfPage.width
+      val height = pdfPage.height
+      val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+      bitmap.eraseColor(Color.WHITE)
+      pdfPage.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+      pdfPage.close()
+      renderer.close()
+      descriptor.close()
+
+      val outputFile = File(context.cacheDir, "pdf_thumb_${UUID.randomUUID()}.jpg")
+      FileOutputStream(outputFile).use { stream ->
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+      }
+      bitmap.recycle()
+
+      mapOf(
+        "uri" to Uri.fromFile(outputFile).toString(),
+        "width" to width,
+        "height" to height
+      )
+    }
+  }
+
+  private fun resolveFile(filePath: String): File {
+    if (filePath.startsWith("file://")) {
+      return File(Uri.parse(filePath).path!!)
+    }
+    if (filePath.startsWith("content://")) {
+      val inputStream = context.contentResolver.openInputStream(Uri.parse(filePath))
+        ?: throw CodedException("ERR_PDF_OPEN", "Could not open content URI: $filePath", null)
+      val tempFile = File(context.cacheDir, "pdf_input_${UUID.randomUUID()}.pdf")
+      inputStream.use { input ->
+        FileOutputStream(tempFile).use { output ->
+          input.copyTo(output)
+        }
+      }
+      return tempFile
+    }
+    return File(filePath)
+  }
+}

--- a/modules/pdf-thumbnail/ios/PdfThumbnail.podspec
+++ b/modules/pdf-thumbnail/ios/PdfThumbnail.podspec
@@ -1,0 +1,28 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'PdfThumbnail'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = 'Gumroad'
+  s.homepage       = 'https://github.com/antiwork/gumroad-mobile'
+  s.platforms      = {
+    :ios => '15.1'
+  }
+  s.swift_version  = '5.9'
+  s.source         = { :git => 'https://github.com/antiwork/gumroad-mobile.git' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = '**/*.{h,m,swift}'
+end

--- a/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
+++ b/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
@@ -1,5 +1,6 @@
 import ExpoModulesCore
 import PDFKit
+import UIKit
 
 public class PdfThumbnailModule: Module {
   public func definition() -> ModuleDefinition {

--- a/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
+++ b/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
@@ -1,0 +1,45 @@
+import ExpoModulesCore
+import PDFKit
+
+public class PdfThumbnailModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("PdfThumbnail")
+
+    AsyncFunction("generate") { (filePath: String, page: Int, quality: Int) -> [String: Any] in
+      guard let url = URL(string: filePath) ?? URL(fileURLWithPath: filePath) as URL?,
+            let document = PDFDocument(url: url) else {
+        throw Exception(name: "ERR_PDF_OPEN", description: "Could not open PDF at \(filePath)")
+      }
+
+      guard let pdfPage = document.page(at: page) else {
+        throw Exception(name: "ERR_PDF_PAGE", description: "Page \(page) not found in PDF")
+      }
+
+      let pageRect = pdfPage.bounds(for: .mediaBox)
+      let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+      let image = renderer.image { ctx in
+        UIColor.white.setFill()
+        ctx.fill(pageRect)
+        ctx.cgContext.translateBy(x: 0, y: pageRect.height)
+        ctx.cgContext.scaleBy(x: 1, y: -1)
+        pdfPage.draw(with: .mediaBox, to: ctx.cgContext)
+      }
+
+      let jpegQuality = CGFloat(quality) / 100.0
+      guard let data = image.jpegData(compressionQuality: jpegQuality) else {
+        throw Exception(name: "ERR_PDF_RENDER", description: "Failed to render page as JPEG")
+      }
+
+      let tempDir = FileManager.default.temporaryDirectory
+      let fileName = "pdf_thumb_\(UUID().uuidString).jpg"
+      let fileURL = tempDir.appendingPathComponent(fileName)
+      try data.write(to: fileURL)
+
+      return [
+        "uri": fileURL.absoluteString,
+        "width": Int(pageRect.width),
+        "height": Int(pageRect.height)
+      ]
+    }
+  }
+}

--- a/modules/pdf-thumbnail/package.json
+++ b/modules/pdf-thumbnail/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "pdf-thumbnail",
+  "version": "1.0.0",
+  "description": "Generates PDF page thumbnails for the Gumroad mobile app.",
+  "main": "index.ts",
+  "sideEffects": false,
+  "license": "MIT",
+  "peerDependencies": {
+    "expo": "*"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds native Swift (iOS) and Kotlin (Android) implementations for the `PdfThumbnail` Expo module, which were missing from PR #174
- iOS uses `PDFKit` to render PDF pages to JPEG temp files
- Android uses `PdfRenderer` to render PDF pages to JPEG temp files
- Updates `.gitignore` to track the `pdf-thumbnail` native source files

Fixes the Sentry crash: https://gumroad-to.sentry.io/issues/7450007603/

The `expo-module.config.json` and `index.ts` wrapper were added in #174 but the actual native Swift/Kotlin code was never included, causing a `Cannot find native module 'PdfThumbnail'` error whenever the PDF navigation sheet tries to generate page thumbnails.

## Test plan

- [x] All 111 existing tests pass (`npx jest`)
- [ ] Open a product with a PDF file attachment on iOS — verify thumbnails render in the navigation sheet
- [ ] Open a product with a PDF file attachment on Android — verify thumbnails render in the navigation sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)