### PR TITLE
Fix Background ANR in Android widget update handler

### DIFF
--- a/components/revenue-widget-android-handler.tsx
+++ b/components/revenue-widget-android-handler.tsx
@@ -12,6 +12,12 @@ interface RevenueTotalsResponse {
   year: { formatted_revenue: string };
 }
 
+// Android widget updates run as headless tasks triggered by broadcast intents.
+// The system enforces a ~5 s background ANR timeout, so network requests must
+// complete well within that window to avoid "Background ANR" crashes.
+// See: https://gumroad-to.sentry.io/issues/7450709376/
+const WIDGET_REQUEST_TIMEOUT_MS = 4_000;
+
 const renderRevenueWidget = async () => {
   const accessToken = await SecureStore.getItemAsync("gumroad_access_token");
 
@@ -21,9 +27,13 @@ const renderRevenueWidget = async () => {
 
   try {
     const url = buildApiUrl("mobile/analytics/revenue_totals.json");
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), WIDGET_REQUEST_TIMEOUT_MS);
     const data = await request<RevenueTotalsResponse>(url, {
       headers: { Authorization: `Bearer ${accessToken}` },
+      signal: controller.signal,
     });
+    clearTimeout(timeoutId);
 
     return (
       <RevenueWidgetAndroid

--- a/tests/components/revenue-widget-android-handler.test.tsx
+++ b/tests/components/revenue-widget-android-handler.test.tsx
@@ -1,0 +1,115 @@
+// --- Mocks (must be defined before require) ---
+let mockSecureStoreToken: string | null = "test-access-token";
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(() => Promise.resolve(mockSecureStoreToken)),
+}));
+
+const mockRenderWidget = jest.fn();
+let registeredHandler: ((props: any) => Promise<void>) | null = null;
+jest.mock("react-native-android-widget", () => ({
+  registerWidgetTaskHandler: jest.fn((handler: any) => {
+    registeredHandler = handler;
+  }),
+}));
+
+jest.mock("@/components/revenue-widget-android", () => ({
+  RevenueWidgetAndroid: (props: any) => props,
+}));
+
+// Import after mocks so the module-level registerWidgetTaskHandler captures our mock.
+require("@/components/revenue-widget-android-handler");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSecureStoreToken = "test-access-token";
+});
+
+const triggerWidgetUpdate = () =>
+  registeredHandler!({ widgetAction: "WIDGET_UPDATE", renderWidget: mockRenderWidget });
+
+/** Extract props from the JSX element passed to renderWidget */
+const renderedProps = () => mockRenderWidget.mock.calls[0][0].props;
+
+describe("revenue-widget-android-handler", () => {
+  it("registers a widget task handler", () => {
+    expect(registeredHandler).toBeDefined();
+  });
+
+  it("renders logged-out state when no access token", async () => {
+    mockSecureStoreToken = null;
+    await triggerWidgetUpdate();
+
+    expect(mockRenderWidget).toHaveBeenCalledTimes(1);
+    expect(renderedProps()).toMatchObject({ isLoggedIn: false, hasError: false });
+  });
+
+  it("renders revenue data on successful fetch", async () => {
+    jest.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          day: { formatted_revenue: "$100" },
+          week: { formatted_revenue: "$500" },
+          month: { formatted_revenue: "$2,000" },
+          year: { formatted_revenue: "$10,000" },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await triggerWidgetUpdate();
+
+    expect(mockRenderWidget).toHaveBeenCalledTimes(1);
+    expect(renderedProps()).toMatchObject({
+      today: "$100",
+      week: "$500",
+      month: "$2,000",
+      year: "$10,000",
+      isLoggedIn: true,
+      hasError: false,
+    });
+  });
+
+  it("renders error state when fetch fails", async () => {
+    jest.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+    await triggerWidgetUpdate();
+
+    expect(mockRenderWidget).toHaveBeenCalledTimes(1);
+    expect(renderedProps()).toMatchObject({ isLoggedIn: true, hasError: true });
+  });
+
+  it(
+    "aborts the request and renders error state when it exceeds the widget timeout",
+    async () => {
+      jest.useFakeTimers();
+
+      // fetch that never resolves until its signal is aborted
+      jest.spyOn(globalThis, "fetch").mockImplementationOnce(
+        (_url, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            if (signal?.aborted) {
+              reject(new DOMException("Aborted", "AbortError"));
+              return;
+            }
+            signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError")),
+            );
+          }),
+      );
+
+      const updatePromise = triggerWidgetUpdate();
+
+      // Advance past the 4 s widget timeout (and the 30 s default request timeout)
+      await jest.advanceTimersByTimeAsync(31_000);
+
+      await updatePromise;
+
+      expect(mockRenderWidget).toHaveBeenCalledTimes(1);
+      expect(renderedProps()).toMatchObject({ isLoggedIn: true, hasError: true });
+
+      jest.useRealTimers();
+    },
+    35_000,
+  );
+});


### PR DESCRIPTION
## Problem

The Android revenue widget's `registerWidgetTaskHandler` makes a network request to fetch revenue totals using the default 30-second timeout. When Android triggers a widget update broadcast while the app is in the background, the system enforces a ~5-second ANR deadline. A slow or unresponsive network causes the request to block past this deadline, producing a **Background ANR for at least 5000 ms** (`android.os.MessageQueue.nativePollOnce`).

**Sentry issue:** https://gumroad-to.sentry.io/issues/7450709376/

## Fix

Added a 4-second `AbortController` timeout to the widget handler's fetch call. If the network request doesn't complete within 4 seconds, it aborts and the widget gracefully renders its error state instead of blocking the main thread past the ANR threshold.

## Changes

- `components/revenue-widget-android-handler.tsx`: Added `WIDGET_REQUEST_TIMEOUT_MS` (4 s) with an `AbortController` that aborts the fetch before the system ANR deadline
- `tests/components/revenue-widget-android-handler.test.tsx`: New test suite covering logged-out state, successful fetch, error state, and timeout abort behavior

## Testing

All 116 tests pass (15 suites), including 5 new tests for the widget handler.