### PR TITLE
Add error UI and Sentry diagnostics for failed video playback

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -1,4 +1,5 @@
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { Text } from "@/components/ui/text";
 import { useRefToLatest } from "@/components/use-ref-to-latest";
 import { useAuth } from "@/lib/auth-context";
 import { updateMediaLocation } from "@/lib/media-location";
@@ -6,7 +7,7 @@ import { requestAPI } from "@/lib/request";
 import { useQueryClient } from "@tanstack/react-query";
 import * as Sentry from "@sentry/react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
-import { useVideoPlayer, VideoView } from "expo-video";
+import { useVideoPlayer, VideoView, type VideoPlayerStatus } from "expo-video";
 import { useEffect, useRef, useState } from "react";
 import { AppState, type AppStateStatus, StyleSheet, View } from "react-native";
 
@@ -28,6 +29,7 @@ export default function VideoPlayerScreen() {
   const queryClient = useQueryClient();
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [currentPosition, setCurrentPosition] = useState(initialPosition ? Number(initialPosition) : 0);
   const currentPositionRef = useRefToLatest(currentPosition);
 
@@ -86,6 +88,33 @@ export default function VideoPlayerScreen() {
     };
   }, [player]);
 
+  useEffect(() => {
+    const subscription = player.addListener(
+      "statusChange",
+      ({ status, error }: { status: VideoPlayerStatus; error?: { message: string } }) => {
+        if (status === "error") {
+          const message = error?.message ?? "Unknown playback error";
+          setPlaybackError(message);
+          Sentry.captureMessage("Video playback failed", {
+            level: "error",
+            extra: {
+              message,
+              videoUrl,
+              sourceUri: uri,
+              streamingUrl,
+              urlRedirectId,
+              productFileId,
+              purchaseId,
+            },
+          });
+        } else if (status === "readyToPlay") {
+          setPlaybackError(null);
+        }
+      },
+    );
+    return () => subscription.remove();
+  }, [player, videoUrl, uri, streamingUrl, urlRedirectId, productFileId, purchaseId]);
+
   useEffect(
     () => () => {
       if (!urlRedirectId || !productFileId) return;
@@ -133,6 +162,27 @@ export default function VideoPlayerScreen() {
     );
   }
 
+  if (playbackError) {
+    return (
+      <View style={styles.container}>
+        <Stack.Screen
+          options={{
+            title: title ?? "Video",
+            headerStyle: { backgroundColor: "#000" },
+            headerTintColor: "#fff",
+          }}
+        />
+        <View style={styles.errorContainer}>
+          <Text className="text-center text-lg font-semibold text-white">This video failed to load</Text>
+          <Text className="mt-2 text-center text-sm text-white/70">
+            Try downloading the file from the product page instead.
+          </Text>
+          <Text className="mt-4 text-center text-xs text-white/50">{playbackError}</Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
       <Stack.Screen
@@ -156,6 +206,12 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "center",
     alignItems: "center",
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
   },
   video: {
     flex: 1,

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -1,6 +1,10 @@
 import { AppState } from "react-native";
 import { renderWithQueryClient } from "../render-with-query-client";
 
+type StatusChangePayload = { status: string; error?: { message: string } };
+let statusChangeListener: ((payload: StatusChangePayload) => void) | null = null;
+const mockSubscriptionRemove = jest.fn();
+
 const mockPlayer = {
   loop: false,
   staysActiveInBackground: true,
@@ -8,6 +12,10 @@ const mockPlayer = {
   currentTime: 0,
   play: jest.fn(),
   pause: jest.fn(),
+  addListener: jest.fn((eventName: string, listener: (payload: StatusChangePayload) => void) => {
+    if (eventName === "statusChange") statusChangeListener = listener;
+    return { remove: mockSubscriptionRemove };
+  }),
 };
 
 jest.mock("expo-video", () => {
@@ -48,7 +56,9 @@ describe("VideoPlayerScreen", () => {
     mockPlayer.playing = true;
     mockPlayer.staysActiveInBackground = true;
     mockPlayer.loop = false;
+    mockPlayer.currentTime = 0;
     appStateCallback = null;
+    statusChangeListener = null;
 
     jest.spyOn(AppState, "addEventListener").mockImplementation((_type, callback) => {
       appStateCallback = callback as (state: string) => void;
@@ -114,5 +124,30 @@ describe("VideoPlayerScreen", () => {
     unmount();
 
     expect(mockPlayer.pause).toHaveBeenCalled();
+  });
+
+  it("renders an error message when the player reports an error status", () => {
+    const { queryByText } = renderScreen();
+
+    act(() => {
+      statusChangeListener!({ status: "error", error: { message: "AVPlayer cannot decode the file" } });
+    });
+
+    expect(queryByText("This video failed to load")).toBeTruthy();
+    expect(queryByText("AVPlayer cannot decode the file")).toBeTruthy();
+  });
+
+  it("clears the error state once the player becomes ready to play", () => {
+    const { queryByText } = renderScreen();
+
+    act(() => {
+      statusChangeListener!({ status: "error", error: { message: "Transient network error" } });
+    });
+    expect(queryByText("This video failed to load")).toBeTruthy();
+
+    act(() => {
+      statusChangeListener!({ status: "readyToPlay" });
+    });
+    expect(queryByText("This video failed to load")).toBeNull();
   });
 });


### PR DESCRIPTION
## What

When the native video player encountered an error (the buyer in #242 sees "Error Code: 100013" for one specific 108.8 MB MP4), the app's React side did nothing about it — the loading spinner disappeared and the buyer was left looking at a black screen with no explanation, and Sentry received no breadcrumb either, so we have no way to track which files fail or why.

Subscribe to `player.statusChange`. When the player enters the `error` status:
- Render an inline error message ("This video failed to load" + the underlying `error.message` for support) instead of a black screen.
- Send `Sentry.captureMessage("Video playback failed", ...)` with `videoUrl`, `sourceUri`, `streamingUrl`, `urlRedirectId`, `productFileId`, and `purchaseId` as `extra` context.

Clear the error if the player later reaches `readyToPlay` (e.g. transient buffer recovery).

## Why

The root cause of #242 is almost certainly server-side — the file in question plays fine in HTML5 on gumroad.com but fails in AVPlayer, which is consistent with either an MP4 without `moov`-atom faststart or a missing transcoded `streaming_url`. We can't fix that from the mobile app. But we can:

1. Give the buyer a clear message instead of a frozen black screen.
2. Capture enough context in Sentry that the next time someone reports a similar failure we can immediately tell which file/purchase is affected and what AVPlayer said.

Refs #242



---

AI disclosure: Authored by Claude Opus 4.7.