### PR TITLE
Fix video playback resetting to beginning when app is backgrounded

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -65,15 +65,24 @@ export default function VideoPlayerScreen() {
   });
 
   const wasPlayingBeforeBackgroundRef = useRef(false);
+  const positionBeforeBackgroundRef = useRef<number | null>(null);
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
       if (nextState === "background" || nextState === "inactive") {
         wasPlayingBeforeBackgroundRef.current = player.playing;
+        positionBeforeBackgroundRef.current = player.currentTime;
         player.pause();
-      } else if (nextState === "active" && wasPlayingBeforeBackgroundRef.current) {
-        player.play();
-        wasPlayingBeforeBackgroundRef.current = false;
+      } else if (nextState === "active") {
+        const savedPosition = positionBeforeBackgroundRef.current;
+        if (savedPosition !== null && player.currentTime < savedPosition - 1) {
+          player.currentTime = savedPosition;
+        }
+        positionBeforeBackgroundRef.current = null;
+        if (wasPlayingBeforeBackgroundRef.current) {
+          player.play();
+          wasPlayingBeforeBackgroundRef.current = false;
+        }
       }
     });
 

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -115,4 +115,40 @@ describe("VideoPlayerScreen", () => {
 
     expect(mockPlayer.pause).toHaveBeenCalled();
   });
+
+  it("restores the playback position when returning from background", () => {
+    renderScreen();
+    mockPlayer.currentTime = 120;
+    mockPlayer.playing = true;
+
+    act(() => {
+      appStateCallback!("background");
+    });
+
+    mockPlayer.currentTime = 0;
+
+    act(() => {
+      appStateCallback!("active");
+    });
+
+    expect(mockPlayer.currentTime).toBe(120);
+  });
+
+  it("does not seek when the player has retained its position after returning from background", () => {
+    renderScreen();
+    mockPlayer.currentTime = 120;
+    mockPlayer.playing = true;
+
+    act(() => {
+      appStateCallback!("background");
+    });
+
+    mockPlayer.currentTime = 119.5;
+
+    act(() => {
+      appStateCallback!("active");
+    });
+
+    expect(mockPlayer.currentTime).toBe(119.5);
+  });
 });


### PR DESCRIPTION
## What

When the user backgrounds the app while watching a video and returns later, the video sometimes restarts from `0:00` instead of resuming from where they left off.

Save the playback position when the app goes to background and seek back to it when the app becomes active. The seek is only performed if the player came back with an earlier position (more than 1s behind the saved value), so we don't overwrite a position the player legitimately retained on its own.

## Why

[#215](https://github.com/antiwork/gumroad-mobile/pull/215) intentionally set `player.staysActiveInBackground = false` to fix a Background ANR caused by the media3 session service staying active in the background. With that flag off, iOS/Android may release the underlying `AVPlayer`/`ExoPlayer` resources while the app is backgrounded; when the app returns to foreground the player can come back with `currentTime = 0`, which is what the buyer in the linked support ticket experienced. The existing `AppState` listener already remembered whether the player was playing — this PR extends it to also remember the position.

Re-enabling `staysActiveInBackground` would reintroduce the ANR fixed in #215, so the fix is in JS instead.

Fixes #239.

https://github.com/user-attachments/assets/27545015-ffa6-4f96-b112-0401a4088dd9

---

AI disclosure: Authored by Claude Opus 4.7