### PR TITLE
Fix Android OutOfMemoryError in GIF frame decoder

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -37,6 +37,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   },
   plugins: [
     "./plugins/gradle-memory",
+    "./plugins/android-large-heap",
     "expo-router",
     [
       "expo-font",

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -32,7 +32,7 @@ import * as Sentry from "@sentry/react-native";
 const CarouselItem = ({ item, onPress }: { item: Purchase; onPress: () => void }) => (
   <TouchableOpacity onPress={onPress} className="size-50 overflow-hidden rounded">
     {item.thumbnail_url ? (
-      <Image source={{ uri: item.thumbnail_url }} className="absolute inset-0" contentFit="cover" />
+      <Image source={{ uri: item.thumbnail_url }} className="absolute inset-0" contentFit="cover" autoplay={false} />
     ) : (
       <View className="absolute inset-0 items-center justify-center bg-muted">
         <Text className="text-4xl">📦</Text>
@@ -44,7 +44,7 @@ const CarouselItem = ({ item, onPress }: { item: Purchase; onPress: () => void }
         {item.name}
       </Text>
       <View className="mt-1 flex-row items-center gap-1.5">
-        <Image source={{ uri: item.creator_profile_picture_url }} className="size-5 rounded-full border border-white" />
+        <Image source={{ uri: item.creator_profile_picture_url }} className="size-5 rounded-full border border-white" autoplay={false} />
         <Text className="font-sans text-xs text-white" numberOfLines={1}>
           {item.creator_name}
         </Text>
@@ -241,7 +241,7 @@ export default function Index() {
                     className={cn("flex-row items-center gap-4", isFilterLoading && "opacity-50")}
                   >
                     {item.thumbnail_url ? (
-                      <Image source={{ uri: item.thumbnail_url }} className="size-17 bg-muted" contentFit="cover" />
+                      <Image source={{ uri: item.thumbnail_url }} className="size-17 bg-muted" contentFit="cover" autoplay={false} />
                     ) : (
                       <View className="size-17 items-center justify-center bg-muted">
                         <Text className="text-2xl">📦</Text>
@@ -252,7 +252,7 @@ export default function Index() {
                         {item.name}
                       </Text>
                       <View className="flex-row items-center gap-1.5">
-                        <Image source={{ uri: item.creator_profile_picture_url }} className="size-4 rounded-full" />
+                        <Image source={{ uri: item.creator_profile_picture_url }} className="size-4 rounded-full" autoplay={false} />
                         <Text className="text-sm text-muted" numberOfLines={1}>
                           {item.creator_name}
                         </Text>

--- a/components/dashboard/sale-item.tsx
+++ b/components/dashboard/sale-item.tsx
@@ -12,7 +12,7 @@ interface SaleItemProps {
 export const SaleItem = ({ sale, onPress }: SaleItemProps) => (
   <TouchableOpacity onPress={onPress} className="flex-row items-center gap-3 border-b border-border bg-background pr-4">
     {sale.product_thumbnail_url ? (
-      <Image source={{ uri: sale.product_thumbnail_url }} className="size-16 bg-body-bg" contentFit="cover" />
+      <Image source={{ uri: sale.product_thumbnail_url }} className="size-16 bg-body-bg" contentFit="cover" autoplay={false} />
     ) : (
       <View className="size-16 items-center justify-center bg-body-bg">
         <Text className="text-lg">📦</Text>

--- a/plugins/android-large-heap.js
+++ b/plugins/android-large-heap.js
@@ -1,0 +1,10 @@
+const { withAndroidManifest } = require("expo/config-plugins");
+
+module.exports = (config) =>
+  withAndroidManifest(config, (config) => {
+    const app = config.modResults.manifest.application?.[0];
+    if (app) {
+      app.$["android:largeHeap"] = "true";
+    }
+    return config;
+  });

--- a/tests/app/library.test.tsx
+++ b/tests/app/library.test.tsx
@@ -1,0 +1,119 @@
+import { render } from "@testing-library/react-native";
+import Library from "@/app/(tabs)/library";
+
+const imageProps: Record<string, unknown>[] = [];
+
+jest.mock("@/components/styled", () => {
+  const { View } = require("react-native");
+  return {
+    StyledImage: (props: Record<string, unknown>) => {
+      imageProps.push(props);
+      return <View testID="styled-image" {...props} />;
+    },
+  };
+});
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ isLoading: false, accessToken: "test-token" }),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("@sentry/react-native", () => ({ captureException: jest.fn() }));
+
+jest.mock("react-native-context-menu-view", () => {
+  const { View } = require("react-native");
+  return {
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+const mockMakePurchase = (id: string) => ({
+  name: `Product ${id}`,
+  unique_permalink: id,
+  creator_name: "Creator",
+  creator_username: "creator",
+  creator_profile_url: "https://example.com/creator",
+  creator_profile_picture_url: "https://example.com/avatar.png",
+  thumbnail_url: "https://example.com/thumb.gif",
+  url_redirect_token: `token-${id}`,
+  purchase_email: "buyer@test.com",
+  purchase_id: `purchase-${id}`,
+});
+
+const mockPurchases = [mockMakePurchase("1"), mockMakePurchase("2")];
+
+jest.mock("@/components/library/use-library-filters", () => ({
+  useLibraryFilters: () => ({
+    searchText: "",
+    hasActiveFilters: false,
+    apiFilters: {},
+    isSearchPending: false,
+  }),
+}));
+
+jest.mock("@/components/library/use-purchases", () => ({
+  usePurchases: () => ({
+    purchases: mockPurchases,
+    totalCount: mockPurchases.length,
+    error: null,
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    refetch: jest.fn(),
+  }),
+  useSellers: () => [],
+  useArchivePurchase: () => jest.fn(),
+  useDeletePurchase: () => jest.fn(),
+}));
+
+jest.mock("@/components/library/use-recent-products", () => ({
+  MAX_RECENT: 5,
+  useRecentPurchases: () => ({
+    purchases: [],
+    isLoading: false,
+    refresh: jest.fn(),
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/library/library-filters", () => {
+  const { View } = require("react-native");
+  return {
+    LibraryFilters: ({ children }: { children: React.ReactNode }) => <View>{children}</View>,
+  };
+});
+
+jest.mock("@/components/ui/screen", () => {
+  const { View } = require("react-native");
+  return { Screen: ({ children }: { children: React.ReactNode }) => <View>{children}</View> };
+});
+
+jest.mock("@/components/ui/loading-spinner", () => {
+  const { View } = require("react-native");
+  return { LoadingSpinner: () => <View /> };
+});
+
+jest.mock("@/components/ui/text", () => {
+  const { Text } = require("react-native");
+  return { Text };
+});
+
+describe("Library image autoplay", () => {
+  beforeEach(() => {
+    imageProps.length = 0;
+  });
+
+  it("renders all images with autoplay disabled", () => {
+    render(<Library />);
+    expect(imageProps.length).toBeGreaterThan(0);
+    imageProps.forEach((props) => {
+      expect(props.autoplay).toBe(false);
+    });
+  });
+});

--- a/tests/components/dashboard/sale-item.test.tsx
+++ b/tests/components/dashboard/sale-item.test.tsx
@@ -1,0 +1,37 @@
+import { SaleItem } from "@/components/dashboard/sale-item";
+import { SalePurchase } from "@/components/dashboard/use-sales-analytics";
+import { render } from "@testing-library/react-native";
+
+jest.mock("@/components/styled", () => {
+  const { View } = require("react-native");
+  return { StyledImage: (props: Record<string, unknown>) => <View testID="styled-image" {...props} /> };
+});
+
+const makeSale = (overrides: Partial<SalePurchase> = {}): SalePurchase => ({
+  id: "sale-1",
+  product_name: "Test Product",
+  formatted_total_price: "$10.00",
+  email: "buyer@test.com",
+  timestamp: "Jan 1, 2024",
+  refunded: false,
+  partially_refunded: false,
+  chargedback: false,
+  product_thumbnail_url: "https://example.com/thumb.gif",
+  ...overrides,
+});
+
+describe("SaleItem", () => {
+  it("renders thumbnail with autoplay disabled", () => {
+    const { getByTestId } = render(<SaleItem sale={makeSale()} onPress={jest.fn()} />);
+    const image = getByTestId("styled-image");
+    expect(image.props.autoplay).toBe(false);
+  });
+
+  it("renders placeholder when no thumbnail URL", () => {
+    const { queryByTestId, getByText } = render(
+      <SaleItem sale={makeSale({ product_thumbnail_url: null })} onPress={jest.fn()} />,
+    );
+    expect(queryByTestId("styled-image")).toBeNull();
+    expect(getByText("📦")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Problem

Android OOM crash in `okio.Segment.<init>` when the 256MB heap fills up:

```
OutOfMemoryError: Failed to allocate a 8208 byte allocation with 2089712 free bytes
and 2040KB until OOM, target footprint 268435456, growth limit 268435456
```

[Sentry issue](https://gumroad-to.sentry.io/issues/7453895444/)

## Root Cause

Animated GIF/APNG thumbnails in list views (library, dashboard) are decoded frame-by-frame by expo-image's APNG4Android decoder. When scrolling through many products with animated thumbnails, each decoded frame buffer accumulates in the heap until the OkHttp networking layer (okio.Segment) can't allocate even 8KB.

## Fix

1. **Disable autoplay on list thumbnails** — adds `autoplay={false}` to all `<Image>` components in library and dashboard sale lists. This tells expo-image to render only the first frame of animated images instead of decoding the full animation, dramatically reducing per-thumbnail memory.

2. **Add `android:largeHeap` config plugin** — requests a larger heap from the OS as an additional safety net for devices with tight default limits.

## Tests

- New `tests/app/library.test.tsx` verifies all library images render with `autoplay={false}`
- New `tests/components/dashboard/sale-item.test.tsx` verifies sale item thumbnails render with `autoplay={false}`
- All 140 tests pass