### PR TITLE
Fix missing library and sale-item thumbnails

### DIFF
--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -13,7 +13,7 @@ import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import { cn } from "@/lib/utils";
-import { Image } from "expo-image";
+import { StyledImage as Image } from "@/components/styled";
 import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback, useMemo, useRef } from "react";
 import {

--- a/components/dashboard/sale-item.tsx
+++ b/components/dashboard/sale-item.tsx
@@ -1,6 +1,6 @@
 import { SalePurchase } from "@/components/dashboard/use-sales-analytics";
 import { Text } from "@/components/ui/text";
-import { Image } from "expo-image";
+import { StyledImage as Image } from "@/components/styled";
 import { TouchableOpacity, View } from "react-native";
 import { Badge } from "../ui/badge";
 


### PR DESCRIPTION
## What

Product thumbnails and creator avatars stopped rendering on the Library tab (carousel and list rows) and on the Dashboard sale items. The `<Image>` elements were collapsing to 0×0 because their `className` props were being silently dropped.

This switches both files to import the existing `StyledImage` wrapper (`withUniwind(Image)` from `components/styled.tsx`) so Uniwind/Tailwind class names like `size-17`, `absolute inset-0`, and `rounded-full` actually take effect.

## Why

PR #206 swapped React Native's `Image` for `expo-image` to fix a main-thread hang. `expo-image` doesn't natively understand Uniwind class names, so any `<Image className="…">` rendered with no width/height. Two screens still imported `Image` directly from `expo-image` and so lost their thumbnails. The project already has a `StyledImage = withUniwind(Image)` wrapper for exactly this reason — most callers already use it; these two were missed.

## Before/After

Before:

<img width="480" src="https://github.com/user-attachments/assets/7ceb4a1e-4266-40e8-aa4b-362b0e8ca493" />

After:

<img width="380" src="https://github.com/user-attachments/assets/0d0d342c-b3c8-4840-afb1-cfa5cb85fe9e" />

---

This PR was implemented with AI assistance using Claude Opus 4.7.