### PR TITLE
Don't report transient video playback errors to Sentry

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -115,27 +115,14 @@ export default function VideoPlayerScreen() {
       "statusChange",
       ({ status, error }: { status: VideoPlayerStatus; error?: { message: string } }) => {
         if (status === "error") {
-          const message = error?.message ?? "Unknown playback error";
-          setPlaybackError(message);
-          Sentry.captureMessage("Video playback failed", {
-            level: "error",
-            extra: {
-              message,
-              videoUrl,
-              sourceUri: uri,
-              streamingUrl,
-              urlRedirectId,
-              productFileId,
-              purchaseId,
-            },
-          });
+          setPlaybackError(error?.message ?? "Unknown playback error");
         } else if (status === "readyToPlay") {
           setPlaybackError(null);
         }
       },
     );
     return () => subscription.remove();
-  }, [player, videoUrl, uri, streamingUrl, urlRedirectId, productFileId, purchaseId]);
+  }, [player]);
 
   useEffect(
     () => () => {

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -43,6 +43,7 @@ jest.mock("@/lib/media-location", () => ({
 }));
 
 import VideoPlayerScreen from "@/app/video-player";
+import * as Sentry from "@sentry/react-native";
 import { act } from "react";
 
 let appStateCallback: ((state: string) => void) | null = null;
@@ -221,6 +222,7 @@ describe("VideoPlayerScreen", () => {
 
     expect(queryByText("This video failed to load")).toBeTruthy();
     expect(queryByText("AVPlayer cannot decode the file")).toBeTruthy();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
   });
 
   it("clears the error state once the player becomes ready to play", () => {


### PR DESCRIPTION
## What

The `statusChange` listener in `app/video-player.tsx` called `Sentry.captureMessage("Video playback failed")` on **every** `status === "error"`. These are overwhelmingly transient stream/network conditions, not actionable bugs — [Sentry issue 7497061675](https://gumroad-to.sentry.io/issues/7497061675/), ~942 events / ~573 users.

## Change

- Drop the `captureMessage` call. The user-facing handling is unchanged: `setPlaybackError(message)` still renders the error UI ("This video failed to load" + the message), and it's still cleared on `readyToPlay`.
- Trim the effect's dependency array to `[player]`, since `videoUrl`/`uri`/`streamingUrl`/`urlRedirectId`/`productFileId`/`purchaseId` were only referenced by the removed capture payload.

`Sentry.captureException` for the streaming-playlist fetch failure (line 65) is **kept** — that's a genuine, actionable error.

## Tests

`tests/app/video-player.test.tsx` — existing error-status tests still pass (UX unchanged), and the error test now also asserts `Sentry.captureMessage` is **not** called. 13/13 pass; `tsc` clean; eslint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785187129&installation_id=134400930&pr_number=277&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F277&signature=33a4526e4d914a66d6125e062b47e8825901e9b998e7816ea7fd732fb4bd83fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change for transient player errors; playback error UI and streaming-fetch exception reporting are unchanged.
> 
> **Overview**
> Stops sending **every** expo-video `statusChange` error to Sentry via `captureMessage`, which was mostly transient stream/network noise rather than fixable bugs. **User-facing behavior is unchanged**: errors still set `playbackError` and show the existing “This video failed to load” UI, and clear again on `readyToPlay`.
> 
> The `statusChange` effect dependency list is reduced to **`[player]`** because the removed Sentry payload was the only consumer of route/video metadata in that listener. **`Sentry.captureException` on streaming playlist fetch failure is left in place** as an actionable failure path.
> 
> Tests now assert that a player error status does **not** call `Sentry.captureMessage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0265f1cfd078849e406928a7e209147fce9e122a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->