### PR TITLE
Add Profile settings screen

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -160,14 +160,16 @@ const SettingsSheet = () => {
             ) : null}
           </View>
           {isCreator ? (
-            <Button variant="outline" className="mb-2" onPress={handleEditProfile}>
-              <Text>Edit profile</Text>
-              <LineIcon name="user-circle" size={20} className="text-foreground" />
-            </Button>
-            <Button variant="outline" className="mb-2" onPress={handlePayoutSettings}>
-              <Text>Payout settings</Text>
-              <LineIcon name="dollar-circle" size={20} className="text-foreground" />
-            </Button>
+            <>
+              <Button variant="outline" className="mb-2" onPress={handleEditProfile}>
+                <Text>Edit profile</Text>
+                <LineIcon name="user-circle" size={20} className="text-foreground" />
+              </Button>
+              <Button variant="outline" className="mb-2" onPress={handlePayoutSettings}>
+                <Text>Payout settings</Text>
+                <LineIcon name="dollar-circle" size={20} className="text-foreground" />
+              </Button>
+            </>
           ) : null}
           <Button onPress={handleLogout}>
             <Text>Logout</Text>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,7 +13,7 @@ import { safeOpenURL } from "@/lib/open-url";
 import { BottomTabBar } from "@react-navigation/bottom-tabs";
 import * as Application from "expo-application";
 import Constants from "expo-constants";
-import { Tabs } from "expo-router";
+import { Tabs, useRouter } from "expo-router";
 import { createContext, useContext, useRef, useState } from "react";
 import { Alert, Pressable, TouchableOpacity, View } from "react-native";
 import { useCSSVariable, useResolveClassNames } from "uniwind";
@@ -94,12 +94,18 @@ const SettingsButton = () => {
 
 const SettingsSheet = () => {
   const { isSettingsOpen, setSettingsOpen } = useSettingsSheet();
-  const { logout } = useAuth();
+  const { logout, isCreator } = useAuth();
   const { data: user, isLoading: isUserLoading } = useUser();
+  const router = useRouter();
 
   const handleLogout = () => {
     setSettingsOpen(false);
     logout();
+  };
+
+  const handleEditProfile = () => {
+    setSettingsOpen(false);
+    router.push("/settings/profile");
   };
 
   const handleDeleteAccount = () => {
@@ -117,6 +123,16 @@ const SettingsSheet = () => {
         <SheetTitle>Settings</SheetTitle>
       </SheetHeader>
       <SheetContent>
+        {isCreator ? (
+          <View className="border-b border-border p-4">
+            <Text className="mb-2 font-sans text-lg text-foreground">Profile</Text>
+            <Text className="mb-4 text-sm text-muted-foreground">Edit your profile and customize how it looks.</Text>
+            <Button variant="outline" onPress={handleEditProfile}>
+              <Text>Edit profile</Text>
+              <LineIcon name="user-circle" size={20} className="text-foreground" />
+            </Button>
+          </View>
+        ) : null}
         <View className="border-b border-border p-4">
           <Text className="mb-2 font-sans text-lg text-foreground">Feedback</Text>
           <Text className="mb-4 text-sm text-muted-foreground">Report a bug or suggest an improvement.</Text>

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -123,16 +123,6 @@ const SettingsSheet = () => {
         <SheetTitle>Settings</SheetTitle>
       </SheetHeader>
       <SheetContent>
-        {isCreator ? (
-          <View className="border-b border-border p-4">
-            <Text className="mb-2 font-sans text-lg text-foreground">Profile</Text>
-            <Text className="mb-4 text-sm text-muted-foreground">Edit your profile and customize how it looks.</Text>
-            <Button variant="outline" onPress={handleEditProfile}>
-              <Text>Edit profile</Text>
-              <LineIcon name="user-circle" size={20} className="text-foreground" />
-            </Button>
-          </View>
-        ) : null}
         <View className="border-b border-border p-4">
           <Text className="mb-2 font-sans text-lg text-foreground">Feedback</Text>
           <Text className="mb-4 text-sm text-muted-foreground">Report a bug or suggest an improvement.</Text>
@@ -164,6 +154,12 @@ const SettingsSheet = () => {
               </>
             ) : null}
           </View>
+          {isCreator ? (
+            <Button variant="outline" className="mb-2" onPress={handleEditProfile}>
+              <Text>Edit profile</Text>
+              <LineIcon name="user-circle" size={20} className="text-foreground" />
+            </Button>
+          ) : null}
           <Button onPress={handleLogout}>
             <Text>Logout</Text>
             <LineIcon name="arrow-out-left-square-half" size={20} className="text-primary-foreground" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -73,6 +73,7 @@ const RootLayout = () => {
             <Stack.Screen name="(tabs)" options={{ headerShown: false, animation: "none" }} />
             <Stack.Screen name="purchase/[token]" options={{ title: "" }} />
             <Stack.Screen name="sales-export" options={{ title: "Export all sales" }} />
+            <Stack.Screen name="settings/profile" options={{ title: "Profile" }} />
             <Stack.Screen name="post/[id]" options={{ title: "" }} />
             <Stack.Screen name="pdf-viewer" options={{ title: "PDF" }} />
             <Stack.Screen name="+not-found" options={{ title: "Not Found" }} />

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -29,6 +29,9 @@ const isAllowedInWebView = (url: string) => {
   }
 };
 
+const buildProfileUrl = (token: string | null) =>
+  `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/profile?display=mobile_app&access_token=${token}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`;
+
 export default function ProfileSettingsScreen() {
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
@@ -36,11 +39,11 @@ export default function ProfileSettingsScreen() {
   const [hasError, setHasError] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
 
-  const url = useMemo(
-    () =>
-      `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/profile?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`,
-    [accessToken],
-  );
+  const sessionTokenRef = useRef(accessToken);
+  if (sessionTokenRef.current == null) sessionTokenRef.current = accessToken;
+  const sessionToken = sessionTokenRef.current;
+
+  const url = useMemo(() => buildProfileUrl(sessionToken), [sessionToken]);
 
   const mainUrlRef = useRef(url);
 
@@ -66,11 +69,12 @@ export default function ProfileSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
-    mainUrlRef.current = url;
+    sessionTokenRef.current = accessToken;
+    mainUrlRef.current = buildProfileUrl(accessToken);
     setCanSave(false);
     setHasError(false);
     setReloadKey((k) => k + 1);
-  }, [url]);
+  }, [accessToken]);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
     if (event.nativeEvent.url !== mainUrlRef.current) return;
@@ -115,7 +119,7 @@ export default function ProfileSettingsScreen() {
         }}
       />
       <StyledWebView
-        key={`${accessToken ?? "anonymous"}-${reloadKey}`}
+        key={`${sessionToken ?? "anonymous"}-${reloadKey}`}
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -34,6 +34,7 @@ export default function ProfileSettingsScreen() {
   const webViewRef = useRef<BaseWebView>(null);
   const [canSave, setCanSave] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const url = useMemo(
     () =>
@@ -65,10 +66,11 @@ export default function ProfileSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
+    mainUrlRef.current = url;
     setCanSave(false);
     setHasError(false);
-    webViewRef.current?.reload();
-  }, []);
+    setReloadKey((k) => k + 1);
+  }, [url]);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
     if (event.nativeEvent.url !== mainUrlRef.current) return;
@@ -113,7 +115,7 @@ export default function ProfileSettingsScreen() {
         }}
       />
       <StyledWebView
-        key={accessToken ?? "anonymous"}
+        key={`${accessToken ?? "anonymous"}-${reloadKey}`}
         ref={webViewRef}
         source={{ uri: url }}
         className="flex-1 bg-transparent"

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -65,23 +65,22 @@ export default function ProfileSettingsScreen() {
   const handleRetry = useCallback(() => {
     setCanSave(false);
     setHasError(false);
+    webViewRef.current?.reload();
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
+    const isGumroadDocument = (() => {
+      try {
+        return new URL(event.nativeEvent.url).origin === gumroadOrigin;
+      } catch {
+        return false;
+      }
+    })();
+    if (!isGumroadDocument) return;
     setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Profile WebView load error: ${event.nativeEvent.description}`));
   }, []);
-
-  const handleHttpError = useCallback(
-    (event: WebViewHttpErrorEvent) => {
-      if (event.nativeEvent.url !== url) return;
-      setCanSave(false);
-      setHasError(true);
-      Sentry.captureException(new Error(`Profile WebView HTTP error: ${event.nativeEvent.statusCode}`));
-    },
-    [url],
-  );
 
   useEffect(() => setCanSave(false), [accessToken]);
 
@@ -105,8 +104,22 @@ export default function ProfileSettingsScreen() {
           ),
         }}
       />
+      <StyledWebView
+        key={accessToken ?? "anonymous"}
+        ref={webViewRef}
+        source={{ uri: url }}
+        className="flex-1 bg-transparent"
+        webviewDebuggingEnabled={__DEV__}
+        pullToRefreshEnabled
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        originWhitelist={["*"]}
+        onMessage={handleMessage}
+        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onError={handleError}
+      />
       {hasError ? (
-        <View className="flex-1 items-center justify-center gap-4 bg-body-bg p-6">
+        <View className="absolute inset-0 items-center justify-center gap-4 bg-body-bg p-6">
           <Text className="text-center text-lg font-bold text-foreground">Something went wrong</Text>
           <Text className="text-center font-sans text-muted">
             We couldn&apos;t load your profile settings. Please check your connection and try again.
@@ -115,23 +128,7 @@ export default function ProfileSettingsScreen() {
             <Text>Retry</Text>
           </Button>
         </View>
-      ) : (
-        <StyledWebView
-          key={accessToken ?? "anonymous"}
-          ref={webViewRef}
-          source={{ uri: url }}
-          className="flex-1 bg-transparent"
-          webviewDebuggingEnabled={__DEV__}
-          pullToRefreshEnabled
-          sharedCookiesEnabled
-          thirdPartyCookiesEnabled
-          originWhitelist={["*"]}
-          onMessage={handleMessage}
-          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
-          onError={handleError}
-          onHttpError={handleHttpError}
-        />
-      )}
+      ) : null}
     </Screen>
   );
 }

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -8,7 +8,7 @@ import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
 import * as Sentry from "@sentry/react-native";
 import { Stack } from "expo-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
 import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
@@ -49,9 +49,7 @@ export default function ProfileSettingsScreen() {
     try {
       const message = JSON.parse(event.nativeEvent.data) as { type: string; canUpdate?: boolean };
       if (message.type === "settingsCanUpdate") setCanSave(Boolean(message.canUpdate));
-    } catch {
-      // ignore non-JSON messages
-    }
+    } catch {}
   }, []);
 
   const handleShouldStartLoadWithRequest = useCallback(
@@ -65,19 +63,27 @@ export default function ProfileSettingsScreen() {
   );
 
   const handleRetry = useCallback(() => {
+    setCanSave(false);
     setHasError(false);
-    webViewRef.current?.reload();
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
+    setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Profile WebView load error: ${event.nativeEvent.description}`));
   }, []);
 
-  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
-    setHasError(true);
-    Sentry.captureException(new Error(`Profile WebView HTTP error: ${event.nativeEvent.statusCode}`));
-  }, []);
+  const handleHttpError = useCallback(
+    (event: WebViewHttpErrorEvent) => {
+      if (event.nativeEvent.url !== url) return;
+      setCanSave(false);
+      setHasError(true);
+      Sentry.captureException(new Error(`Profile WebView HTTP error: ${event.nativeEvent.statusCode}`));
+    },
+    [url],
+  );
+
+  useEffect(() => setCanSave(false), [accessToken]);
 
   if (isLoading) {
     return (

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -1,0 +1,94 @@
+import { StyledWebView } from "@/components/styled";
+import { LoadingSpinner } from "@/components/ui/loading-spinner";
+import { Screen } from "@/components/ui/screen";
+import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
+import { env } from "@/lib/env";
+import { safeOpenURL } from "@/lib/open-url";
+import { Stack } from "expo-router";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { TouchableOpacity, View } from "react-native";
+import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
+
+const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
+
+const isWebUrl = (url: string) => /^https?:\/\//.test(url);
+
+const isGumroadUrl = (url: string) => {
+  try {
+    return new URL(url).origin === gumroadOrigin;
+  } catch {
+    return false;
+  }
+};
+
+export default function ProfileSettingsScreen() {
+  const { isLoading, accessToken } = useAuth();
+  const webViewRef = useRef<BaseWebView>(null);
+  const [canSave, setCanSave] = useState(false);
+
+  const url = useMemo(
+    () =>
+      `${env.EXPO_PUBLIC_GUMROAD_URL}/settings/profile?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`,
+    [accessToken],
+  );
+
+  const handleSave = useCallback(() => {
+    webViewRef.current?.postMessage(JSON.stringify({ type: "mobileAppSettingsSave" }));
+  }, []);
+
+  const handleMessage = useCallback((event: WebViewMessageEvent) => {
+    try {
+      const message = JSON.parse(event.nativeEvent.data) as { type: string; canUpdate?: boolean };
+      if (message.type === "settingsCanUpdate") setCanSave(Boolean(message.canUpdate));
+    } catch {
+      // ignore non-JSON messages
+    }
+  }, []);
+
+  const handleShouldStartLoadWithRequest = useCallback(
+    (request: { url: string; mainDocumentURL?: string }) => {
+      if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
+      if (request.url === url || !isWebUrl(request.url) || isGumroadUrl(request.url)) return true;
+      safeOpenURL(request.url);
+      return false;
+    },
+    [url],
+  );
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-body-bg">
+        <LoadingSpinner size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <Screen>
+      <Stack.Screen
+        options={{
+          title: "Profile",
+          headerRight: () => (
+            <TouchableOpacity onPress={handleSave} disabled={!canSave} className="mr-3">
+              <Text className={canSave ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
+            </TouchableOpacity>
+          ),
+        }}
+      />
+      <StyledWebView
+        key={accessToken ?? "anonymous"}
+        ref={webViewRef}
+        source={{ uri: url }}
+        className="flex-1 bg-transparent"
+        webviewDebuggingEnabled
+        pullToRefreshEnabled
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
+        originWhitelist={["*"]}
+        onMessage={handleMessage}
+        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+      />
+    </Screen>
+  );
+}

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -87,9 +87,10 @@ export default function ProfileSettingsScreen() {
   }, []);
 
   useEffect(() => {
+    mainUrlRef.current = url;
     setCanSave(false);
     setHasError(false);
-  }, [accessToken]);
+  }, [url]);
 
   if (isLoading) {
     return (

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -41,6 +41,8 @@ export default function ProfileSettingsScreen() {
     [accessToken],
   );
 
+  const mainUrlRef = useRef(url);
+
   const handleSave = useCallback(() => {
     webViewRef.current?.postMessage(JSON.stringify({ type: "mobileAppSettingsSave" }));
   }, []);
@@ -69,20 +71,25 @@ export default function ProfileSettingsScreen() {
   }, []);
 
   const handleError = useCallback((event: WebViewErrorEvent) => {
-    const isGumroadDocument = (() => {
-      try {
-        return new URL(event.nativeEvent.url).origin === gumroadOrigin;
-      } catch {
-        return false;
-      }
-    })();
-    if (!isGumroadDocument) return;
+    if (event.nativeEvent.url !== mainUrlRef.current) return;
     setCanSave(false);
     setHasError(true);
     Sentry.captureException(new Error(`Profile WebView load error: ${event.nativeEvent.description}`));
   }, []);
 
-  useEffect(() => setCanSave(false), [accessToken]);
+  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
+    if (event.nativeEvent.url !== mainUrlRef.current) return;
+    setCanSave(false);
+    setHasError(true);
+    Sentry.captureException(
+      new Error(`Profile WebView HTTP error ${event.nativeEvent.statusCode}: ${event.nativeEvent.description}`),
+    );
+  }, []);
+
+  useEffect(() => {
+    setCanSave(false);
+    setHasError(false);
+  }, [accessToken]);
 
   if (isLoading) {
     return (
@@ -116,7 +123,11 @@ export default function ProfileSettingsScreen() {
         originWhitelist={["*"]}
         onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onNavigationStateChange={(navState) => {
+          mainUrlRef.current = navState.url;
+        }}
         onError={handleError}
+        onHttpError={handleHttpError}
       />
       {hasError ? (
         <View className="absolute inset-0 items-center justify-center gap-4 bg-body-bg p-6">

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -1,22 +1,29 @@
 import { StyledWebView } from "@/components/styled";
+import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
+import * as Sentry from "@sentry/react-native";
 import { Stack } from "expo-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
+const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
+
 const isWebUrl = (url: string) => /^https?:\/\//.test(url);
 
-const isGumroadUrl = (url: string) => {
+const isAllowedInWebView = (url: string) => {
   try {
-    return new URL(url).origin === gumroadOrigin;
+    const { origin, hostname } = new URL(url);
+    if (origin === gumroadOrigin) return true;
+    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
   } catch {
     return false;
   }
@@ -26,6 +33,7 @@ export default function ProfileSettingsScreen() {
   const { isLoading, accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
   const [canSave, setCanSave] = useState(false);
+  const [hasError, setHasError] = useState(false);
 
   const url = useMemo(
     () =>
@@ -49,12 +57,27 @@ export default function ProfileSettingsScreen() {
   const handleShouldStartLoadWithRequest = useCallback(
     (request: { url: string; mainDocumentURL?: string }) => {
       if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
-      if (request.url === url || !isWebUrl(request.url) || isGumroadUrl(request.url)) return true;
+      if (request.url === url || !isWebUrl(request.url) || isAllowedInWebView(request.url)) return true;
       safeOpenURL(request.url);
       return false;
     },
     [url],
   );
+
+  const handleRetry = useCallback(() => {
+    setHasError(false);
+    webViewRef.current?.reload();
+  }, []);
+
+  const handleError = useCallback((event: WebViewErrorEvent) => {
+    setHasError(true);
+    Sentry.captureException(new Error(`Profile WebView load error: ${event.nativeEvent.description}`));
+  }, []);
+
+  const handleHttpError = useCallback((event: WebViewHttpErrorEvent) => {
+    setHasError(true);
+    Sentry.captureException(new Error(`Profile WebView HTTP error: ${event.nativeEvent.statusCode}`));
+  }, []);
 
   if (isLoading) {
     return (
@@ -70,25 +93,39 @@ export default function ProfileSettingsScreen() {
         options={{
           title: "Profile",
           headerRight: () => (
-            <TouchableOpacity onPress={handleSave} disabled={!canSave} className="mr-3">
-              <Text className={canSave ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
+            <TouchableOpacity onPress={handleSave} disabled={!canSave || hasError} className="mr-3">
+              <Text className={canSave && !hasError ? "font-sans text-accent" : "font-sans text-muted"}>Save</Text>
             </TouchableOpacity>
           ),
         }}
       />
-      <StyledWebView
-        key={accessToken ?? "anonymous"}
-        ref={webViewRef}
-        source={{ uri: url }}
-        className="flex-1 bg-transparent"
-        webviewDebuggingEnabled
-        pullToRefreshEnabled
-        sharedCookiesEnabled
-        thirdPartyCookiesEnabled
-        originWhitelist={["*"]}
-        onMessage={handleMessage}
-        onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
-      />
+      {hasError ? (
+        <View className="flex-1 items-center justify-center gap-4 bg-body-bg p-6">
+          <Text className="text-center text-lg font-bold text-foreground">Something went wrong</Text>
+          <Text className="text-center font-sans text-muted">
+            We couldn&apos;t load your profile settings. Please check your connection and try again.
+          </Text>
+          <Button onPress={handleRetry}>
+            <Text>Retry</Text>
+          </Button>
+        </View>
+      ) : (
+        <StyledWebView
+          key={accessToken ?? "anonymous"}
+          ref={webViewRef}
+          source={{ uri: url }}
+          className="flex-1 bg-transparent"
+          webviewDebuggingEnabled={__DEV__}
+          pullToRefreshEnabled
+          sharedCookiesEnabled
+          thirdPartyCookiesEnabled
+          originWhitelist={["*"]}
+          onMessage={handleMessage}
+          onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+          onError={handleError}
+          onHttpError={handleHttpError}
+        />
+      )}
     </Screen>
   );
 }

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -11,7 +11,7 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent } from "react-native-webview/lib/WebViewTypes";
+import type { WebViewErrorEvent, WebViewHttpErrorEvent, WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
@@ -19,11 +19,18 @@ const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
 
 const isWebUrl = (url: string) => /^https?:\/\//.test(url);
 
+const isPaymentProviderUrl = (url: string) => {
+  try {
+    const { hostname } = new URL(url);
+    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
+  } catch {
+    return false;
+  }
+};
+
 const isAllowedInWebView = (url: string) => {
   try {
-    const { origin, hostname } = new URL(url);
-    if (origin === gumroadOrigin) return true;
-    return allowedHostSuffixes.some((suffix) => hostname === suffix.slice(1) || hostname.endsWith(suffix));
+    return new URL(url).origin === gumroadOrigin || isPaymentProviderUrl(url);
   } catch {
     return false;
   }
@@ -67,6 +74,15 @@ export default function ProfileSettingsScreen() {
     },
     [url],
   );
+
+  const handleOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
+    const { targetUrl } = event.nativeEvent;
+    if (isPaymentProviderUrl(targetUrl)) {
+      webViewRef.current?.injectJavaScript(`window.location.href = ${JSON.stringify(targetUrl)}; true;`);
+    } else {
+      safeOpenURL(targetUrl);
+    }
+  }, []);
 
   const handleRetry = useCallback(() => {
     sessionTokenRef.current = accessToken;
@@ -127,9 +143,12 @@ export default function ProfileSettingsScreen() {
         pullToRefreshEnabled
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
+        setSupportMultipleWindows
+        javaScriptCanOpenWindowsAutomatically
         originWhitelist={["*"]}
         onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
+        onOpenWindow={handleOpenWindow}
         onNavigationStateChange={(navState) => {
           mainUrlRef.current = navState.url;
         }}

--- a/tests/app/profile.test.tsx
+++ b/tests/app/profile.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react-native";
 
 const mockUseAuth = jest.fn();
 const mockSafeOpenURL = jest.fn();
+const mockInjectJavaScript = jest.fn();
 
 jest.mock("@/lib/auth-context", () => ({
   useAuth: () => mockUseAuth(),
@@ -28,7 +29,10 @@ jest.mock("react-native-webview", () => {
   const React = require("react");
   const { View } = require("react-native");
   return {
-    WebView: (props: Record<string, unknown>) => React.createElement(View, { testID: "profile-webview", ...props }),
+    WebView: React.forwardRef(function MockWebView(props: Record<string, unknown>, ref: unknown) {
+      React.useImperativeHandle(ref, () => ({ injectJavaScript: mockInjectJavaScript, postMessage: jest.fn() }));
+      return React.createElement(View, { testID: "profile-webview", ...props });
+    }),
   };
 });
 
@@ -51,6 +55,10 @@ describe("ProfileSettingsScreen", () => {
     expect(source.uri).toContain("access_token=test-access-token");
     expect(source.uri).toContain("mobile_token=test-mobile-token");
     expect(source.uri).toBe(expectedUrl);
+
+    const props = screen.getByTestId("profile-webview").props;
+    expect(props.setSupportMultipleWindows).toBe(true);
+    expect(props.javaScriptCanOpenWindowsAutomatically).toBe(true);
   });
 
   it("keeps Gumroad navigation in the WebView and opens unrelated links outside it", () => {
@@ -65,5 +73,21 @@ describe("ProfileSettingsScreen", () => {
 
     expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+
+  it("opens target=_blank help links externally but keeps provider popups in the WebView", () => {
+    render(<ProfileSettingsScreen />);
+
+    const onOpenWindow = screen.getByTestId("profile-webview").props.onOpenWindow as (event: {
+      nativeEvent: { targetUrl: string };
+    }) => void;
+
+    onOpenWindow({ nativeEvent: { targetUrl: "https://example.com/help/article/123" } });
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("https://example.com/help/article/123");
+
+    mockSafeOpenURL.mockClear();
+    onOpenWindow({ nativeEvent: { targetUrl: "https://connect.stripe.com/setup/s/abc" } });
+    expect(mockSafeOpenURL).not.toHaveBeenCalled();
+    expect(mockInjectJavaScript).toHaveBeenCalled();
   });
 });

--- a/tests/app/profile.test.tsx
+++ b/tests/app/profile.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react-native";
+
+const mockUseAuth = jest.fn();
+const mockSafeOpenURL = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/open-url", () => ({
+  safeOpenURL: (url: string) => mockSafeOpenURL(url),
+}));
+
+jest.mock("expo-router", () => ({
+  Stack: {
+    Screen: ({ options }: { options?: { headerRight?: () => React.ReactNode } }) => {
+      const React = require("react");
+      return React.createElement(React.Fragment, null, options?.headerRight?.());
+    },
+  },
+}));
+
+jest.mock("@sentry/react-native", () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock("react-native-webview", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    WebView: (props: Record<string, unknown>) => React.createElement(View, { testID: "profile-webview", ...props }),
+  };
+});
+
+import ProfileSettingsScreen from "@/app/settings/profile";
+
+const expectedUrl =
+  "https://example.com/settings/profile?display=mobile_app&access_token=test-access-token&mobile_token=test-mobile-token";
+
+describe("ProfileSettingsScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isLoading: false, accessToken: "test-access-token" });
+  });
+
+  it("loads the authenticated profile page inside the WebView", () => {
+    render(<ProfileSettingsScreen />);
+
+    const source = screen.getByTestId("profile-webview").props.source as { uri: string };
+    expect(source.uri).toContain("display=mobile_app");
+    expect(source.uri).toContain("access_token=test-access-token");
+    expect(source.uri).toContain("mobile_token=test-mobile-token");
+    expect(source.uri).toBe(expectedUrl);
+  });
+
+  it("keeps Gumroad navigation in the WebView and opens unrelated links outside it", () => {
+    render(<ProfileSettingsScreen />);
+
+    const shouldStart = screen.getByTestId("profile-webview").props.onShouldStartLoadWithRequest as (request: {
+      url: string;
+      mainDocumentURL?: string;
+    }) => boolean;
+
+    expect(shouldStart({ url: "https://example.com/settings/profile" })).toBe(true);
+
+    expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+});


### PR DESCRIPTION
## What

Adds a **Profile settings** screen — a native screen wrapping `/settings/profile` in an authenticated WebView (chrome hidden, Save bridged to the native header), reachable from the settings sheet's **Account** section.

## Companion PR

Web backend: `antiwork/gumroad` #5536 (incl. hiding the profile editor's own "Update profile" button + Save bridge, since `/settings/profile` redirects to the `/profile` editor layout).

## Review fixes included

- Same WebView hardening as the payout screen: provider/challenge host allowlist, `onError`/`onHttpError` + retry UI + Sentry, `__DEV__` debug gate, and a screen test.

## Account section

The "Edit profile" button lives in the Account section (above Logout), `isCreator`-gated.

## Verification

iOS + Android simulators: profile editor renders chrome-free and the redundant web "Update profile" button is hidden (the native Save drives it).

> Follow-up: "Connect to X" (and other social OAuth) still navigates out — these flows are inherently awkward in a WebView; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784613111&installation_id=134400930&pr_number=271&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F271&signature=753d91742cd618002270de45db3c51af1d01e4b74179145e32a2866494639910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Authenticated WebView with token-in-URL and save bridging touches account profile data; risk is mitigated by the same allowlist/error handling as payouts but still depends on web companion behavior.
> 
> **Overview**
> Adds an in-app **Profile** settings flow for creators: the settings sheet now includes **Edit profile** (above payout settings), and the root stack registers `settings/profile`.
> 
> The new screen loads Gumroad’s `/settings/profile` in an authenticated WebView (`display=mobile_app`), with a native header **Save** that posts `mobileAppSettingsSave` and enables only when the page sends `settingsCanUpdate`. Navigation is hardened like payouts: Gumroad and payment-provider hosts stay in the WebView; other links open externally; load/HTTP failures show retry UI and report to Sentry.
> 
> Includes unit tests for URL construction, navigation allowlisting, and popup handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377e958024b8a2d19304dd796714bc6848271bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->