### PR TITLE
Fix Android app crash when leaving the video player

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -14,6 +14,15 @@ import { AppState, type AppStateStatus, StyleSheet, View } from "react-native";
 const fetchStreamingPlaylistUrl = async (streamingUrl: string, accessToken: string): Promise<string> =>
   (await requestAPI<{ playlist_url: string }>(streamingUrl, { accessToken })).playlist_url;
 
+const withReleasedPlayerGuard = (operation: () => void) => {
+  try {
+    operation();
+  } catch (error) {
+    if ((error as { code?: string })?.code === "ERR_USING_RELEASED_SHARED_OBJECT") return;
+    throw error;
+  }
+};
+
 export default function VideoPlayerScreen() {
   const { accessToken } = useAuth();
   const { uri, streamingUrl, title, urlRedirectId, productFileId, purchaseId, initialPosition } = useLocalSearchParams<{
@@ -71,27 +80,29 @@ export default function VideoPlayerScreen() {
 
   useEffect(() => {
     const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
-      if (nextState === "background" || nextState === "inactive") {
-        wasPlayingBeforeBackgroundRef.current = player.playing;
-        positionBeforeBackgroundRef.current = player.currentTime;
-        player.pause();
-      } else if (nextState === "active") {
-        const savedPosition = positionBeforeBackgroundRef.current;
-        if (savedPosition !== null && player.currentTime < savedPosition - 1) {
-          player.currentTime = savedPosition;
+      withReleasedPlayerGuard(() => {
+        if (nextState === "background" || nextState === "inactive") {
+          wasPlayingBeforeBackgroundRef.current = player.playing;
+          positionBeforeBackgroundRef.current = player.currentTime;
+          player.pause();
+        } else if (nextState === "active") {
+          const savedPosition = positionBeforeBackgroundRef.current;
+          if (savedPosition !== null && player.currentTime < savedPosition - 1) {
+            player.currentTime = savedPosition;
+          }
+          positionBeforeBackgroundRef.current = null;
+          if (wasPlayingBeforeBackgroundRef.current) {
+            player.play();
+            wasPlayingBeforeBackgroundRef.current = false;
+          }
         }
-        positionBeforeBackgroundRef.current = null;
-        if (wasPlayingBeforeBackgroundRef.current) {
-          player.play();
-          wasPlayingBeforeBackgroundRef.current = false;
-        }
-      }
+      });
     });
 
     return () => subscription.remove();
   }, [player]);
 
-  useEffect(() => () => player.pause(), [player]);
+  useEffect(() => () => withReleasedPlayerGuard(() => player.pause()), [player]);
 
   useEffect(() => {
     const subscription = player.addListener(

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -14,11 +14,17 @@ import { AppState, type AppStateStatus, StyleSheet, View } from "react-native";
 const fetchStreamingPlaylistUrl = async (streamingUrl: string, accessToken: string): Promise<string> =>
   (await requestAPI<{ playlist_url: string }>(streamingUrl, { accessToken })).playlist_url;
 
+const isReleasedPlayerError = (error: unknown): boolean => {
+  const { code, message } = (error ?? {}) as { code?: string; message?: string };
+  if (code === "ERR_USING_RELEASED_SHARED_OBJECT" || code === "ERR_NATIVE_SHARED_OBJECT_NOT_FOUND") return true;
+  return /shared object that was already released|find the native shared object/i.test(message ?? "");
+};
+
 const withReleasedPlayerGuard = (operation: () => void) => {
   try {
     operation();
   } catch (error) {
-    if ((error as { code?: string })?.code === "ERR_USING_RELEASED_SHARED_OBJECT") return;
+    if (isReleasedPlayerError(error)) return;
     throw error;
   }
 };

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -126,6 +126,28 @@ describe("VideoPlayerScreen", () => {
     expect(mockPlayer.pause).toHaveBeenCalled();
   });
 
+  it("does not crash on unmount when the player has already been released", () => {
+    const { unmount } = renderScreen();
+    mockPlayer.pause.mockImplementation(() => {
+      throw Object.assign(new Error("Cannot use shared object that was already released"), {
+        code: "ERR_USING_RELEASED_SHARED_OBJECT",
+      });
+    });
+
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it("does not crash on background when the player has already been released", () => {
+    renderScreen();
+    mockPlayer.pause.mockImplementation(() => {
+      throw Object.assign(new Error("Cannot use shared object that was already released"), {
+        code: "ERR_USING_RELEASED_SHARED_OBJECT",
+      });
+    });
+
+    expect(() => act(() => appStateCallback!("background"))).not.toThrow();
+  });
+
   it("restores the playback position when returning from background", () => {
     renderScreen();
     mockPlayer.currentTime = 120;

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -148,6 +148,34 @@ describe("VideoPlayerScreen", () => {
     expect(() => act(() => appStateCallback!("background"))).not.toThrow();
   });
 
+  it("does not crash on unmount when the player call fails with the iOS not-found exception", () => {
+    const { unmount } = renderScreen();
+    mockPlayer.pause.mockImplementation(() => {
+      throw Object.assign(
+        new Error(
+          "Calling the 'pause' function has failed\n→ Caused by: Unable to find the native shared object associated with given JavaScript object",
+        ),
+        { code: "ERR_FUNCTION_CALL" },
+      );
+    });
+
+    expect(() => unmount()).not.toThrow();
+  });
+
+  it("does not crash on background when the player call fails with the iOS not-found exception", () => {
+    renderScreen();
+    mockPlayer.pause.mockImplementation(() => {
+      throw Object.assign(
+        new Error(
+          "Calling the 'pause' function has failed\n→ Caused by: Unable to find the native shared object associated with given JavaScript object",
+        ),
+        { code: "ERR_FUNCTION_CALL" },
+      );
+    });
+
+    expect(() => act(() => appStateCallback!("background"))).not.toThrow();
+  });
+
   it("restores the playback position when returning from background", () => {
     renderScreen();
     mockPlayer.currentTime = 120;


### PR DESCRIPTION
## What

On Android, opening a video and pressing back closed the **entire app** instead of returning to the previous screen (Fixes #267). The "app close" is a fatal, unhandled JS exception on the back path. This guards the player calls that run during teardown so they can no longer crash the app.

## Why

Tearing down the video screen runs this cleanup:

```ts
useEffect(() => () => player.pause(), [player]);
```

During back navigation, `react-native-screens` freezes/detaches the screen and expo-video's `useReleasingSharedObject` releases the native player. The subsequent `player.pause()` then runs against an **already-released** shared object and throws:

```
Call to function 'VideoPlayer.pause' has been rejected.
→ Caused by: Cannot use shared object that was already released
   code: ERR_USING_RELEASED_SHARED_OBJECT
```

In dev this is a red box; in production it is an uncaught exception that closes the app — matching the report and the high-volume `player.*` expo-video Sentry crash group. The race is timing-dependent, which is why it can't be reproduced reliably in-house yet hits many users in the wild.

**Approach chosen:** wrap the player calls that can run during teardown — the unmount `pause()` and the `AppState` background/foreground handler — in a guard that swallows `ERR_USING_RELEASED_SHARED_OBJECT` and rethrows everything else. This neutralizes the exact failing call regardless of teardown ordering, with no behavior change on the happy path. Alternatives considered and rejected: deferring player creation to avoid the null-source recreation (verified on-device to *not* prevent this crash); removing the manual pause (relies on release timing and still leaves the AppState path exposed).

## Before/After

Verified on an Android emulator (API 36) against the production API.

- **Before (unguarded):** back from the video player → `ERR_USING_RELEASED_SHARED_OBJECT` from `player.pause()` (red box + logcat); in production this closes the app.
- **After (this PR):** repeated open → back cycles with both system back and the header back arrow (including the playback-error state) → returns to the previous screen, app stays alive, no exception.

_Walkthrough video attached as a comment below (GitHub media can only be uploaded through the web UI)._

## Test Results

`jest` — 29 suites, 214 tests passing, including two new regression tests in `tests/app/video-player.test.tsx` that assert teardown/background no longer crash when the player is already released. Both fail when the guard is reverted.

```
Test Suites: 29 passed, 29 total
Tests:       214 passed, 214 total
```

`tsc --noEmit` and `expo lint` both clean.

---

### AI disclosure

Model: **Claude Opus 4.8** (via Claude Code).

Prompts given by the author:
1. "github.com/antiwork/gumroad-mobile/issues/267 — debug and fix this, create PR and assign to me"
2. "are you 100% sure it will fix the issue?"
3. "do verification on real app on simulator, run the app either iOS or Android and verify the fix, and test before/after. update the env first to use production API"
4. "so does the PR fix the issue?"
5. "check reviewer comments, and address them if correct"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change around teardown timing; happy-path playback is unchanged and other errors still propagate.
> 
> **Overview**
> Fixes a fatal crash when leaving the video player on Android by **guarding expo-video player calls** that can run after the native player is already released during screen teardown.
> 
> Adds `isReleasedPlayerError` / `withReleasedPlayerGuard` to swallow `ERR_USING_RELEASED_SHARED_OBJECT`, `ERR_NATIVE_SHARED_OBJECT_NOT_FOUND`, and matching message patterns, while rethrowing other errors. Wraps the **unmount** `player.pause()` cleanup and the full **AppState** background/foreground handler so `pause`, seek, and resume no longer throw when the shared object is gone.
> 
> Adds regression tests in `video-player.test.tsx` for unmount and background paths when `pause` throws released-player errors (Android) and iOS “native shared object not found” failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860c657a95dcd672316f82b06bfe3853d038616f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->