### PR TITLE
Fix notification deep link to post on cold start

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -30,14 +30,16 @@ export default function Index() {
         router.replace("/login");
         return;
       }
+      const defaultRoute = isCreator ? "/(tabs)/dashboard" : "/(tabs)/library";
       const response = await Notifications.getLastNotificationResponseAsync();
       const notificationRoute = getNotificationRoute(response);
       if (notificationRoute) {
-        await Notifications.clearLastNotificationResponseAsync();
-        router.replace(notificationRoute as any);
+        router.replace(defaultRoute);
+        router.push(notificationRoute as any);
+        Notifications.clearLastNotificationResponseAsync().catch(() => {});
         return;
       }
-      router.replace(isCreator ? "/(tabs)/dashboard" : "/(tabs)/library");
+      router.replace(defaultRoute);
     });
 
     return () => cancelAnimationFrame(id);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,6 @@
+import { getNotificationRoute } from "@/components/use-push-notifications";
 import { useAuth } from "@/lib/auth-context";
+import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { useEffect } from "react";
@@ -23,12 +25,19 @@ export default function Index() {
     // Without this, on low-end Android devices the NativeAnimatedModule may try
     // to add events to a view that has already been removed from the Fabric tree,
     // causing: "addAnimatedEventToView: Animated node with tag [N] does not exist"
-    const id = requestAnimationFrame(() => {
+    const id = requestAnimationFrame(async () => {
       if (!isAuthenticated) {
         router.replace("/login");
-      } else {
-        router.replace(isCreator ? "/(tabs)/dashboard" : "/(tabs)/library");
+        return;
       }
+      const response = await Notifications.getLastNotificationResponseAsync();
+      const notificationRoute = getNotificationRoute(response);
+      if (notificationRoute) {
+        await Notifications.clearLastNotificationResponseAsync();
+        router.replace(notificationRoute as any);
+        return;
+      }
+      router.replace(isCreator ? "/(tabs)/dashboard" : "/(tabs)/library");
     });
 
     return () => cancelAnimationFrame(id);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,5 +1,6 @@
-import { getNotificationRoute } from "@/components/use-push-notifications";
+import { consumeNotificationRoute } from "@/components/use-push-notifications";
 import { useAuth } from "@/lib/auth-context";
+import * as Sentry from "@sentry/react-native";
 import * as Notifications from "expo-notifications";
 import { useRouter } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -31,8 +32,13 @@ export default function Index() {
         return;
       }
       const defaultRoute = isCreator ? "/(tabs)/dashboard" : "/(tabs)/library";
-      const response = await Notifications.getLastNotificationResponseAsync();
-      const notificationRoute = getNotificationRoute(response);
+      let notificationRoute: string | null = null;
+      try {
+        const response = await Notifications.getLastNotificationResponseAsync();
+        notificationRoute = consumeNotificationRoute(response);
+      } catch (error) {
+        Sentry.captureException(error);
+      }
       if (notificationRoute) {
         router.replace(defaultRoute);
         router.push(notificationRoute as any);

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import { consumeNotificationRoute } from "@/components/use-push-notifications";
+import { consumeNotificationRoute, markIndexInitialRoutingComplete } from "@/components/use-push-notifications";
 import { useAuth } from "@/lib/auth-context";
 import * as Sentry from "@sentry/react-native";
 import * as Notifications from "expo-notifications";
@@ -20,6 +20,7 @@ export default function Index() {
 
   useEffect(() => {
     if (isLoading) return;
+    let cancelled = false;
 
     // Defer navigation to the next frame so react-native-screens can finish
     // registering its onTransitionProgress Animated.event on the current screen.
@@ -27,28 +28,36 @@ export default function Index() {
     // to add events to a view that has already been removed from the Fabric tree,
     // causing: "addAnimatedEventToView: Animated node with tag [N] does not exist"
     const id = requestAnimationFrame(async () => {
+      if (cancelled) return;
       if (!isAuthenticated) {
         router.replace("/login");
+        markIndexInitialRoutingComplete();
         return;
       }
       const defaultRoute = isCreator ? "/(tabs)/dashboard" : "/(tabs)/library";
       let notificationRoute: string | null = null;
       try {
         const response = await Notifications.getLastNotificationResponseAsync();
+        if (cancelled) return;
         notificationRoute = consumeNotificationRoute(response);
       } catch (error) {
         Sentry.captureException(error);
       }
+      if (cancelled) return;
       if (notificationRoute) {
         router.replace(defaultRoute);
         router.push(notificationRoute as any);
         Notifications.clearLastNotificationResponseAsync().catch(() => {});
-        return;
+      } else {
+        router.replace(defaultRoute);
       }
-      router.replace(defaultRoute);
+      markIndexInitialRoutingComplete();
     });
 
-    return () => cancelAnimationFrame(id);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(id);
+    };
   }, [isLoading, isAuthenticated, isCreator, router]);
 
   return null;

--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -62,16 +62,34 @@ const getExpoPushToken = async () => {
   return tokenData.data;
 };
 
-export const getNotificationRoute = (response: Notifications.NotificationResponse | null): string | null => {
-  const data = response?.notification.request.content.data as Record<string, string> | undefined;
-  if (!data?.installment_id) return null;
+const handledNotificationIdentifiers = new Set<string>();
 
+const buildNotificationRoute = (data: Record<string, string>): string | null => {
+  if (!data.installment_id) return null;
   const params = new URLSearchParams();
   if (data.purchase_id) params.set("purchaseId", data.purchase_id);
   else if (data.subscription_id) params.set("subscriptionId", data.subscription_id);
   else if (data.follower_id) params.set("followerId", data.follower_id);
   const query = params.toString();
   return `/post/${data.installment_id}${query ? `?${query}` : ""}`;
+};
+
+// Returns the route for an unhandled notification response and marks it consumed.
+// iOS replays cold-start responses to newly registered listeners (see
+// NotificationCenterManager.addDelegate), so both `getLastNotificationResponseAsync`
+// in `app/index.tsx` and `addNotificationResponseReceivedListener` below can fire
+// for the same notification. The identifier set deduplicates them.
+export const consumeNotificationRoute = (
+  response: Notifications.NotificationResponse | null,
+): string | null => {
+  if (!response) return null;
+  const identifier = response.notification.request.identifier;
+  if (handledNotificationIdentifiers.has(identifier)) return null;
+  const data = response.notification.request.content.data as Record<string, string> | undefined;
+  const route = data ? buildNotificationRoute(data) : null;
+  if (!route) return null;
+  handledNotificationIdentifiers.add(identifier);
+  return route;
 };
 
 export const usePushNotifications = () => {
@@ -94,7 +112,7 @@ export const usePushNotifications = () => {
 
   useEffect(() => {
     notificationResponseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      const route = getNotificationRoute(response);
+      const route = consumeNotificationRoute(response);
       if (route) router.push(route as any);
     });
 

--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -62,19 +62,16 @@ const getExpoPushToken = async () => {
   return tokenData.data;
 };
 
-const handleNotificationResponse = (
-  response: Notifications.NotificationResponse,
-  router: ReturnType<typeof useRouter>,
-) => {
-  const data = response.notification.request.content.data as Record<string, string> | undefined;
-  if (!data?.installment_id) return;
+export const getNotificationRoute = (response: Notifications.NotificationResponse | null): string | null => {
+  const data = response?.notification.request.content.data as Record<string, string> | undefined;
+  if (!data?.installment_id) return null;
 
   const params = new URLSearchParams();
   if (data.purchase_id) params.set("purchaseId", data.purchase_id);
   else if (data.subscription_id) params.set("subscriptionId", data.subscription_id);
   else if (data.follower_id) params.set("followerId", data.follower_id);
   const query = params.toString();
-  router.push(`/post/${data.installment_id}${query ? `?${query}` : ""}` as any);
+  return `/post/${data.installment_id}${query ? `?${query}` : ""}`;
 };
 
 export const usePushNotifications = () => {
@@ -96,12 +93,9 @@ export const usePushNotifications = () => {
   }, [isAuthenticated, accessToken]);
 
   useEffect(() => {
-    Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (response) handleNotificationResponse(response, router);
-    });
-
     notificationResponseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      handleNotificationResponse(response, router);
+      const route = getNotificationRoute(response);
+      if (route) router.push(route as any);
     });
 
     return () => {

--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -64,6 +64,17 @@ const getExpoPushToken = async () => {
 
 const handledNotificationIdentifiers = new Set<string>();
 
+let indexInitialRoutingComplete = false;
+
+export const markIndexInitialRoutingComplete = () => {
+  indexInitialRoutingComplete = true;
+};
+
+export const __resetPushNotificationsModuleStateForTests = () => {
+  handledNotificationIdentifiers.clear();
+  indexInitialRoutingComplete = false;
+};
+
 const buildNotificationRoute = (data: Record<string, string>): string | null => {
   if (!data.installment_id) return null;
   const params = new URLSearchParams();
@@ -112,8 +123,11 @@ export const usePushNotifications = () => {
 
   useEffect(() => {
     notificationResponseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
+      if (!indexInitialRoutingComplete) return;
       const route = consumeNotificationRoute(response);
-      if (route) router.push(route as any);
+      if (!route) return;
+      router.push(route as any);
+      Notifications.clearLastNotificationResponseAsync().catch(() => {});
     });
 
     return () => {

--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -85,11 +85,6 @@ const buildNotificationRoute = (data: Record<string, string>): string | null => 
   return `/post/${data.installment_id}${query ? `?${query}` : ""}`;
 };
 
-// Returns the route for an unhandled notification response and marks it consumed.
-// iOS replays cold-start responses to newly registered listeners (see
-// NotificationCenterManager.addDelegate), so both `getLastNotificationResponseAsync`
-// in `app/index.tsx` and `addNotificationResponseReceivedListener` below can fire
-// for the same notification. The identifier set deduplicates them.
 export const consumeNotificationRoute = (
   response: Notifications.NotificationResponse | null,
 ): string | null => {

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -25,7 +25,19 @@ jest.mock("@/lib/auth-context", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
+const mockMarkIndexInitialRoutingComplete = jest.fn();
+jest.mock("@/components/use-push-notifications", () => {
+  const actual = jest.requireActual<typeof import("@/components/use-push-notifications")>(
+    "@/components/use-push-notifications",
+  );
+  return {
+    ...actual,
+    markIndexInitialRoutingComplete: () => mockMarkIndexInitialRoutingComplete(),
+  };
+});
+
 import Index from "@/app/index";
+import { __resetPushNotificationsModuleStateForTests } from "@/components/use-push-notifications";
 
 describe("Index", () => {
   let rafCallbacks: Array<() => unknown>;
@@ -40,6 +52,7 @@ describe("Index", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    __resetPushNotificationsModuleStateForTests();
     mockGetLastNotificationResponseAsync.mockResolvedValue(null);
     mockClearLastNotificationResponseAsync.mockResolvedValue(undefined);
     rafCallbacks = [];
@@ -85,6 +98,7 @@ describe("Index", () => {
 
     expect(mockReplace).toHaveBeenCalledWith("/login");
     expect(mockGetLastNotificationResponseAsync).not.toHaveBeenCalled();
+    expect(mockMarkIndexInitialRoutingComplete).toHaveBeenCalledTimes(1);
   });
 
   it("navigates to /(tabs)/dashboard for creators", async () => {
@@ -96,6 +110,7 @@ describe("Index", () => {
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/(tabs)/dashboard");
+    expect(mockMarkIndexInitialRoutingComplete).toHaveBeenCalledTimes(1);
   });
 
   it("navigates to /(tabs)/library for non-creators", async () => {
@@ -129,6 +144,7 @@ describe("Index", () => {
     expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
     expect(mockPush).toHaveBeenCalledWith("/post/abc123?purchaseId=p1");
     expect(mockClearLastNotificationResponseAsync).toHaveBeenCalled();
+    expect(mockMarkIndexInitialRoutingComplete).toHaveBeenCalledTimes(1);
   });
 
   it("uses /(tabs)/dashboard as the back target for creators launched via notification", async () => {
@@ -189,5 +205,32 @@ describe("Index", () => {
     unmount();
 
     expect(globalThis.cancelAnimationFrame).toHaveBeenCalledWith(1);
+  });
+
+  it("does not navigate or mark routing complete when the effect is cancelled mid-await", async () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
+    let resolveResponse: ((value: unknown) => void) | undefined;
+    mockGetLastNotificationResponseAsync.mockImplementation(
+      () => new Promise((resolve) => (resolveResponse = resolve)),
+    );
+
+    const { unmount } = render(<Index />);
+
+    await act(async () => {
+      for (const cb of rafCallbacks) cb();
+    });
+
+    unmount();
+    resolveResponse?.({
+      notification: { request: { identifier: "stale-1", content: { data: { installment_id: "stale-post" } } } },
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(mockMarkIndexInitialRoutingComplete).not.toHaveBeenCalled();
   });
 });

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -10,6 +10,15 @@ jest.mock("expo-splash-screen", () => ({
   hideAsync: jest.fn(),
 }));
 
+const mockGetLastNotificationResponseAsync = jest.fn();
+const mockClearLastNotificationResponseAsync = jest.fn();
+jest.mock("expo-notifications", () => ({
+  setNotificationHandler: jest.fn(),
+  getLastNotificationResponseAsync: () => mockGetLastNotificationResponseAsync(),
+  clearLastNotificationResponseAsync: () => mockClearLastNotificationResponseAsync(),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+}));
+
 const mockUseAuth = jest.fn();
 jest.mock("@/lib/auth-context", () => ({
   useAuth: () => mockUseAuth(),
@@ -18,12 +27,20 @@ jest.mock("@/lib/auth-context", () => ({
 import Index from "@/app/index";
 
 describe("Index", () => {
-  let rafCallbacks: Array<() => void>;
+  let rafCallbacks: Array<() => unknown>;
   let originalRAF: typeof globalThis.requestAnimationFrame;
   let originalCAF: typeof globalThis.cancelAnimationFrame;
 
+  const flushRaf = async () => {
+    for (const cb of rafCallbacks) {
+      await cb();
+    }
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetLastNotificationResponseAsync.mockResolvedValue(null);
+    mockClearLastNotificationResponseAsync.mockResolvedValue(undefined);
     rafCallbacks = [];
     originalRAF = globalThis.requestAnimationFrame;
     originalCAF = globalThis.cancelAnimationFrame;
@@ -57,37 +74,75 @@ describe("Index", () => {
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it("navigates to /login for unauthenticated users after requestAnimationFrame", () => {
+  it("navigates to /login for unauthenticated users after requestAnimationFrame", async () => {
     mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: false, isCreator: false });
     render(<Index />);
 
-    act(() => {
-      rafCallbacks.forEach((cb) => cb());
+    await act(async () => {
+      await flushRaf();
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/login");
+    expect(mockGetLastNotificationResponseAsync).not.toHaveBeenCalled();
   });
 
-  it("navigates to /(tabs)/dashboard for creators", () => {
+  it("navigates to /(tabs)/dashboard for creators", async () => {
     mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: true });
     render(<Index />);
 
-    act(() => {
-      rafCallbacks.forEach((cb) => cb());
+    await act(async () => {
+      await flushRaf();
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/(tabs)/dashboard");
   });
 
-  it("navigates to /(tabs)/library for non-creators", () => {
+  it("navigates to /(tabs)/library for non-creators", async () => {
     mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
     render(<Index />);
 
-    act(() => {
-      rafCallbacks.forEach((cb) => cb());
+    await act(async () => {
+      await flushRaf();
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+  });
+
+  it("navigates to the linked post when launched from a notification tap", async () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
+    mockGetLastNotificationResponseAsync.mockResolvedValue({
+      notification: {
+        request: {
+          content: { data: { installment_id: "abc123", purchase_id: "p1" } },
+        },
+      },
+    });
+
+    render(<Index />);
+
+    await act(async () => {
+      await flushRaf();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/post/abc123?purchaseId=p1");
+    expect(mockReplace).not.toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockClearLastNotificationResponseAsync).toHaveBeenCalled();
+  });
+
+  it("falls back to default route when notification has no installment_id", async () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
+    mockGetLastNotificationResponseAsync.mockResolvedValue({
+      notification: { request: { content: { data: {} } } },
+    });
+
+    render(<Index />);
+
+    await act(async () => {
+      await flushRaf();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockClearLastNotificationResponseAsync).not.toHaveBeenCalled();
   });
 
   it("cancels animation frame on unmount", () => {

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -1,8 +1,9 @@
 import { render, act } from "@testing-library/react-native";
 
 const mockReplace = jest.fn();
+const mockPush = jest.fn();
 jest.mock("expo-router", () => ({
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
 }));
 
 jest.mock("expo-splash-screen", () => ({
@@ -124,9 +125,29 @@ describe("Index", () => {
       await flushRaf();
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/post/abc123?purchaseId=p1");
-    expect(mockReplace).not.toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockPush).toHaveBeenCalledWith("/post/abc123?purchaseId=p1");
     expect(mockClearLastNotificationResponseAsync).toHaveBeenCalled();
+  });
+
+  it("uses /(tabs)/dashboard as the back target for creators launched via notification", async () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: true });
+    mockGetLastNotificationResponseAsync.mockResolvedValue({
+      notification: {
+        request: {
+          content: { data: { installment_id: "xyz" } },
+        },
+      },
+    });
+
+    render(<Index />);
+
+    await act(async () => {
+      await flushRaf();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/dashboard");
+    expect(mockPush).toHaveBeenCalledWith("/post/xyz");
   });
 
   it("falls back to default route when notification has no installment_id", async () => {

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -114,6 +114,7 @@ describe("Index", () => {
     mockGetLastNotificationResponseAsync.mockResolvedValue({
       notification: {
         request: {
+          identifier: "notif-1",
           content: { data: { installment_id: "abc123", purchase_id: "p1" } },
         },
       },
@@ -135,6 +136,7 @@ describe("Index", () => {
     mockGetLastNotificationResponseAsync.mockResolvedValue({
       notification: {
         request: {
+          identifier: "notif-2",
           content: { data: { installment_id: "xyz" } },
         },
       },
@@ -153,7 +155,7 @@ describe("Index", () => {
   it("falls back to default route when notification has no installment_id", async () => {
     mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
     mockGetLastNotificationResponseAsync.mockResolvedValue({
-      notification: { request: { content: { data: {} } } },
+      notification: { request: { identifier: "notif-3", content: { data: {} } } },
     });
 
     render(<Index />);
@@ -164,6 +166,20 @@ describe("Index", () => {
 
     expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
     expect(mockClearLastNotificationResponseAsync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to default route when the notifications API throws", async () => {
+    mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false });
+    mockGetLastNotificationResponseAsync.mockRejectedValue(new Error("native module unavailable"));
+
+    render(<Index />);
+
+    await act(async () => {
+      await flushRaf();
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockPush).not.toHaveBeenCalled();
   });
 
   it("cancels animation frame on unmount", () => {

--- a/tests/components/use-push-notifications.test.ts
+++ b/tests/components/use-push-notifications.test.ts
@@ -1,19 +1,54 @@
+type NotificationResponseListener = (response: unknown) => void;
+let capturedListener: NotificationResponseListener | null = null;
+const mockClearLastNotificationResponseAsync = jest.fn();
 jest.mock("expo-notifications", () => ({
   setNotificationHandler: jest.fn(),
-  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
-  getPermissionsAsync: jest.fn(),
-  requestPermissionsAsync: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn((cb: NotificationResponseListener) => {
+    capturedListener = cb;
+    return { remove: jest.fn() };
+  }),
+  clearLastNotificationResponseAsync: () => mockClearLastNotificationResponseAsync(),
+  getPermissionsAsync: jest.fn(() => Promise.resolve({ status: "denied" })),
+  requestPermissionsAsync: jest.fn(() => Promise.resolve({ status: "denied" })),
   getDevicePushTokenAsync: jest.fn(),
   setNotificationChannelAsync: jest.fn(),
   AndroidImportance: { MAX: 5 },
 }));
 
-import { consumeNotificationRoute } from "@/components/use-push-notifications";
+const mockRouterPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn() }),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/request", () => ({
+  requestAPI: jest.fn(),
+}));
+
+jest.mock("expo-application", () => ({ nativeApplicationVersion: "1.0" }));
+
+jest.mock("@sentry/react-native", () => ({ captureException: jest.fn() }));
+
+import { renderHook } from "@testing-library/react-native";
+import {
+  __resetPushNotificationsModuleStateForTests,
+  consumeNotificationRoute,
+  markIndexInitialRoutingComplete,
+  usePushNotifications,
+} from "@/components/use-push-notifications";
 
 const makeResponse = (identifier: string, data: Record<string, string>) =>
   ({ notification: { request: { identifier, content: { data } } } }) as any;
 
 describe("consumeNotificationRoute", () => {
+  beforeEach(() => {
+    __resetPushNotificationsModuleStateForTests();
+  });
+
   it("returns null when the response is null", () => {
     expect(consumeNotificationRoute(null)).toBeNull();
   });
@@ -41,5 +76,69 @@ describe("consumeNotificationRoute", () => {
     const response = makeResponse("dup-1", { installment_id: "post-dup" });
     expect(consumeNotificationRoute(response)).toBe("/post/post-dup");
     expect(consumeNotificationRoute(response)).toBeNull();
+  });
+});
+
+describe("usePushNotifications listener", () => {
+  beforeEach(() => {
+    __resetPushNotificationsModuleStateForTests();
+    capturedListener = null;
+    mockClearLastNotificationResponseAsync.mockReset();
+    mockClearLastNotificationResponseAsync.mockResolvedValue(undefined);
+    mockRouterPush.mockReset();
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, accessToken: null });
+  });
+
+  it("ignores notification responses delivered before index marks initial routing complete", () => {
+    renderHook(() => usePushNotifications());
+
+    expect(capturedListener).not.toBeNull();
+    capturedListener?.(makeResponse("cold-replay-1", { installment_id: "cold-post" }));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockClearLastNotificationResponseAsync).not.toHaveBeenCalled();
+  });
+
+  it("navigates and clears the cached response once index marks initial routing complete", () => {
+    renderHook(() => usePushNotifications());
+    markIndexInitialRoutingComplete();
+
+    capturedListener?.(makeResponse("live-tap-1", { installment_id: "live-post", purchase_id: "p" }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith("/post/live-post?purchaseId=p");
+    expect(mockClearLastNotificationResponseAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not navigate or clear when a foreground notification has no installment_id", () => {
+    renderHook(() => usePushNotifications());
+    markIndexInitialRoutingComplete();
+
+    capturedListener?.(makeResponse("no-data-1", { unrelated: "x" }));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(mockClearLastNotificationResponseAsync).not.toHaveBeenCalled();
+  });
+
+  it("does not double-navigate when the same notification identifier is delivered twice", () => {
+    renderHook(() => usePushNotifications());
+    markIndexInitialRoutingComplete();
+
+    const response = makeResponse("repeat-1", { installment_id: "repeat-post" });
+    capturedListener?.(response);
+    capturedListener?.(response);
+
+    expect(mockRouterPush).toHaveBeenCalledTimes(1);
+    expect(mockClearLastNotificationResponseAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows clearLastNotificationResponseAsync rejections so listener stays robust", () => {
+    mockClearLastNotificationResponseAsync.mockReturnValue(Promise.reject(new Error("native error")));
+    renderHook(() => usePushNotifications());
+    markIndexInitialRoutingComplete();
+
+    expect(() =>
+      capturedListener?.(makeResponse("clear-fail-1", { installment_id: "post-x" })),
+    ).not.toThrow();
+    expect(mockRouterPush).toHaveBeenCalledWith("/post/post-x");
   });
 });

--- a/tests/components/use-push-notifications.test.ts
+++ b/tests/components/use-push-notifications.test.ts
@@ -1,0 +1,45 @@
+jest.mock("expo-notifications", () => ({
+  setNotificationHandler: jest.fn(),
+  addNotificationResponseReceivedListener: jest.fn(() => ({ remove: jest.fn() })),
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getDevicePushTokenAsync: jest.fn(),
+  setNotificationChannelAsync: jest.fn(),
+  AndroidImportance: { MAX: 5 },
+}));
+
+import { consumeNotificationRoute } from "@/components/use-push-notifications";
+
+const makeResponse = (identifier: string, data: Record<string, string>) =>
+  ({ notification: { request: { identifier, content: { data } } } }) as any;
+
+describe("consumeNotificationRoute", () => {
+  it("returns null when the response is null", () => {
+    expect(consumeNotificationRoute(null)).toBeNull();
+  });
+
+  it("returns null when the data has no installment_id", () => {
+    expect(consumeNotificationRoute(makeResponse("a", { foo: "bar" }))).toBeNull();
+  });
+
+  it("builds a /post route with purchaseId when available", () => {
+    expect(
+      consumeNotificationRoute(makeResponse("p-1", { installment_id: "post1", purchase_id: "p1" })),
+    ).toBe("/post/post1?purchaseId=p1");
+  });
+
+  it("falls back to subscriptionId or followerId when purchaseId is missing", () => {
+    expect(
+      consumeNotificationRoute(makeResponse("p-2", { installment_id: "post2", subscription_id: "s2" })),
+    ).toBe("/post/post2?subscriptionId=s2");
+    expect(
+      consumeNotificationRoute(makeResponse("p-3", { installment_id: "post3", follower_id: "f3" })),
+    ).toBe("/post/post3?followerId=f3");
+  });
+
+  it("deduplicates by notification identifier", () => {
+    const response = makeResponse("dup-1", { installment_id: "post-dup" });
+    expect(consumeNotificationRoute(response)).toBe("/post/post-dup");
+    expect(consumeNotificationRoute(response)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the first sub-issue of #257: tapping a "news update" notification opens the Library default view instead of the linked post.
- Moves the cold-start notification response handling into `app/index.tsx`. The default-route `router.replace` was racing with the notification handler's `router.push("/post/{id}")` and wiping it when the async response resolved first.
- `usePushNotifications` now only handles live notification taps (`addNotificationResponseReceivedListener`); the initial-launch response is consumed by `index.tsx` and cleared via `clearLastNotificationResponseAsync` to avoid re-firing on remount.

## Test plan
- [ ] Cold-launch the Android app by tapping a `news update` push notification → app opens directly to `/post/{installment_id}`, not `/(tabs)/library` or `/(tabs)/dashboard`.
- [ ] Tap a push notification while the app is in background → app foregrounds onto `/post/{installment_id}`.
- [ ] Launch the app via the launcher icon (no notification) → app routes to `/(tabs)/library` (consumer) or `/(tabs)/dashboard` (creator) as before.
- [ ] Launch via notification while logged out → app routes to `/login`.
- [ ] Repeat on iOS to confirm parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782378552&installation_id=134400930&pr_number=258&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F258&signature=552fee4f18f6e747746ddb0bbe8669b4a4c8dbc1f05cc6ad279d01b032b514af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app entry navigation and push routing coordination; mistakes could mis-route users on launch or duplicate navigation, but scope is limited to notification handling with solid test coverage.
> 
> **Overview**
> **Cold-start notification deep links** are handled in `app/index.tsx` instead of `usePushNotifications`, so the default tab `router.replace` no longer races with and overwrites a notification-driven `router.push` to `/post/{installment_id}`.
> 
> On launch, index **defers routing** with `requestAnimationFrame`, reads `getLastNotificationResponseAsync`, and when a valid post route exists it **`replace`s the creator/consumer home tab then `push`es the post**, clears the cached notification response, and calls **`markIndexInitialRoutingComplete`**. Unmount/cancel guards avoid navigating after the effect is torn down.
> 
> **`use-push-notifications`** now exposes **`consumeNotificationRoute`** (route building + per-notification dedup) and only handles **live taps** via `addNotificationResponseReceivedListener` after initial routing is complete; it no longer consumes the last response on mount.
> 
> **Tests** cover index notification/cold-start paths and the hook’s route parsing, dedup, and listener gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f306d48242b3c61eb23d7208af56f0c4c66c27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->