### PR TITLE
Fix app hang in ImageView.maybeRenderLocalAsset for remote URLs

### DIFF
--- a/patches/expo-image+55.0.6.patch
+++ b/patches/expo-image+55.0.6.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/expo-image/ios/ImageView.swift b/node_modules/expo-image/ios/ImageView.swift
-index adcf377..9bc3480 100644
+index adcf377..14148a3 100644
 --- a/node_modules/expo-image/ios/ImageView.swift
 +++ b/node_modules/expo-image/ios/ImageView.swift
 @@ -122,6 +122,10 @@ public final class ImageView: ExpoView {
@@ -13,3 +13,16 @@ index adcf377..9bc3480 100644
      // Apply trilinear filtering to smooth out mis-sized images.
      sdImageView.layer.magnificationFilter = .trilinear
      sdImageView.layer.minificationFilter = .trilinear
+@@ -347,6 +351,12 @@ public final class ImageView: ExpoView {
+   }
+ 
+   private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
++    // Skip remote URLs — UIImage(named:) performs a synchronous asset-catalog
++    // search on the main thread that hangs the UI for every remote image.
++    if let scheme = source.uri?.scheme?.lowercased(), scheme == "http" || scheme == "https" {
++      return false
++    }
++
+     let path: String? = {
+       // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
+       // It also crashes with EXC_BREAKPOINT when parsing data:image uris


### PR DESCRIPTION
## Problem

Sentry: https://gumroad-to.sentry.io/issues/7464088307/

The app hangs for 2000ms+ on the main thread in `ImageView.maybeRenderLocalAsset`. This method is called during every image reload, including for remote (http/https) URLs.

The culprit is `UIImage(named:)`, which performs a synchronous search through all asset catalogs. For remote URLs, this search always returns nil but still blocks the main thread while scanning.

**Sentry event count:** 1 occurrence (first seen, newly reported)
**Users affected:** Low volume so far (single occurrence), but affects every remote image load path
**Estimated support tickets:** ~0/month (app hang, not a crash, but degrades UX)

## Fix

Add an early return in `maybeRenderLocalAsset` when the source URL has an `http` or `https` scheme. Remote URLs can never be local assets, so we skip the expensive `UIImage(named:)` call entirely.

This is added as a second hunk to the existing `expo-image+55.0.6.patch` (which already disables progressive animated image loading to prevent a similar main-thread hang).

## Changes

- `patches/expo-image+55.0.6.patch`: Added scheme check guard to `maybeRenderLocalAsset`