### PR TITLE
Fix ReferenceError: DOMException doesn't exist in Hermes runtime

### DIFF
--- a/lib/media-location.ts
+++ b/lib/media-location.ts
@@ -43,7 +43,7 @@ export const updateMediaLocation = async ({
     console.warn("Failed to update media location:", error);
     // AbortError is expected when requests timeout (e.g. poor connectivity)
     // during periodic background sync - no need to report to Sentry
-    if (!(error instanceof DOMException && error.name === "AbortError")) {
+    if (!(error instanceof Error && error.name === "AbortError")) {
       Sentry.captureException(error);
     }
   }

--- a/tests/lib/media-location.test.ts
+++ b/tests/lib/media-location.test.ts
@@ -50,7 +50,8 @@ const jsonResponse = (status = 200) =>
 
 describe("updateMediaLocation", () => {
   it("does not report AbortError to Sentry", async () => {
-    const abortError = new DOMException("Aborted", "AbortError");
+    const abortError = new Error("Aborted");
+    abortError.name = "AbortError";
     mockFetch.mockRejectedValueOnce(abortError);
 
     await updateMediaLocation(defaultParams);


### PR DESCRIPTION
## Summary

- **Bug**: `ReferenceError: Property 'DOMException' doesn't exist` thrown in `updateMediaLocation` catch block when a request times out via `AbortController`
- **Root cause**: `DOMException` is a Web API that doesn't exist in React Native's Hermes engine. The catch block referenced it with `error instanceof DOMException`, which throws a `ReferenceError` instead of catching the abort gracefully
- **Fix**: Replace `instanceof DOMException` with `instanceof Error` — abort errors in both browser and React Native environments extend `Error` and have `name === "AbortError"`

## Details

**Sentry issue**: https://gumroad-to.sentry.io/issues/7450749551/

| Metric | Value |
|---|---|
| Occurrences | 1 (first seen) |
| Estimated users affected | Low (only triggered on request timeouts) |
| Estimated support tickets | 0 (silent crash, non-critical sync) |

## Test plan

- [x] Updated test to use plain `Error` with `name = "AbortError"` instead of `DOMException` (mirrors what Hermes actually throws)
- [x] All existing media-location tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)