### PR TITLE
Add Payout settings screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,7 +13,7 @@ import { safeOpenURL } from "@/lib/open-url";
 import { BottomTabBar } from "@react-navigation/bottom-tabs";
 import * as Application from "expo-application";
 import Constants from "expo-constants";
-import { Tabs } from "expo-router";
+import { Tabs, useRouter } from "expo-router";
 import { createContext, useContext, useRef, useState } from "react";
 import { Alert, Pressable, TouchableOpacity, View } from "react-native";
 import { useCSSVariable, useResolveClassNames } from "uniwind";
@@ -94,12 +94,18 @@ const SettingsButton = () => {
 
 const SettingsSheet = () => {
   const { isSettingsOpen, setSettingsOpen } = useSettingsSheet();
-  const { logout } = useAuth();
+  const { logout, isCreator } = useAuth();
   const { data: user, isLoading: isUserLoading } = useUser();
+  const router = useRouter();
 
   const handleLogout = () => {
     setSettingsOpen(false);
     logout();
+  };
+
+  const handlePayoutSettings = () => {
+    setSettingsOpen(false);
+    router.push("/settings/payments");
   };
 
   const handleDeleteAccount = () => {
@@ -117,6 +123,16 @@ const SettingsSheet = () => {
         <SheetTitle>Settings</SheetTitle>
       </SheetHeader>
       <SheetContent>
+        {isCreator ? (
+          <View className="border-b border-border p-4">
+            <Text className="mb-2 font-sans text-lg text-foreground">Payouts</Text>
+            <Text className="mb-4 text-sm text-muted-foreground">Manage how and when you get paid.</Text>
+            <Button variant="outline" onPress={handlePayoutSettings}>
+              <Text>Payout settings</Text>
+              <LineIcon name="dollar-circle" size={20} className="text-foreground" />
+            </Button>
+          </View>
+        ) : null}
         <View className="border-b border-border p-4">
           <Text className="mb-2 font-sans text-lg text-foreground">Feedback</Text>
           <Text className="mb-4 text-sm text-muted-foreground">Report a bug or suggest an improvement.</Text>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -123,16 +123,6 @@ const SettingsSheet = () => {
         <SheetTitle>Settings</SheetTitle>
       </SheetHeader>
       <SheetContent>
-        {isCreator ? (
-          <View className="border-b border-border p-4">
-            <Text className="mb-2 font-sans text-lg text-foreground">Payouts</Text>
-            <Text className="mb-4 text-sm text-muted-foreground">Manage how and when you get paid.</Text>
-            <Button variant="outline" onPress={handlePayoutSettings}>
-              <Text>Payout settings</Text>
-              <LineIcon name="dollar-circle" size={20} className="text-foreground" />
-            </Button>
-          </View>
-        ) : null}
         <View className="border-b border-border p-4">
           <Text className="mb-2 font-sans text-lg text-foreground">Feedback</Text>
           <Text className="mb-4 text-sm text-muted-foreground">Report a bug or suggest an improvement.</Text>
@@ -164,6 +154,12 @@ const SettingsSheet = () => {
               </>
             ) : null}
           </View>
+          {isCreator ? (
+            <Button variant="outline" className="mb-2" onPress={handlePayoutSettings}>
+              <Text>Payout settings</Text>
+              <LineIcon name="dollar-circle" size={20} className="text-foreground" />
+            </Button>
+          ) : null}
           <Button onPress={handleLogout}>
             <Text>Logout</Text>
             <LineIcon name="arrow-out-left-square-half" size={20} className="text-primary-foreground" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -73,6 +73,7 @@ const RootLayout = () => {
             <Stack.Screen name="(tabs)" options={{ headerShown: false, animation: "none" }} />
             <Stack.Screen name="purchase/[token]" options={{ title: "" }} />
             <Stack.Screen name="sales-export" options={{ title: "Export all sales" }} />
+            <Stack.Screen name="settings/payments" options={{ title: "Payouts" }} />
             <Stack.Screen name="post/[id]" options={{ title: "" }} />
             <Stack.Screen name="pdf-viewer" options={{ title: "PDF" }} />
             <Stack.Screen name="+not-found" options={{ title: "Not Found" }} />

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -34,6 +34,7 @@ export default function PayoutSettingsScreen() {
   const webViewRef = useRef<BaseWebView>(null);
   const [canSave, setCanSave] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const url = useMemo(
     () =>
@@ -65,10 +66,11 @@ export default function PayoutSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
+    mainUrlRef.current = url;
     setCanSave(false);
     setHasError(false);
-    webViewRef.current?.reload();
-  }, []);
+    setReloadKey((k) => k + 1);
+  }, [url]);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
     if (event.nativeEvent.url !== mainUrlRef.current) return;
@@ -113,7 +115,7 @@ export default function PayoutSettingsScreen() {
         }}
       />
       <StyledWebView
-        key={accessToken ?? "anonymous"}
+        key={`${accessToken ?? "anonymous"}-${reloadKey}`}
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -143,6 +143,8 @@ export default function PayoutSettingsScreen() {
         pullToRefreshEnabled
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
+        setSupportMultipleWindows
+        javaScriptCanOpenWindowsAutomatically
         originWhitelist={["*"]}
         onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -8,7 +8,7 @@ import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
 import * as Sentry from "@sentry/react-native";
 import { Stack } from "expo-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
 import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
@@ -49,9 +49,7 @@ export default function PayoutSettingsScreen() {
     try {
       const message = JSON.parse(event.nativeEvent.data) as { type: string; canUpdate?: boolean };
       if (message.type === "settingsCanUpdate") setCanSave(Boolean(message.canUpdate));
-    } catch {
-      // ignore non-JSON messages
-    }
+    } catch {}
   }, []);
 
   const handleShouldStartLoadWithRequest = useCallback(
@@ -65,19 +63,27 @@ export default function PayoutSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
+    setCanSave(false);
     setHasError(false);
-    webViewRef.current?.reload();
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
+    setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Payouts WebView load error: ${event.nativeEvent.description}`));
   }, []);
 
-  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
-    setHasError(true);
-    Sentry.captureException(new Error(`Payouts WebView HTTP error: ${event.nativeEvent.statusCode}`));
-  }, []);
+  const handleHttpError = useCallback(
+    (event: WebViewHttpErrorEvent) => {
+      if (event.nativeEvent.url !== url) return;
+      setCanSave(false);
+      setHasError(true);
+      Sentry.captureException(new Error(`Payouts WebView HTTP error: ${event.nativeEvent.statusCode}`));
+    },
+    [url],
+  );
+
+  useEffect(() => setCanSave(false), [accessToken]);
 
   if (isLoading) {
     return (

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -65,23 +65,22 @@ export default function PayoutSettingsScreen() {
   const handleRetry = useCallback(() => {
     setCanSave(false);
     setHasError(false);
+    webViewRef.current?.reload();
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
+    const isGumroadDocument = (() => {
+      try {
+        return new URL(event.nativeEvent.url).origin === gumroadOrigin;
+      } catch {
+        return false;
+      }
+    })();
+    if (!isGumroadDocument) return;
     setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Payouts WebView load error: ${event.nativeEvent.description}`));
   }, []);
-
-  const handleHttpError = useCallback(
-    (event: WebViewHttpErrorEvent) => {
-      if (event.nativeEvent.url !== url) return;
-      setCanSave(false);
-      setHasError(true);
-      Sentry.captureException(new Error(`Payouts WebView HTTP error: ${event.nativeEvent.statusCode}`));
-    },
-    [url],
-  );
 
   useEffect(() => setCanSave(false), [accessToken]);
 
@@ -105,8 +104,22 @@ export default function PayoutSettingsScreen() {
           ),
         }}
       />
+      <StyledWebView
+        key={accessToken ?? "anonymous"}
+        ref={webViewRef}
+        source={{ uri: url }}
+        className="flex-1 bg-transparent"
+        webviewDebuggingEnabled={__DEV__}
+        pullToRefreshEnabled
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        originWhitelist={["*"]}
+        onMessage={handleMessage}
+        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onError={handleError}
+      />
       {hasError ? (
-        <View className="flex-1 items-center justify-center gap-4 bg-body-bg p-6">
+        <View className="absolute inset-0 items-center justify-center gap-4 bg-body-bg p-6">
           <Text className="text-center text-lg font-bold text-foreground">Something went wrong</Text>
           <Text className="text-center font-sans text-muted">
             We couldn&apos;t load your payout settings. Please check your connection and try again.
@@ -115,23 +128,7 @@ export default function PayoutSettingsScreen() {
             <Text>Retry</Text>
           </Button>
         </View>
-      ) : (
-        <StyledWebView
-          key={accessToken ?? "anonymous"}
-          ref={webViewRef}
-          source={{ uri: url }}
-          className="flex-1 bg-transparent"
-          webviewDebuggingEnabled={__DEV__}
-          pullToRefreshEnabled
-          sharedCookiesEnabled
-          thirdPartyCookiesEnabled
-          originWhitelist={["*"]}
-          onMessage={handleMessage}
-          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
-          onError={handleError}
-          onHttpError={handleHttpError}
-        />
-      )}
+      ) : null}
     </Screen>
   );
 }

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -1,0 +1,94 @@
+import { StyledWebView } from "@/components/styled";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { Screen } from "@/components/ui/screen";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
+import { env } from "@/lib/env";
+import { safeOpenURL } from "@/lib/open-url";
+import { Stack } from "expo-router";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
+
+const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
+
+const isWebUrl = (url: string) => /^https?:\/\//.test(url);
+
+const isGumroadUrl = (url: string) => {
+  try {
+    return new URL(url).origin === gumroadOrigin;
+  } catch {
+    return false;
+  }
+};
+
+export default function PayoutSettingsScreen() {
+  const { isLoading, accessToken } = useAuth();
+  const webViewRef = useRef<BaseWebView>(null);
+  const [canSave, setCanSave] = useState(false);
+
+  const url = useMemo(
+    () =>
+      `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/payments?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`,
+    [accessToken],
+  );
+
+  const handleSave = useCallback(() => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: "mobileAppSettingsSave" }));
+  }, []);
+
+  const handleMessage = useCallback((event: WebViewMessageEvent) => {
+    try {
+      const message = JSON.parse(event.nativeEvent.data) as { type: string; canUpdate?: boolean };
+      if (message.type === "settingsCanUpdate") setCanSave(Boolean(message.canUpdate));
+    } catch {
+      // ignore non-JSON messages
+    }
+  }, []);
+
+  const handleShouldStartLoadWithRequest = useCallback(
+    (request: { url: string; mainDocumentURL?: string }) => {
+      if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
+      if (request.url === url || !isWebUrl(request.url) || isGumroadUrl(request.url)) return true;
+      safeOpenURL(request.url);
+      return false;
+    },
+    [url],
+  );
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-body-bg">
+        <LoadingSpinner size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <Screen>
+      <Stack.Screen
+        options={{
+          title: "Payouts",
+          headerRight: () => (
+            <TouchableOpacity onPress={handleSave} disabled={!canSave} className="mr-3">
+              <Text className={canSave ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
+            </TouchableOpacity>
+          ),
+        }}
+      />
+      <StyledWebView
+        key={accessToken ?? "anonymous"}
+        ref={webViewRef}
+        source={{ uri: url }}
+        className="flex-1 bg-transparent"
+        webviewDebuggingEnabled
+        pullToRefreshEnabled
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        originWhitelist={["*"]}
+        onMessage={handleMessage}
+        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+      />
+    </Screen>
+  );
+}

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -29,6 +29,9 @@ const isAllowedInWebView = (url: string) => {
   }
 };
 
+const buildPayoutUrl = (token: string | null) =>
+  `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/payments?display=mobile_app&access_token=${token}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`;
+
 export default function PayoutSettingsScreen() {
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
@@ -36,11 +39,11 @@ export default function PayoutSettingsScreen() {
   const [hasError, setHasError] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
 
-  const url = useMemo(
-    () =>
-      `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/payments?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`,
-    [accessToken],
-  );
+  const sessionTokenRef = useRef(accessToken);
+  if (sessionTokenRef.current == null) sessionTokenRef.current = accessToken;
+  const sessionToken = sessionTokenRef.current;
+
+  const url = useMemo(() => buildPayoutUrl(sessionToken), [sessionToken]);
 
   const mainUrlRef = useRef(url);
 
@@ -66,11 +69,12 @@ export default function PayoutSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
-    mainUrlRef.current = url;
+    sessionTokenRef.current = accessToken;
+    mainUrlRef.current = buildPayoutUrl(accessToken);
     setCanSave(false);
     setHasError(false);
     setReloadKey((k) => k + 1);
-  }, [url]);
+  }, [accessToken]);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
     if (event.nativeEvent.url !== mainUrlRef.current) return;
@@ -115,7 +119,7 @@ export default function PayoutSettingsScreen() {
         }}
       />
       <StyledWebView
-        key={`${accessToken ?? "anonymous"}-${reloadKey}`}
+        key={`${sessionToken ?? "anonymous"}-${reloadKey}`}
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -19,11 +19,18 @@ const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
 
 const isWebUrl = (url: string) => /^https?:\/\//.test(url);
 
+const isPaymentProviderUrl = (url: string) => {
+  try {
+    const { hostname } = new URL(url);
+    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
+  } catch {
+    return false;
+  }
+};
+
 const isAllowedInWebView = (url: string) => {
   try {
-    const { origin, hostname } = new URL(url);
-    if (origin === gumroadOrigin) return true;
-    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
+    return new URL(url).origin === gumroadOrigin || isPaymentProviderUrl(url);
   } catch {
     return false;
   }
@@ -69,7 +76,12 @@ export default function PayoutSettingsScreen() {
   );
 
   const handleOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
-    safeOpenURL(event.nativeEvent.targetUrl);
+    const { targetUrl } = event.nativeEvent;
+    if (isPaymentProviderUrl(targetUrl)) {
+      webViewRef.current?.injectJavaScript(`window.location.href = ${JSON.stringify(targetUrl)}; true;`);
+    } else {
+      safeOpenURL(targetUrl);
+    }
   }, []);
 
   const handleRetry = useCallback(() => {

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent, WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -67,6 +67,10 @@ export default function PayoutSettingsScreen() {
     },
     [url],
   );
+
+  const handleOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
+    safeOpenURL(event.nativeEvent.targetUrl);
+  }, []);
 
   const handleRetry = useCallback(() => {
     sessionTokenRef.current = accessToken;
@@ -130,6 +134,7 @@ export default function PayoutSettingsScreen() {
         originWhitelist={["*"]}
         onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onOpenWindow={handleOpenWindow}
         onNavigationStateChange={(navState) => {
           mainUrlRef.current = navState.url;
         }}

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -1,22 +1,29 @@
 import { StyledWebView } from "@/components/styled";
+import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
+import * as Sentry from "@sentry/react-native";
 import { Stack } from "expo-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
+const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
+
 const isWebUrl = (url: string) => /^https?:\/\//.test(url);
 
-const isGumroadUrl = (url: string) => {
+const isAllowedInWebView = (url: string) => {
   try {
-    return new URL(url).origin === gumroadOrigin;
+    const { origin, hostname } = new URL(url);
+    if (origin === gumroadOrigin) return true;
+    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
   } catch {
     return false;
   }
@@ -26,6 +33,7 @@ export default function PayoutSettingsScreen() {
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
   const [canSave, setCanSave] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   const url = useMemo(
     () =>
@@ -49,12 +57,27 @@ export default function PayoutSettingsScreen() {
   const handleShouldStartLoadWithRequest = useCallback(
     (request: { url: string; mainDocumentURL?: string }) => {
       if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
-      if (request.url === url || !isWebUrl(request.url) || isGumroadUrl(request.url)) return true;
+      if (request.url === url || !isWebUrl(request.url) || isAllowedInWebView(request.url)) return true;
       safeOpenURL(request.url);
       return false;
     },
     [url],
   );
+
+  const handleRetry = useCallback(() => {
+    setHasError(false);
+    webViewRef.current?.reload();
+  }, []);
+
+  const handleError = useCallback((event: WebViewErrorEvent) => {
+    setHasError(true);
+    Sentry.captureException(new Error(`Payouts WebView load error: ${event.nativeEvent.description}`));
+  }, []);
+
+  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
+    setHasError(true);
+    Sentry.captureException(new Error(`Payouts WebView HTTP error: ${event.nativeEvent.statusCode}`));
+  }, []);
 
   if (isLoading) {
     return (
@@ -70,25 +93,39 @@ export default function PayoutSettingsScreen() {
         options={{
           title: "Payouts",
           headerRight: () => (
-            <TouchableOpacity onPress={handleSave} disabled={!canSave} className="mr-3">
-              <Text className={canSave ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
+            <TouchableOpacity onPress={handleSave} disabled={!canSave || hasError} className="mr-3">
+              <Text className={canSave && !hasError ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
             </TouchableOpacity>
           ),
         }}
       />
-      <StyledWebView
-        key={accessToken ?? "anonymous"}
-        ref={webViewRef}
-        source={{ uri: url }}
-        className="flex-1 bg-transparent"
-        webviewDebuggingEnabled
-        pullToRefreshEnabled
-        sharedCookiesEnabled
-        thirdPartyCookiesEnabled
-        originWhitelist={["*"]}
-        onMessage={handleMessage}
-        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
-      />
+      {hasError ? (
+        <View className="flex-1 items-center justify-center gap-4 bg-body-bg p-6">
+          <Text className="text-center text-lg font-bold text-foreground">Something went wrong</Text>
+          <Text className="text-center font-sans text-muted">
+            We couldn&apos;t load your payout settings. Please check your connection and try again.
+          </Text>
+          <Button onPress={handleRetry}>
+            <Text>Retry</Text>
+          </Button>
+        </View>
+      ) : (
+        <StyledWebView
+          key={accessToken ?? "anonymous"}
+          ref={webViewRef}
+          source={{ uri: url }}
+          className="flex-1 bg-transparent"
+          webviewDebuggingEnabled={__DEV__}
+          pullToRefreshEnabled
+          sharedCookiesEnabled
+          thirdPartyCookiesEnabled
+          originWhitelist={["*"]}
+          onMessage={handleMessage}
+          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+          onError={handleError}
+          onHttpError={handleHttpError}
+        />
+      )}
     </Screen>
   );
 }

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -41,6 +41,8 @@ export default function PayoutSettingsScreen() {
     [accessToken],
   );
 
+  const mainUrlRef = useRef(url);
+
   const handleSave = useCallback(() => {
     webViewRef.current?.postMessage(JSON.stringify({ type: "mobileAppSettingsSave" }));
   }, []);
@@ -69,20 +71,25 @@ export default function PayoutSettingsScreen() {
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
-    const isGumroadDocument = (() => {
-      try {
-        return new URL(event.nativeEvent.url).origin === gumroadOrigin;
-      } catch {
-        return false;
-      }
-    })();
-    if (!isGumroadDocument) return;
+    if (event.nativeEvent.url !== mainUrlRef.current) return;
     setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Payouts WebView load error: ${event.nativeEvent.description}`));
   }, []);
 
-  useEffect(() => setCanSave(false), [accessToken]);
+  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
+    if (event.nativeEvent.url !== mainUrlRef.current) return;
+    setCanSave(false);
+    setHasError(true);
+    Sentry.captureException(
+      new Error(`Payouts WebView HTTP error ${event.nativeEvent.statusCode}: ${event.nativeEvent.description}`),
+    );
+  }, []);
+
+  useEffect(() => {
+    setCanSave(false);
+    setHasError(false);
+  }, [accessToken]);
 
   if (isLoading) {
     return (
@@ -116,7 +123,11 @@ export default function PayoutSettingsScreen() {
         originWhitelist={["*"]}
         onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onNavigationStateChange={(navState) => {
+          mainUrlRef.current = navState.url;
+        }}
         onError={handleError}
+        onHttpError={handleHttpError}
       />
       {hasError ? (
         <View className="absolute inset-0 items-center justify-center gap-4 bg-body-bg p-6">

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -87,9 +87,10 @@ export default function PayoutSettingsScreen() {
   }, []);
 
   useEffect(() => {
+    mainUrlRef.current = url;
     setCanSave(false);
     setHasError(false);
-  }, [accessToken]);
+  }, [url]);
 
   if (isLoading) {
     return (

--- a/tests/app/payments.test.tsx
+++ b/tests/app/payments.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react-native";
 
 const mockUseAuth = jest.fn();
 const mockSafeOpenURL = jest.fn();
+const mockInjectJavaScript = jest.fn();
 
 jest.mock("@/lib/auth-context", () => ({
   useAuth: () => mockUseAuth(),
@@ -28,8 +29,10 @@ jest.mock("react-native-webview", () => {
   const React = require("react");
   const { View } = require("react-native");
   return {
-    WebView: (props: Record<string, unknown>) =>
-      React.createElement(View, { testID: "payments-webview", ...props }),
+    WebView: React.forwardRef(function MockWebView(props: Record<string, unknown>, ref: unknown) {
+      React.useImperativeHandle(ref, () => ({ injectJavaScript: mockInjectJavaScript, postMessage: jest.fn() }));
+      return React.createElement(View, { testID: "payments-webview", ...props });
+    }),
   };
 });
 
@@ -67,5 +70,21 @@ describe("PayoutSettingsScreen", () => {
 
     expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+
+  it("opens target=_blank help links externally but keeps provider popups in the WebView", () => {
+    render(<PayoutSettingsScreen />);
+
+    const onOpenWindow = screen.getByTestId("payments-webview").props.onOpenWindow as (event: {
+      nativeEvent: { targetUrl: string };
+    }) => void;
+
+    onOpenWindow({ nativeEvent: { targetUrl: "https://example.com/help/article/260-your-payout-settings-page" } });
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("https://example.com/help/article/260-your-payout-settings-page");
+
+    mockSafeOpenURL.mockClear();
+    onOpenWindow({ nativeEvent: { targetUrl: "https://connect.stripe.com/setup/s/abc" } });
+    expect(mockSafeOpenURL).not.toHaveBeenCalled();
+    expect(mockInjectJavaScript).toHaveBeenCalled();
   });
 });

--- a/tests/app/payments.test.tsx
+++ b/tests/app/payments.test.tsx
@@ -55,6 +55,10 @@ describe("PayoutSettingsScreen", () => {
     expect(source.uri).toContain("access_token=test-access-token");
     expect(source.uri).toContain("mobile_token=test-mobile-token");
     expect(source.uri).toBe(expectedUrl);
+
+    const props = screen.getByTestId("payments-webview").props;
+    expect(props.setSupportMultipleWindows).toBe(true);
+    expect(props.javaScriptCanOpenWindowsAutomatically).toBe(true);
   });
 
   it("keeps payment-provider and Gumroad navigation in the WebView and opens unrelated links outside it", () => {

--- a/tests/app/payments.test.tsx
+++ b/tests/app/payments.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react-native";
+
+const mockUseAuth = jest.fn();
+const mockSafeOpenURL = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/open-url", () => ({
+  safeOpenURL: (url: string) => mockSafeOpenURL(url),
+}));
+
+jest.mock("expo-router", () => ({
+  Stack: {
+    Screen: ({ options }: { options?: { headerRight?: () => React.ReactNode } }) => {
+      const React = require("react");
+      return React.createElement(React.Fragment, null, options?.headerRight?.());
+    },
+  },
+}));
+
+jest.mock("@sentry/react-native", () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock("react-native-webview", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    WebView: (props: Record<string, unknown>) =>
+      React.createElement(View, { testID: "payments-webview", ...props }),
+  };
+});
+
+import PayoutSettingsScreen from "@/app/settings/payments";
+
+const expectedUrl =
+  "https://example.com/settings/payments?display=mobile_app&access_token=test-access-token&mobile_token=test-mobile-token";
+
+describe("PayoutSettingsScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isLoading: false, accessToken: "test-access-token" });
+  });
+
+  it("loads the authenticated payouts page inside the WebView", () => {
+    render(<PayoutSettingsScreen />);
+
+    const source = screen.getByTestId("payments-webview").props.source as { uri: string };
+    expect(source.uri).toContain("display=mobile_app");
+    expect(source.uri).toContain("access_token=test-access-token");
+    expect(source.uri).toContain("mobile_token=test-mobile-token");
+    expect(source.uri).toBe(expectedUrl);
+  });
+
+  it("keeps payment-provider and Gumroad navigation in the WebView and opens unrelated links outside it", () => {
+    render(<PayoutSettingsScreen />);
+
+    const shouldStart = screen.getByTestId("payments-webview").props.onShouldStartLoadWithRequest as (request: {
+      url: string;
+      mainDocumentURL?: string;
+    }) => boolean;
+
+    expect(shouldStart({ url: "https://connect-js.stripe.com/v1.0/connect.js" })).toBe(true);
+    expect(shouldStart({ url: "https://example.com/settings/payments" })).toBe(true);
+
+    expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+});


### PR DESCRIPTION
## What

Adds a **Payout settings** screen — a native screen wrapping `/settings/payments` in an authenticated WebView (chrome hidden, Save bridged to the native header), reachable from the settings sheet's **Account** section.

## Companion PR

Web backend: `antiwork/gumroad` #5536 (WebView auth + chrome hiding + Save bridge).

## Review fixes included

- Keep payment-provider/challenge hosts (`*.stripe.com`, `*.paypal.com`, `*.cloudflare.com`) loading **inside** the WebView so Stripe Connect / PayPal onboarding doesn't escape to Safari (mirrors the download screen's allowlist).
- Added `onError`/`onHttpError` with a friendly retry UI + Sentry reporting (no more permanent blank screen / dead Save on failure).
- Gated `webviewDebuggingEnabled` behind `__DEV__` (payout/banking screen).
- Added a screen test asserting the auth'd source URL and the navigation gating.

## Account section

The "Payout settings" button lives in the Account section (above Logout), `isCreator`-gated — no separate section.

## Verification

iOS + Android simulators: renders chrome-free, native Save enables via the `settingsCanUpdate` bridge.

> Note: full Stripe/PayPal connect round-trips can't be exercised locally (no provider creds); the host allowlist is in place + unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784613107&installation_id=134400930&pr_number=270&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F270&signature=cbebf9dd967176a9f410aed0497c73889fdf80d1ef17ab695239fe327ad5b603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches payout/banking UI with authenticated WebView URLs and payment-provider navigation; mistakes could leak sessions or break Stripe/PayPal onboarding.
> 
> **Overview**
> Adds a **Payout settings** flow for creators: an `isCreator`-gated button in the settings sheet Account section navigates to a new **`settings/payments`** stack screen titled **Payouts**.
> 
> The new screen loads Gumroad `/settings/payments` in an authenticated WebView (`display=mobile_app`, access/mobile tokens), with a native **Save** header action bridged via `mobileAppSettingsSave` / `settingsCanUpdate` messages. Navigation keeps Gumroad and payment-provider hosts (`*.stripe.com`, `*.paypal.com`, `*.cloudflare.com`) in the WebView; other links and non-provider `target=_blank` windows open externally, with provider popups injected in-webview. Load failures show a retry UI and report to Sentry; WebView debugging is limited to `__DEV__`.
> 
> Unit tests cover the authenticated source URL, in-webview vs external navigation, and popup handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b1b20ed48be0a838beb4ab4086115c05cf405b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->