### PR TITLE
Filter expected UnauthorizedError (expired session) from Sentry

### DIFF
--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -38,7 +38,8 @@ const DOWNLOAD_CONTEXT_MARKERS = ["downloadFileAsync", "ExpoAsset.downloadAsync"
 const isNonActionableError = (event: ErrorEvent) => {
   const values = event.exception?.values;
   if (!values) return false;
-  if (values[0]?.type === "AbortError") return true;
+  const primaryType = values[0]?.type;
+  if (primaryType === "AbortError" || primaryType === "UnauthorizedError") return true;
   const text = values.map((value) => `${value.type ?? ""}: ${value.value ?? ""}`).join("\n");
   if (TRANSIENT_MARKERS.some((marker) => text.includes(marker))) return true;
   return (

--- a/tests/lib/sentry.test.ts
+++ b/tests/lib/sentry.test.ts
@@ -69,6 +69,7 @@ describe("sentry beforeSend", () => {
       ["generic network failure", errorEvent([{ type: "TypeError", value: "Network request failed" }])],
       ["aborted request", errorEvent([{ type: "AbortError", value: "Aborted" }])],
       ["user interaction not allowed", errorEvent([{ type: "Error", value: "User interaction is not allowed" }])],
+      ["expired session (UnauthorizedError)", errorEvent([{ type: "UnauthorizedError", value: "Unauthorized" }])],
     ];
 
     it.each(dropped)("drops: %s", (_label, event) => {
@@ -104,6 +105,13 @@ describe("sentry beforeSend", () => {
         errorEvent([
           { type: "Error", value: "Token refresh request failed" },
           { type: "Error", value: "java.net.ConnectException: Failed to connect to api.gumroad.com" },
+        ]),
+      ],
+      [
+        "real primary error with an UnauthorizedError later in the chain",
+        errorEvent([
+          { type: "TypeError", value: "Cannot read property 'id' of undefined" },
+          { type: "UnauthorizedError", value: "Unauthorized" },
         ]),
       ],
       [


### PR DESCRIPTION
## What

A `401` surfaces as our typed `UnauthorizedError`. Direct `requestAPI` calls that aren't wrapped in the refresh/logout retry flow — media-location updates, device registration, etc. — let it bubble up as an **unhandled rejection**, flooding Sentry with an expected, logout-handled auth condition.

Two issues, ~8.5k events combined: [7378039382](https://gumroad-to.sentry.io/issues/7378039382/) (~6k) + [7377763112](https://gumroad-to.sentry.io/issues/7377763112/) (~2.5k).

## Change

One line in the already-merged `beforeSend` (`lib/sentry.ts`): drop events whose **primary** exception type is `UnauthorizedError`, alongside the existing `AbortError` check.

Matching the **primary** type (`values[0]`) only — not the whole chain — means a genuine error that happens to have an `UnauthorizedError` cause still reports. This is the same primary-only approach reviewers asked for on the `AbortError` case.

A 401 is never an actionable app bug; the app already handles it (token refresh, else logout), so there's no actionable `UnauthorizedError` to lose.

## Tests

`tests/lib/sentry.test.ts` — adds a drop case for `UnauthorizedError` and a keep case proving a real primary error with an `UnauthorizedError` cause still reports. 22/22 pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785187573&installation_id=134400930&pr_number=278&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F278&signature=ff1d133f1dd81c8b6fead155814caffbb85f88440e2dd656cca6be36f2a804e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to Sentry filtering; no auth or API behavior changes, with tests locking primary-vs-chained semantics.
> 
> **Overview**
> **Sentry noise reduction for expired sessions:** `beforeSend` in `lib/sentry.ts` now treats a **primary** exception of type `UnauthorizedError` like `AbortError` and drops the event, so expected 401 / logout-handled auth failures stop flooding Sentry from unhandled rejections on paths that don’t wrap `requestAPI`.
> 
> Only `values[0]?.type` is checked, so a real bug that appears first in the chain still reports even if `UnauthorizedError` shows up as a later cause—matching the existing abort behavior.
> 
> Tests in `tests/lib/sentry.test.ts` cover dropping a top-level `UnauthorizedError` and keeping an error whose primary type is something else with `UnauthorizedError` chained behind it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346be819f82f5a45a29361fec5782ddd7bfad5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->