### PR TITLE
Fix TypeError: Cannot read property 'interval' of null in track-player-service

### DIFF
--- a/components/track-player-service.ts
+++ b/components/track-player-service.ts
@@ -46,12 +46,14 @@ export const playbackService = async () => {
     if (index !== undefined && index > 0) await TrackPlayer.skipToPrevious();
   });
 
-  TrackPlayer.addEventListener(Event.RemoteJumpForward, async ({ interval }) => {
+  TrackPlayer.addEventListener(Event.RemoteJumpForward, async (event) => {
+    const interval = event?.interval ?? 30;
     const { position } = await TrackPlayer.getProgress();
     await TrackPlayer.seekTo(position + interval);
   });
 
-  TrackPlayer.addEventListener(Event.RemoteJumpBackward, async ({ interval }) => {
+  TrackPlayer.addEventListener(Event.RemoteJumpBackward, async (event) => {
+    const interval = event?.interval ?? 15;
     const { position } = await TrackPlayer.getProgress();
     await TrackPlayer.seekTo(Math.max(0, position - interval));
   });

--- a/tests/components/track-player-service.test.ts
+++ b/tests/components/track-player-service.test.ts
@@ -1,4 +1,3 @@
-// Capture event handlers registered by playbackService
 const eventHandlers: Record<string, (event: unknown) => Promise<void>> = {};
 
 jest.mock("react-native-track-player", () => ({
@@ -54,40 +53,45 @@ const mockTrackPlayer = TrackPlayer as jest.Mocked<typeof TrackPlayer>;
 
 describe("playbackService", () => {
   beforeEach(async () => {
+    jest.useFakeTimers();
     jest.clearAllMocks();
     Object.keys(eventHandlers).forEach((key) => delete eventHandlers[key]);
     (mockTrackPlayer.getProgress as jest.Mock).mockResolvedValue({ position: 60, duration: 300 });
     await playbackService();
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("handles RemoteJumpForward with a normal event payload", async () => {
     await eventHandlers["remote-jump-forward"]({ interval: 30 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
   });
 
   it("handles RemoteJumpForward when event is null", async () => {
     await eventHandlers["remote-jump-forward"](null);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30 (default)
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
   });
 
   it("handles RemoteJumpForward when event is undefined", async () => {
     await eventHandlers["remote-jump-forward"](undefined);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30 (default)
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
   });
 
   it("handles RemoteJumpBackward with a normal event payload", async () => {
     await eventHandlers["remote-jump-backward"]({ interval: 15 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45); // 60 - 15
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45);
   });
 
   it("handles RemoteJumpBackward when event is null", async () => {
     await eventHandlers["remote-jump-backward"](null);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45); // 60 - 15 (default)
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45);
   });
 
   it("clamps RemoteJumpBackward to zero", async () => {
     (mockTrackPlayer.getProgress as jest.Mock).mockResolvedValueOnce({ position: 5, duration: 300 });
     await eventHandlers["remote-jump-backward"]({ interval: 15 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(0); // max(0, 5 - 15)
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(0);
   });
 });

--- a/tests/components/track-player-service.test.ts
+++ b/tests/components/track-player-service.test.ts
@@ -1,0 +1,93 @@
+// Capture event handlers registered by playbackService
+const eventHandlers: Record<string, (event: unknown) => Promise<void>> = {};
+
+jest.mock("react-native-track-player", () => ({
+  __esModule: true,
+  default: {
+    addEventListener: jest.fn((event: string, handler: (event: unknown) => Promise<void>) => {
+      eventHandlers[event] = handler;
+      return { remove: jest.fn() };
+    }),
+    play: jest.fn(),
+    pause: jest.fn(),
+    stop: jest.fn(),
+    getQueue: jest.fn().mockResolvedValue([]),
+    getActiveTrackIndex: jest.fn().mockResolvedValue(0),
+    getProgress: jest.fn().mockResolvedValue({ position: 60, duration: 300 }),
+    getPlaybackState: jest.fn().mockResolvedValue({ state: "playing" }),
+    seekTo: jest.fn(),
+    skipToNext: jest.fn(),
+    skipToPrevious: jest.fn(),
+  },
+  Event: {
+    RemotePlay: "remote-play",
+    RemotePause: "remote-pause",
+    RemoteStop: "remote-stop",
+    RemoteNext: "remote-next",
+    RemotePrevious: "remote-previous",
+    RemoteJumpForward: "remote-jump-forward",
+    RemoteJumpBackward: "remote-jump-backward",
+    PlaybackState: "playback-state",
+    PlaybackQueueEnded: "playback-queue-ended",
+    PlaybackActiveTrackChanged: "playback-active-track-changed",
+  },
+  State: { Playing: "playing", Paused: "paused", Stopped: "stopped" },
+}));
+
+jest.mock("@/lib/audio-player-store", () => ({
+  getAudioContext: jest.fn().mockReturnValue(null),
+  getAudioAccessToken: jest.fn().mockReturnValue(null),
+}));
+
+jest.mock("@/lib/media-location", () => ({
+  updateMediaLocation: jest.fn(),
+}));
+
+jest.mock("../../components/use-audio-player-sync", () => ({
+  isPlayerInitialized: jest.fn().mockReturnValue(true),
+}));
+
+import TrackPlayer from "react-native-track-player";
+import { playbackService } from "../../components/track-player-service";
+
+const mockTrackPlayer = TrackPlayer as jest.Mocked<typeof TrackPlayer>;
+
+describe("playbackService", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    Object.keys(eventHandlers).forEach((key) => delete eventHandlers[key]);
+    (mockTrackPlayer.getProgress as jest.Mock).mockResolvedValue({ position: 60, duration: 300 });
+    await playbackService();
+  });
+
+  it("handles RemoteJumpForward with a normal event payload", async () => {
+    await eventHandlers["remote-jump-forward"]({ interval: 30 });
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30
+  });
+
+  it("handles RemoteJumpForward when event is null", async () => {
+    await eventHandlers["remote-jump-forward"](null);
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30 (default)
+  });
+
+  it("handles RemoteJumpForward when event is undefined", async () => {
+    await eventHandlers["remote-jump-forward"](undefined);
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90); // 60 + 30 (default)
+  });
+
+  it("handles RemoteJumpBackward with a normal event payload", async () => {
+    await eventHandlers["remote-jump-backward"]({ interval: 15 });
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45); // 60 - 15
+  });
+
+  it("handles RemoteJumpBackward when event is null", async () => {
+    await eventHandlers["remote-jump-backward"](null);
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45); // 60 - 15 (default)
+  });
+
+  it("clamps RemoteJumpBackward to zero", async () => {
+    (mockTrackPlayer.getProgress as jest.Mock).mockResolvedValueOnce({ position: 5, duration: 300 });
+    await eventHandlers["remote-jump-backward"]({ interval: 15 });
+    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(0); // max(0, 5 - 15)
+  });
+});


### PR DESCRIPTION
## Problem

`RemoteJumpForward` and `RemoteJumpBackward` event handlers in `track-player-service.ts` destructured `{ interval }` directly from the event payload. When the OS media controls fire these events with a `null` payload, this causes:

```
TypeError: Cannot read property 'interval' of null
```

[Sentry issue](https://gumroad-to.sentry.io/issues/7452331719/)

## Fix

Use optional chaining on the event parameter with sensible fallback defaults matching the configured jump intervals:
- Forward: 30 seconds (matches `forwardJumpInterval` in `setupPlayer`)
- Backward: 15 seconds (matches `backwardJumpInterval` in `setupPlayer`)

## Tests

Added `tests/components/track-player-service.test.ts` with 6 test cases covering:
- Normal event payloads (interval provided)
- Null event payloads (falls back to defaults)
- Undefined event payloads (falls back to defaults)
- Backward jump clamping to zero