### PR TITLE
Don't report the expected "large export" case to Sentry

### DIFF
--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -28,6 +28,7 @@ const isGumroadUrl = (url: string) => {
 
 const SALES_CSV_FILE_NAME = "sales.csv";
 const HTML_TAG_OPEN_BYTE = "<".charCodeAt(0);
+const LARGE_EXPORT_MESSAGE = "Large exports arrive by email.";
 
 const downloadSalesExportFile = async (url: string) => {
   const file = new File(Paths.cache, SALES_CSV_FILE_NAME);
@@ -45,7 +46,7 @@ const downloadSalesExportFile = async (url: string) => {
     firstByte === undefined
       ? "Failed to download file"
       : firstByte === HTML_TAG_OPEN_BYTE
-        ? "Large exports arrive by email."
+        ? LARGE_EXPORT_MESSAGE
         : null;
 
   if (failureMessage !== null) {
@@ -84,8 +85,12 @@ export default function SalesExportScreen() {
         dialogTitle: "Export all sales",
       });
     } catch (error) {
-      Sentry.captureException(error);
-      Alert.alert("Download failed", error instanceof Error ? error.message : "Failed to download file");
+      if (error instanceof Error && error.message === LARGE_EXPORT_MESSAGE) {
+        Alert.alert("Large export", LARGE_EXPORT_MESSAGE);
+      } else {
+        Sentry.captureException(error);
+        Alert.alert("Download failed", error instanceof Error ? error.message : "Failed to download file");
+      }
     } finally {
       setIsDownloading(false);
     }

--- a/tests/app/sales-export.test.tsx
+++ b/tests/app/sales-export.test.tsx
@@ -123,7 +123,7 @@ describe("SalesExportScreen", () => {
     expect(mockDelete).not.toHaveBeenCalled();
   });
 
-  it("does not share export responses that are not a CSV", async () => {
+  it("shows an info alert without reporting to Sentry when the export is too large", async () => {
     jest.spyOn(NativeAlert, "alert");
     mockReadBytes.mockReturnValueOnce(new Uint8Array([60]));
 
@@ -132,8 +132,9 @@ describe("SalesExportScreen", () => {
     fireEvent.press(screen.getByText("Download CSV"));
 
     await waitFor(() => {
-      expect(NativeAlert.alert).toHaveBeenCalledWith("Download failed", "Large exports arrive by email.");
+      expect(NativeAlert.alert).toHaveBeenCalledWith("Large export", "Large exports arrive by email.");
     });
+    expect(mockCaptureException).not.toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalled();
     expect(mockShareAsync).not.toHaveBeenCalled();
   });
@@ -149,11 +150,12 @@ describe("SalesExportScreen", () => {
     await waitFor(() => {
       expect(NativeAlert.alert).toHaveBeenCalledWith("Download failed", "Failed to download file");
     });
+    expect(mockCaptureException).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalled();
     expect(mockShareAsync).not.toHaveBeenCalled();
   });
 
-  it("surfaces the original error even if deleting the temp file fails", async () => {
+  it("still surfaces the large-export notice even if deleting the temp file fails", async () => {
     jest.spyOn(NativeAlert, "alert");
     mockReadBytes.mockReturnValueOnce(new Uint8Array([60]));
     mockDelete.mockImplementationOnce(() => {
@@ -165,7 +167,7 @@ describe("SalesExportScreen", () => {
     fireEvent.press(screen.getByText("Download CSV"));
 
     await waitFor(() => {
-      expect(NativeAlert.alert).toHaveBeenCalledWith("Download failed", "Large exports arrive by email.");
+      expect(NativeAlert.alert).toHaveBeenCalledWith("Large export", "Large exports arrive by email.");
     });
     expect(mockShareAsync).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What

When a sales export is too large to download synchronously, the server returns the redirect-to-email page and `downloadSalesExportFile` throws `"Large exports arrive by email."`. That's an **expected outcome**, not a failure — but the `catch` in `downloadSalesExport` reported it via `Sentry.captureException` and surfaced it to the user under a misleading **"Download failed"** title.

This is [Sentry issue 7497105427](https://gumroad-to.sentry.io/issues/7497105427/) (~20 events) — pure noise.

## Change

- Extract the message to a shared `LARGE_EXPORT_MESSAGE` constant (used at the throw site and the check, so they can't drift).
- In the `catch`, treat that specific message as informational: show a **"Large export"** alert and **skip** the Sentry capture.
- Genuine failures (download errors, zero-byte responses, sharing unavailable) still `captureException` and still show **"Download failed"**.

## Tests

Updated `tests/app/sales-export.test.tsx`:
- Large-export case now asserts the `"Large export"` info alert **and** that `captureException` is **not** called.
- Added an explicit assertion that real failures (zero-byte download) **do** still report to Sentry.

`npx jest tests/app/sales-export.test.tsx` — 7/7 pass. `tsc` clean; eslint 0 errors.

## Note

Builds on #273 (already merged), which owns `downloadSalesExportFile`. The change is confined to the caller's `catch` plus the shared constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785186468&installation_id=134400930&pr_number=276&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F276&signature=21392a96612a274ae3d0a270e97f64cb80407eed9a39f72abfc23160354dd782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX and error-handling change on the sales export screen with no auth or data-path changes; behavior for true failures is unchanged.
> 
> **Overview**
> When a sales CSV download is actually the server’s HTML “export by email” page, the app now treats that as **expected** instead of a failure.
> 
> The large-export copy is centralized in `LARGE_EXPORT_MESSAGE`, and `downloadSalesExport`’s `catch` shows a **"Large export"** alert for that case while **skipping** `Sentry.captureException`. Real problems still log to Sentry and use **"Download failed"**.
> 
> Tests were updated to expect the new alert title, assert Sentry is not called for large exports, and confirm genuine failures still report to Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515d748084b67551e60c5b818372b87698dd0963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->