### PR TITLE
Fix iOS notification deep link to post (read trigger.payload)

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -40,6 +40,12 @@ export default function Index() {
         const response = await Notifications.getLastNotificationResponseAsync();
         if (cancelled) return;
         notificationRoute = consumeNotificationRoute(response);
+        Sentry.addBreadcrumb?.({
+          category: "notifications",
+          level: "info",
+          message: "Cold-start notification routing",
+          data: { hasResponse: response != null, route: notificationRoute },
+        });
       } catch (error) {
         Sentry.captureException(error);
       }

--- a/components/use-push-notifications.ts
+++ b/components/use-push-notifications.ts
@@ -75,7 +75,7 @@ export const __resetPushNotificationsModuleStateForTests = () => {
   indexInitialRoutingComplete = false;
 };
 
-const buildNotificationRoute = (data: Record<string, string>): string | null => {
+const buildNotificationRoute = (data: Record<string, any>): string | null => {
   if (!data.installment_id) return null;
   const params = new URLSearchParams();
   if (data.purchase_id) params.set("purchaseId", data.purchase_id);
@@ -89,11 +89,28 @@ export const consumeNotificationRoute = (
   response: Notifications.NotificationResponse | null,
 ): string | null => {
   if (!response) return null;
-  const identifier = response.notification.request.identifier;
+  const request = response.notification.request as {
+    identifier: string;
+    content?: { data?: Record<string, any> | null };
+    trigger?: { payload?: Record<string, any> | null } | null;
+  };
+  const identifier = request.identifier;
   if (handledNotificationIdentifiers.has(identifier)) return null;
-  const data = response.notification.request.content.data as Record<string, string> | undefined;
-  const route = data ? buildNotificationRoute(data) : null;
-  if (!route) return null;
+  const payloads = [request.content?.data, request.trigger?.payload];
+  let route: string | null = null;
+  for (const payload of payloads) {
+    if (payload) route = buildNotificationRoute(payload);
+    if (route) break;
+  }
+  if (!route) {
+    Sentry.addBreadcrumb?.({
+      category: "notifications",
+      level: "warning",
+      message: "Notification tapped but no post route was built",
+      data: { contentData: request.content?.data ?? null, triggerPayload: request.trigger?.payload ?? null },
+    });
+    return null;
+  }
   handledNotificationIdentifiers.add(identifier);
   return route;
 };

--- a/tests/components/use-push-notifications.test.ts
+++ b/tests/components/use-push-notifications.test.ts
@@ -72,10 +72,48 @@ describe("consumeNotificationRoute", () => {
     ).toBe("/post/post3?followerId=f3");
   });
 
+  it("reads the payload from the iOS trigger when content.data is null", () => {
+    const response = {
+      notification: {
+        request: {
+          identifier: "ios-1",
+          content: { data: null },
+          trigger: { payload: { installment_id: "postIos", purchase_id: "pIos", aps: { alert: {} } } },
+        },
+      },
+    } as any;
+    expect(consumeNotificationRoute(response)).toBe("/post/postIos?purchaseId=pIos");
+  });
+
   it("deduplicates by notification identifier", () => {
     const response = makeResponse("dup-1", { installment_id: "post-dup" });
     expect(consumeNotificationRoute(response)).toBe("/post/post-dup");
     expect(consumeNotificationRoute(response)).toBeNull();
+  });
+
+  it("ignores the tag and message fields the Android FCM payload carries", () => {
+    expect(
+      consumeNotificationRoute(
+        makeResponse("a-1", {
+          installment_id: "postA",
+          purchase_id: "pA",
+          tag: "postA",
+          message: "New content added to product",
+        }),
+      ),
+    ).toBe("/post/postA?purchaseId=pA");
+  });
+
+  it("routes each of several distinct notifications (distinct tags are not deduped)", () => {
+    expect(consumeNotificationRoute(makeResponse("postA", { installment_id: "postA", tag: "postA" }))).toBe(
+      "/post/postA",
+    );
+    expect(consumeNotificationRoute(makeResponse("postB", { installment_id: "postB", tag: "postB" }))).toBe(
+      "/post/postB",
+    );
+    expect(consumeNotificationRoute(makeResponse("postC", { installment_id: "postC", tag: "postC" }))).toBe(
+      "/post/postC",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
Tapping a Gumroad push notification on **iOS** opened the home tab instead of the linked post (follow-up to the cold-start work in #258).

**Root cause:** for remote pushes on iOS, `expo-notifications` leaves `request.content.data` **null** and places the APNs payload (`installment_id`, `purchase_id`, …) under **`request.trigger.payload`**. The handler only read `content.data`, so it never found `installment_id` and fell back to the default tab. (Verified against the real backend payload in `gumroad` — `post_sendgrid_api.rb` sends those keys top-level on iOS / in the FCM `data` field on Android.)

**Fix:** `consumeNotificationRoute` now reads the payload from **both** `request.content.data` (Android FCM data field / Expo push) and `request.trigger.payload` (iOS remote), so the route resolves on both platforms. Added Sentry breadcrumbs at the cold-start and parse sites to surface the payload shape if a future notification ever fails to route.

## Changes
- `components/use-push-notifications.ts` — read payload from `content.data` **and** `trigger.payload`; breadcrumb when no route is built.
- `app/index.tsx` — breadcrumb recording cold-start response/route.
- `tests/components/use-push-notifications.test.ts` — cover the iOS `trigger.payload` shape, the Android FCM payload (with `tag`/`message` ignored), and multi-notification routing.

## Test plan
Verified end-to-end on **iOS simulator** and **Android emulator** against production data:
- [x] Cold-start tap → opens `/post/{installment_id}` (not the home tab).
- [x] Installment content loads (`200`) once `purchase_id` is included (matches the real push payload).
- [x] Android: multiple distinct notifications stack as separate tray entries; tapping one routes correctly and leaves the others (complements the backend tag fix antiwork/gumroad#5289).
- [x] `tsc --noEmit`, `expo lint`, and `jest` (200/200) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783506329&installation_id=134400930&pr_number=264&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F264&signature=65453dade68de3e7a5d0fa7f18f9c0036ad5154c65b9e8293cc76e55898fc4db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to notification routing and observability; Android behavior stays on content.data first, with no auth or data-model changes.
> 
> **Overview**
> Fixes **iOS push notification deep links** so tapping a notification opens the linked post instead of the default home tab.
> 
> `consumeNotificationRoute` now resolves routing data from **`request.content.data`** (Android / Expo) and **`request.trigger.payload`** (iOS remote APNs), trying each until a `/post/{installment_id}` route can be built. When parsing fails, it records a **Sentry warning breadcrumb** with both payload shapes; cold-start routing in `app/index.tsx` adds an **info breadcrumb** for the last response and resolved route.
> 
> Tests cover the iOS `trigger.payload` shape, Android FCM payloads with extra `tag`/`message` fields, and routing multiple distinct notifications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2105b2aeb8ee3ac38a67d1712a26ef9c56c82f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->