### PR TITLE
Fix audio player seek buttons being non-functional

### DIFF
--- a/components/full-audio-player.tsx
+++ b/components/full-audio-player.tsx
@@ -89,15 +89,11 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
   };
 
   const handleSkipBack = async () => {
-    const { position } = await TrackPlayer.getProgress();
-    const newPosition = Math.max(position - 15, 0);
-    await TrackPlayer.seekTo(newPosition);
+    await TrackPlayer.seekBy(-15);
   };
 
   const handleSkipForward = async () => {
-    const { position, duration } = await TrackPlayer.getProgress();
-    const newPosition = Math.min(position + 30, duration);
-    await TrackPlayer.seekTo(newPosition);
+    await TrackPlayer.seekBy(30);
   };
 
   const handleClose = async () => {

--- a/components/mini-audio-player.tsx
+++ b/components/mini-audio-player.tsx
@@ -36,9 +36,7 @@ const MiniAudioPlayerBase = () => {
   };
 
   const handleSkipForward = async () => {
-    const { position, duration } = await TrackPlayer.getProgress();
-    const newPosition = Math.min(position + 30, duration);
-    await TrackPlayer.seekTo(newPosition);
+    await TrackPlayer.seekBy(30);
   };
 
   if (!isVisible || !activeTrack) {

--- a/components/track-player-service.ts
+++ b/components/track-player-service.ts
@@ -48,14 +48,12 @@ export const playbackService = async () => {
 
   TrackPlayer.addEventListener(Event.RemoteJumpForward, async (event) => {
     const interval = event?.interval ?? 30;
-    const { position } = await TrackPlayer.getProgress();
-    await TrackPlayer.seekTo(position + interval);
+    await TrackPlayer.seekBy(interval);
   });
 
   TrackPlayer.addEventListener(Event.RemoteJumpBackward, async (event) => {
     const interval = event?.interval ?? 15;
-    const { position } = await TrackPlayer.getProgress();
-    await TrackPlayer.seekTo(Math.max(0, position - interval));
+    await TrackPlayer.seekBy(-interval);
   });
 
   setInterval(async () => {

--- a/tests/components/track-player-service.test.ts
+++ b/tests/components/track-player-service.test.ts
@@ -15,6 +15,7 @@ jest.mock("react-native-track-player", () => ({
     getProgress: jest.fn().mockResolvedValue({ position: 60, duration: 300 }),
     getPlaybackState: jest.fn().mockResolvedValue({ state: "playing" }),
     seekTo: jest.fn(),
+    seekBy: jest.fn(),
     skipToNext: jest.fn(),
     skipToPrevious: jest.fn(),
   },
@@ -66,32 +67,31 @@ describe("playbackService", () => {
 
   it("handles RemoteJumpForward with a normal event payload", async () => {
     await eventHandlers["remote-jump-forward"]({ interval: 30 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(30);
   });
 
   it("handles RemoteJumpForward when event is null", async () => {
     await eventHandlers["remote-jump-forward"](null);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(30);
   });
 
   it("handles RemoteJumpForward when event is undefined", async () => {
     await eventHandlers["remote-jump-forward"](undefined);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(90);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(30);
   });
 
   it("handles RemoteJumpBackward with a normal event payload", async () => {
     await eventHandlers["remote-jump-backward"]({ interval: 15 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(-15);
   });
 
   it("handles RemoteJumpBackward when event is null", async () => {
     await eventHandlers["remote-jump-backward"](null);
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(45);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(-15);
   });
 
-  it("clamps RemoteJumpBackward to zero", async () => {
-    (mockTrackPlayer.getProgress as jest.Mock).mockResolvedValueOnce({ position: 5, duration: 300 });
-    await eventHandlers["remote-jump-backward"]({ interval: 15 });
-    expect(mockTrackPlayer.seekTo).toHaveBeenCalledWith(0);
+  it("handles RemoteJumpBackward when event is undefined", async () => {
+    await eventHandlers["remote-jump-backward"](undefined);
+    expect(mockTrackPlayer.seekBy).toHaveBeenCalledWith(-15);
   });
 });


### PR DESCRIPTION
## Problem

The Rewind (-15) and Fast Forward (+30) buttons in the audio player appear in the UI but don't respond to taps. Reported in #237 — play/pause works correctly but the seek buttons are inactive.

## Root cause

The handlers called `TrackPlayer.getProgress()` to read the current position/duration, computed a new absolute position, and then called `TrackPlayer.seekTo()`:

```ts
const handleSkipForward = async () => {
  const { position, duration } = await TrackPlayer.getProgress();
  const newPosition = Math.min(position + 30, duration);
  await TrackPlayer.seekTo(newPosition);
};
```

When the player reports `duration` as `0` (e.g. during initial buffering, or before track metadata fully loads), `Math.min(position + 30, 0)` evaluates to `0`, so `seekTo(0)` is called. From the user's perspective, the button does nothing — it either jumps silently to the start or no-ops if already there.

Skip-back has the same shape of bug: when `position < 15`, `Math.max(position - 15, 0)` is `0` and the seek goes to (or stays at) the start.

## Fix

Replace the `getProgress` + `seekTo` round-trip with `TrackPlayer.seekBy()`, which performs a relative seek natively without depending on the JS-side progress values. This is also the more idiomatic API for relative seeks.

The same pattern was used in `track-player-service.ts` for the `RemoteJumpForward` / `RemoteJumpBackward` handlers (system controls / lock screen / notification buttons), so those are fixed too.

## After

### Android

https://github.com/user-attachments/assets/8a58faab-c247-4219-ac6d-d0ad43c5ebd9

### IOS

https://github.com/user-attachments/assets/9f96ebbd-792c-45f4-8c36-ced10f220417

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)