### PR TITLE
Fix random filenames on Android downloads

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -71,10 +71,14 @@ const fileIconName = (mediaType: FileMediaType) => {
 const downloadUrl = (urlRedirectToken: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`);
 
-const downloadFile = (urlRedirectToken: string, productFileId: string) =>
-  File.downloadFileAsync(downloadUrl(urlRedirectToken, productFileId), Paths.cache, {
-    idempotent: true,
-  });
+const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|]/g, "_").trim();
+
+const downloadFile = (urlRedirectToken: string, productFileId: string, fileName: string) =>
+  File.downloadFileAsync(
+    downloadUrl(urlRedirectToken, productFileId),
+    new File(Paths.cache, sanitizeFileName(fileName)),
+    { idempotent: true },
+  );
 
 const fontDataPromise = Promise.all(
   [
@@ -151,7 +155,8 @@ export default function PostScreen() {
       setDownloadingFileId(fileId);
       if (!post?.url_redirect_external_id || !purchase?.url_redirect_token)
         throw new Error("Missing URL redirect token");
-      const downloadedFile = await downloadFile(purchase.url_redirect_token, fileId);
+      const file = post.files_data?.find((f) => f.id === fileId);
+      const downloadedFile = await downloadFile(purchase.url_redirect_token, fileId, file?.name ?? fileId);
       const isAvailable = await Sharing.isAvailableAsync();
       if (!isAvailable) throw new Error("Sharing is not available on this device");
       await Sharing.shareAsync(downloadedFile.uri);

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -7,10 +7,11 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
+import { cacheFileDestination } from "@/lib/file-utils";
 import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
-import { File, Paths } from "expo-file-system";
+import { File } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { Asset } from "expo-asset";
@@ -71,12 +72,10 @@ const fileIconName = (mediaType: FileMediaType) => {
 const downloadUrl = (urlRedirectToken: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`);
 
-const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|]/g, "_").trim();
-
 const downloadFile = (urlRedirectToken: string, productFileId: string, fileName: string) =>
   File.downloadFileAsync(
     downloadUrl(urlRedirectToken, productFileId),
-    new File(Paths.cache, sanitizeFileName(fileName)),
+    cacheFileDestination(productFileId, fileName),
     { idempotent: true },
   );
 
@@ -156,7 +155,8 @@ export default function PostScreen() {
       if (!post?.url_redirect_external_id || !purchase?.url_redirect_token)
         throw new Error("Missing URL redirect token");
       const file = post.files_data?.find((f) => f.id === fileId);
-      const downloadedFile = await downloadFile(purchase.url_redirect_token, fileId, file?.name ?? fileId);
+      if (!file) throw new Error("File metadata not found");
+      const downloadedFile = await downloadFile(purchase.url_redirect_token, fileId, file.name);
       const isAvailable = await Sharing.isAvailableAsync();
       if (!isAvailable) throw new Error("Sharing is not available on this device");
       await Sharing.shareAsync(downloadedFile.uri);

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -8,9 +8,10 @@ import { useAddRecentPurchase } from "@/components/library/use-recent-products";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
+import { cacheFileDestination } from "@/lib/file-utils";
 import { safeOpenURL } from "@/lib/open-url";
 import { buildApiUrl } from "@/lib/request";
-import { File, Paths } from "expo-file-system";
+import { File } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -47,10 +48,8 @@ type TocDataMessage = {
 const downloadUrl = (token: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${token}/${productFileId}`);
 
-const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|]/g, "_").trim();
-
 const downloadFile = (token: string, productFileId: string, fileName: string) =>
-  File.downloadFileAsync(downloadUrl(token, productFileId), new File(Paths.cache, sanitizeFileName(fileName)), {
+  File.downloadFileAsync(downloadUrl(token, productFileId), cacheFileDestination(productFileId, fileName), {
     idempotent: true,
   });
 

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -47,8 +47,10 @@ type TocDataMessage = {
 const downloadUrl = (token: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${token}/${productFileId}`);
 
-const downloadFile = (token: string, productFileId: string) =>
-  File.downloadFileAsync(downloadUrl(token, productFileId), Paths.cache, {
+const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|]/g, "_").trim();
+
+const downloadFile = (token: string, productFileId: string, fileName: string) =>
+  File.downloadFileAsync(downloadUrl(token, productFileId), new File(Paths.cache, sanitizeFileName(fileName)), {
     idempotent: true,
   });
 
@@ -185,7 +187,14 @@ export default function DownloadScreen() {
       }
 
       setIsDownloading(true);
-      const downloadedFile = await downloadFile(token, message.payload.resourceId);
+      const fallbackName = message.payload.extension
+        ? `${message.payload.resourceId}.${message.payload.extension.toLowerCase()}`
+        : message.payload.resourceId;
+      const downloadedFile = await downloadFile(
+        token,
+        message.payload.resourceId,
+        fileData?.name ?? fallbackName,
+      );
       await shareFile(downloadedFile.uri);
     } catch (error) {
       console.error("Download failed:", error, data);

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -1,0 +1,9 @@
+import { Directory, File, Paths } from "expo-file-system";
+
+const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|]/g, "_").trim();
+
+export const cacheFileDestination = (uniqueKey: string, fileName: string) => {
+  const dir = new Directory(Paths.cache, uniqueKey);
+  if (!dir.exists) dir.create({ idempotent: true });
+  return new File(dir, sanitizeFileName(fileName));
+};


### PR DESCRIPTION
## Summary
- Fixes the second bug in #257: files downloaded from the Library on Android saved with random-looking names instead of the original product filename.
- `File.downloadFileAsync(url, Paths.cache, …)` passes a directory to expo-file-system; the Android module then calls `URLUtil.guessFileName(url, contentDisposition, contentType)`, which falls back to the URL's last path segment (the opaque product file id) when `Content-Disposition` parsing fails.
- Pass an explicit destination `File(Paths.cache, sanitizeFileName(name))` built from the purchase / post file metadata. Falls back to `<id>.<extension>` when metadata is unavailable.
- Applied in both download call sites: `app/purchase/[token].tsx` (Library product downloads via the in-page WebView) and `app/post/[id].tsx` (post attachment downloads).

## Before
<img width="357" height="803" alt="Screenshot 2026-05-26 at 18 44 13" src="https://github.com/user-attachments/assets/9c24d108-5094-4a0f-b908-f37e5de47f8a" />


## After
<img width="370" height="809" alt="image" src="https://github.com/user-attachments/assets/c7b502f7-dd87-4131-b3a5-c509ab602ccd" />

Real product name:
<img width="339" height="186" alt="image" src="https://github.com/user-attachments/assets/d0b56883-15c6-4877-84b2-014fbcfcec78" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782378656&installation_id=134400930&pr_number=259&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F259&signature=5094e1394990f8e7edb496fe0ee1bdf99e3d5bc96e3bf7f591aaf5b9265e5f78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized download/share path changes with filename sanitization; no auth or API changes.
> 
> **Overview**
> Fixes **Android Library/post downloads** saving with opaque names by no longer relying on `File.downloadFileAsync` into a bare cache directory (where Android guesses the filename from the URL’s product file id).
> 
> Adds **`cacheFileDestination`** in `lib/file-utils.ts`: per-file cache subfolder, sanitized display name, idempotent directory creation. **Library** (`app/purchase/[token].tsx`) passes purchase `file_data` name or `<id>.<extension>`; **post attachments** (`app/post/[id].tsx`) require `files_data` metadata and use `file.name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7bfdab37b5cbea012ed4296d4d4f4d2ed6e953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->