### PR TITLE
Fix EXC_BAD_ACCESS crash in Hermes GC writeBarrierSlow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "expo-widgets": "^55.0.8",
         "react": "19.2.0",
         "react-dom": "19.2.0",
-        "react-native": "0.83.4",
+        "react-native": "0.83.5",
         "react-native-android-widget": "^0.20.1",
         "react-native-blob-util": "0.24.7",
         "react-native-context-menu-view": "^1.21.0",
@@ -3200,9 +3200,9 @@
       "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.83.4.tgz",
-      "integrity": "sha512-aqKtpbJDSQeSX/Dwv0yMe1/Rd2QfXi12lnyZDXNn/OEKz59u6+LuPBVgO/9CRyclHmdlvwg8c7PJ9eX2ZMnjWg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.83.5.tgz",
+      "integrity": "sha512-8mrWC9cTx8WxopBC2/DwGJhxeGNTedOcMK1qtNq/DpSpOkscU9w2ssHpybxPrJc81/eik6zUmRbSi5FiPKMaMA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
@@ -3323,12 +3323,12 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.4.tgz",
-      "integrity": "sha512-8os0weQEnjUhWy7Db881+JKRwNHVGM40VtTRvltAyA/YYkrGg4kPCqiTybMxQDEcF3rnviuxHyI+ITiglfmgmQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.5.tgz",
+      "integrity": "sha512-uLtxUmGzz1LEohcpKrTtGKNfjalAHQzrjZTtTLp/8EzUtMIhWnOXq4ZmJsvhS5hjQ6uQASuefJEklxK1QtnmHQ==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.83.4",
+        "@react-native/dev-middleware": "0.83.5",
         "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "metro": "^0.83.3",
@@ -3350,6 +3350,51 @@
         "@react-native/metro-config": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.83.5.tgz",
+      "integrity": "sha512-2C66I7PwqbZm6BKGu+BY/jqIHq0IJs2L2bn8dQ9CeS89V9VKBmgQq5FcpkJy1eL9GdJNOWB846Fj/d9avIH51w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-shell": {
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.83.5.tgz",
+      "integrity": "sha512-adqmqfN1DmnJzNMkh3AbXGThsTkn6laLxiIob3o0p9sMW5ePpqMkU45DgSSeXAZ29opTWso6giTfHdYHyO4XPA==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.83.5.tgz",
+      "integrity": "sha512-bx2EZ2QpBM9mJAPPidw5d/xJFBx/8dEePtRYrkVsoL9+px91bZSIgtkqpAtMslVeeyAkwfj+HND0uT4sgSAU2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/ttlcache": "^1.4.1",
+        "@react-native/debugger-frontend": "0.83.5",
+        "@react-native/debugger-shell": "0.83.5",
+        "chrome-launcher": "^0.15.2",
+        "chromium-edge-launcher": "^0.2.0",
+        "connect": "^3.6.5",
+        "debug": "^4.4.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "open": "^7.0.3",
+        "serve-static": "^1.16.2",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
@@ -3410,18 +3455,18 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.4.tgz",
-      "integrity": "sha512-AhaSWw2k3eMKqZ21IUdM7rpyTYOpAfsBbIIiom1QQii3QccX0uW2AWTcRhfuWRxqr2faGFaOBYedWl2fzp5hgw==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.5.tgz",
+      "integrity": "sha512-5VH/cF57QMtScFEKgtRUZ0hHfME8JpUG/OBJpokSDxuJ+pCB7XRBaLO29bOIWFW9NAMef9dwRNWDo5j4co0ZUw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.83.4.tgz",
-      "integrity": "sha512-wYUdv0rt4MjhKhQloO1AnGDXhZQOFZHDxm86dEtEA0WcsCdVrFdRULFM+rKUC/QQtJW2rS6WBqtBusgtrsDADg==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.83.5.tgz",
+      "integrity": "sha512-V3rT5wqOoAcEtK4v9Nv2Bh0yVEE5YpsPFTGk9JNYzHORa9BRx7keoagkcV+QMoVlxxA/ZerpUCMwkmf8RLwTuw==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.4"
@@ -14553,19 +14598,19 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.4.tgz",
-      "integrity": "sha512-H5Wco3UJyY6zZsjoBayY8RM9uiAEQ3FeG4G2NAt+lr9DO43QeqPlVe9xxxYEukMkEmeIhNjR70F6bhXuWArOMQ==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.5.tgz",
+      "integrity": "sha512-5+odG/qcN5JrC6zco3ko+9QIl8lmicwJPGT3Jw0FXbF0mW8scSvhXYbZI3CbV5OYYRwZwS5fD2xNy4jjbuwM8w==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.83.4",
-        "@react-native/codegen": "0.83.4",
-        "@react-native/community-cli-plugin": "0.83.4",
-        "@react-native/gradle-plugin": "0.83.4",
-        "@react-native/js-polyfills": "0.83.4",
-        "@react-native/normalize-colors": "0.83.4",
-        "@react-native/virtualized-lists": "0.83.4",
+        "@react-native/assets-registry": "0.83.5",
+        "@react-native/codegen": "0.83.5",
+        "@react-native/community-cli-plugin": "0.83.5",
+        "@react-native/gradle-plugin": "0.83.5",
+        "@react-native/js-polyfills": "0.83.5",
+        "@react-native/normalize-colors": "0.83.5",
+        "@react-native/virtualized-lists": "0.83.5",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
@@ -14981,10 +15026,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-native/node_modules/@react-native/codegen": {
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.5.tgz",
+      "integrity": "sha512-nxpxtrQipKFrn11ptUYLh7E046iA0wrXUVsF2V7ex+StJMXIEdGxN5oPiP99P2uhHEaq8VaF4XuP2+M59Uctgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.2",
+        "@babel/parser": "^7.25.3",
+        "glob": "^7.1.1",
+        "hermes-parser": "0.32.0",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "*"
+      }
+    },
+    "node_modules/react-native/node_modules/@react-native/normalize-colors": {
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.5.tgz",
+      "integrity": "sha512-oi/yk+8WPwOBsWNmJNMtOUz8BdTA7ttPRnPpGqwc4+sgZ5M2RSfptwLVdxq2/QJecsl3R/NZ6MMiA1FiDLXffA==",
+      "license": "MIT"
+    },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.83.4",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.83.4.tgz",
-      "integrity": "sha512-vNF/8kokMW8JEjG4n+j7veLTjHRRABlt4CaTS6+wtqzvWxCJHNIC8fhCqrDPn9fIn8sNePd8DyiFVX5L9TBBRA==",
+      "version": "0.83.5",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.83.5.tgz",
+      "integrity": "sha512-UaQXVha3VES8DDzS+Qe0alErGdBzrGo8/1F60a5OYg/JhD3iy0QzDfAWs49Js9OlTeVvSZmIbv7WAcLmZMnzNA==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expo-widgets": "^55.0.8",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-native": "0.83.4",
+    "react-native": "0.83.5",
     "react-native-android-widget": "^0.20.1",
     "react-native-blob-util": "0.24.7",
     "react-native-context-menu-view": "^1.21.0",


### PR DESCRIPTION
## Problem

Fatal crash (`EXC_BAD_ACCESS` / `KERN_INVALID_ADDRESS at 0x10`) in `hermes::vm::HadesGC::writeBarrierSlow` on iOS.

**Sentry:** https://gumroad-to.sentry.io/issues/7450245063/
**Events (7-day):** 1 | **Users affected:** 1
**Estimated monthly tickets:** ~0 (single occurrence so far)

## Root Cause

This is a known upstream React Native bug ([facebook/react-native#54859](https://github.com/facebook/react-native/issues/54859)). When an async void TurboModule method throws an `NSException`, the catch block in `RCTTurboModule.mm` calls `convertNSExceptionToJSError` which tries to set properties on a JS object from the wrong thread. This triggers a Hermes GC write barrier crash because the GC isn't expecting mutations from a non-JS thread.

The crash path:
```
ObjCTurboModule::performVoidMethodInvocation
→ TurboModuleConvertUtils::convertNSExceptionToJSError
→ jsi::Object::setProperty (wrong thread)
→ HiddenClass::initializeMissingPropertyMap
→ HadesGC::writeBarrierSlow → KERN_INVALID_ADDRESS
```

## Fix

Bump `react-native` from `0.83.4` → `0.83.5`, which includes the upstream fix ([a9a976a](https://github.com/facebook/react-native/commit/a9a976af89c3cd52e7f742109e24dbc6ebf09aa9) by @fabriziocucci). The fix re-throws the `NSException` instead of converting it to a `JSError` on the wrong thread.

## Changes

- `package.json`: react-native 0.83.4 → 0.83.5
- `package-lock.json`: updated lockfile