### PR TITLE
Fix background ANR in Coil ImageLoader lazy disk cache init

### DIFF
--- a/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
+++ b/patches/react-native-track-player+5.0.0-alpha0-nightly-359af5a12d712d3b685530aed9b9625865a25d74.patch
@@ -74,7 +74,7 @@ index b495b5a..15739da 100644
              // https://github.com/androidx/media/issues/1218
              .setSessionActivity(
 diff --git a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/utils/CoilBitmapLoader.kt b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/utils/CoilBitmapLoader.kt
-index d85e2c7..3195f7b 100644
+index d85e2c7..7c0f99f 100644
 --- a/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/utils/CoilBitmapLoader.kt
 +++ b/node_modules/react-native-track-player/android/src/main/java/com/doublesymmetry/trackplayer/utils/CoilBitmapLoader.kt
 @@ -10,6 +10,7 @@ import androidx.media3.common.util.BitmapLoader
@@ -85,21 +85,25 @@ index d85e2c7..3195f7b 100644
  import coil.request.ImageRequest
  import com.google.common.util.concurrent.ListenableFuture
  import jp.wasabeef.transformers.coil.CropSquareTransformation
-@@ -27,7 +28,17 @@ class CoilBitmapLoader @Inject constructor(
+@@ -27,7 +28,21 @@ class CoilBitmapLoader @Inject constructor(
  ) : BitmapLoader {
  
      private val scope = MainScope()
 -    private val imageLoader = ImageLoader(context)
 +    // Disable the weak reference memory cache to prevent background ANR
 +    // in RealWeakMemoryCache.cleanUp which can block for 5+ seconds.
-+    // The disk cache and strong memory cache still provide adequate caching
-+    // for notification artwork.
++    // Disable disk cache to prevent background ANR when onTrimMemory
++    // triggers lazy disk cache initialization on the main thread
++    // (RealImageLoader.onTrimMemory -> SynchronizedLazyImpl.getValue).
++    // The strong memory cache still provides adequate caching for
++    // notification artwork.
 +    private val imageLoader = ImageLoader.Builder(context)
 +        .memoryCache {
 +            MemoryCache.Builder(context)
 +                .weakReferencesEnabled(false)
 +                .build()
 +        }
++        .diskCache(null)
 +        .build()
  
      override fun supportsMimeType(mimeType: String): Boolean {


### PR DESCRIPTION
## Problem

Background ANR caused by Coil's `RealImageLoader` lazily initializing its disk cache on the main thread when Android's `onTrimMemory` fires.

**Stacktrace:**
```
android.app.Application.onTrimMemory
→ coil.util.SystemCallbacks.onTrimMemory
→ coil.RealImageLoader.onTrimMemory
→ kotlin.SynchronizedLazyImpl.getValue  ← lazy disk cache init
→ coil.ImageLoader$Builder$build$1.invoke
```

## Root cause

`CoilBitmapLoader` (used by react-native-track-player for notification artwork) builds a Coil `ImageLoader` with a disk cache that's lazily initialized. When Android triggers `onTrimMemory` in the background before the disk cache has been accessed, the lazy init runs synchronously on the main thread. Disk cache setup involves filesystem I/O, which is slow enough to trigger an ANR.

## Fix

Disable the disk cache entirely via `.diskCache(null)` on the `ImageLoader.Builder`. The strong memory cache is sufficient for notification artwork (small images loaded once per track), and removing the disk cache eliminates the lazy initialization path that causes the ANR.

This builds on the existing patch that already disabled weak reference memory caching for a similar ANR issue.

## Sentry

- Issue: https://gumroad-to.sentry.io/issues/7450398855/
- Occurrences (7d): 1
- Users affected: 1
- Priority: High (fatal level, Background ANR)
- Fixability score: 0.29

## Testing

- All 111 existing tests pass
- This is a library-level Android fix (Coil config change in a patch-package patch), not directly unit-testable from the JS test suite
- The ANR path is triggered by Android's memory management system calling `onTrimMemory` when the app is backgrounded, which can't be replicated in local dev