### PR TITLE
Fix repeated Cloudflare captcha challenges in purchase WebView

### DIFF
--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -208,12 +208,14 @@ export default function DownloadScreen() {
     <Screen>
       <Stack.Screen options={{ title: purchase?.name ?? "" }} />
       <StyledWebView
+        key={accessToken ?? "anonymous"}
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled
         pullToRefreshEnabled
-        incognito
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
         mediaPlaybackRequiresUserAction={false}
         originWhitelist={["*"]}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}


### PR DESCRIPTION
## What

Users on long video courses are repeatedly hit with "Verifying you are human" Cloudflare challenges every time they leave the app and come back, interrupting playback.

The purchase WebView was mounted with `incognito`, which on iOS maps to `WKWebsiteDataStore.nonPersistentDataStore`. That data store only keeps cookies for the lifetime of the WebView instance, so as soon as iOS kills the web content process (which happens after backgrounding or under memory pressure) the Cloudflare `cf_clearance` cookie is gone and Cloudflare re-challenges.

Switch the WebView to persistent cookies (`sharedCookiesEnabled` on iOS, `thirdPartyCookiesEnabled` on Android). Add `key={accessToken}` so the WebView is fully remounted when the signed-in user changes — together with the existing `access_token` query param in the URL, this preserves the protection from [#119](https://github.com/antiwork/gumroad-mobile/pull/119) against the WebView showing a different user's session state.

## Why

`incognito` was added in [#119](https://github.com/antiwork/gumroad-mobile/pull/119) to stop "this product belongs to another email" prompts when switching users, but it has the side effect of evicting Cloudflare clearance every time the WebView remounts. Since the purchase URL already carries the access token in the query string, the server identifies the viewer from the token rather than from a session cookie, so we don't actually need a non-persistent data store to keep sessions separate — we just need to make sure the WebView remounts on user change, which `key={accessToken}` guarantees.

Fixes #241.

---

AI disclosure: Authored by Claude Opus 4.7.