### PR TITLE
Fix Android compile errors in PdfThumbnailModule

### DIFF
--- a/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
+++ b/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
@@ -1,11 +1,14 @@
 package expo.modules.pdfthumbnail
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
 import android.net.Uri
 import android.os.ParcelFileDescriptor
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import java.io.File
@@ -13,6 +16,9 @@ import java.io.FileOutputStream
 import java.util.UUID
 
 class PdfThumbnailModule : Module() {
+  private val context: Context
+    get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
+
   override fun definition() = ModuleDefinition {
     Name("PdfThumbnail")
 


### PR DESCRIPTION
## What

Fixes the Android release build for the local `pdf-thumbnail` Expo module. The module's Kotlin source referenced `Coroutine` (as the async function modifier) and `context` without importing or defining them, so `:pdf-thumbnail:compileReleaseKotlin` failed with `Unresolved reference 'Coroutine'` and `Unresolved reference 'context'`.

The fix:
- Imports `expo.modules.kotlin.functions.Coroutine` so `AsyncFunction("generate") Coroutine { ... }` resolves.
- Imports `android.content.Context` and `expo.modules.kotlin.exception.Exceptions`, and adds a private `context` property that returns `appContext.reactContext` (or throws `AppContextLost`).

This matches the standard pattern used by first-party Expo modules such as `expo-asset` (`AssetModule.kt`).

## Why

The Android production build of `main` is currently broken — `./gradlew assembleRelease` and `bundleRelease` both fail at this module, blocking Play Store releases. The iOS build is unaffected, which is why earlier releases that shipped iOS-only didn't catch this.

## Testing

- `./gradlew :pdf-thumbnail:compileReleaseKotlin` → `BUILD SUCCESSFUL`.
- `./gradlew assembleRelease` → produces a signed release APK.
- Installed the release APK on a physical Android device (`adb install -r app-release.apk` → `Success`) and verified the app launches.