### PR TITLE
Fix landscape mode not working for video playback

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -142,7 +142,12 @@ export default function VideoPlayerScreen() {
           headerTintColor: "#fff",
         }}
       />
-      <VideoView style={styles.video} player={player} allowsPictureInPicture fullscreenOptions={{ enable: true }} />
+      <VideoView
+        style={styles.video}
+        player={player}
+        allowsPictureInPicture
+        fullscreenOptions={{ enable: true, orientation: "landscape", autoExitOnRotate: true }}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## What

When a buyer taps the fullscreen icon in the bottom-right of the video player (or rotates their device), the video doesn't switch to landscape — the icon appears unresponsive and physical rotation has no effect.

Pass `orientation: "landscape"` and `autoExitOnRotate: true` to `VideoView.fullscreenOptions`. The fullscreen button now rotates the video to landscape, and rotating the device back to portrait exits fullscreen.

## Why

The app is intentionally locked to `orientation: "portrait"` in `app.config.ts` so the rest of the UI (library, settings, etc.) doesn't rotate. With no fullscreen orientation override, `expo-video` inherited that lock — entering "fullscreen" left the video in portrait, which looked broken to the user because nothing visually changed.

`expo-video`'s `fullscreenOptions.orientation` is the documented way to override the app's orientation lock for the duration of fullscreen playback. This is preferable to globally relaxing the app orientation (which would let the rest of the UI rotate in ways it wasn't designed for) and avoids pulling in `expo-screen-orientation` for a single screen.

Fixes #240.

## After

https://github.com/user-attachments/assets/f0c4400e-8e3f-4ce9-b033-619d85a6fe0e

---

AI disclosure: Authored by Claude Opus 4.7