### PR TITLE
Treat permanently-expired sessions as logout, not Sentry errors

### DIFF
--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 import { assertDefined } from "@/lib/assert";
 import { queryClient } from "@/lib/query-client";
 import { env } from "@/lib/env";
-import { KeychainUnavailableError, request, UnauthorizedError } from "@/lib/request";
+import { KeychainUnavailableError, request, SessionExpiredError, UnauthorizedError } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 import * as AuthSession from "expo-auth-session";
 import { useRouter } from "expo-router";
@@ -198,16 +198,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           if (isKeychainUnavailableError(readError)) throw new KeychainUnavailableError();
           throw readError;
         }
-        if (!storedRefreshToken) throw new Error("No refresh token available");
+        if (!storedRefreshToken) throw new SessionExpiredError("No refresh token available");
 
-        const tokenResponse = await request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
-          method: "POST",
-          data: {
-            grant_type: "refresh_token",
-            refresh_token: storedRefreshToken,
-            client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
-          },
-        });
+        let tokenResponse: { access_token: string; refresh_token?: string };
+        try {
+          tokenResponse = await request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
+            method: "POST",
+            data: {
+              grant_type: "refresh_token",
+              refresh_token: storedRefreshToken,
+              client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
+            },
+          });
+        } catch (requestError) {
+          if (requestError instanceof Error && requestError.message.includes("invalid_grant")) {
+            throw new SessionExpiredError("Refresh token is invalid or expired");
+          }
+          throw requestError;
+        }
         await storeTokens(tokenResponse.access_token, tokenResponse.refresh_token);
         return tokenResponse.access_token;
       } finally {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -10,6 +10,13 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class SessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
 export class KeychainUnavailableError extends Error {
   constructor() {
     super("Keychain unavailable");
@@ -115,7 +122,7 @@ export const useAPIRequest = <TResponse, TData = TResponse>(
           newAccessToken = await refreshToken();
         } catch (refreshError) {
           if (refreshError instanceof KeychainUnavailableError) throw error;
-          if (refreshError instanceof UnauthorizedError) {
+          if (refreshError instanceof UnauthorizedError || refreshError instanceof SessionExpiredError) {
             console.warn(refreshError);
           } else {
             Sentry.captureException(refreshError, { tags: { auth_path: "refresh_failed" } });

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -28,6 +28,12 @@ jest.mock("@/lib/request", () => ({
       this.name = "UnauthorizedError";
     }
   },
+  SessionExpiredError: class SessionExpiredError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "SessionExpiredError";
+    }
+  },
   KeychainUnavailableError: class KeychainUnavailableError extends Error {
     constructor() {
       super("Keychain unavailable");
@@ -157,13 +163,25 @@ describe("refreshToken", () => {
     );
   });
 
-  it("throws when there is no stored refresh token", async () => {
+  it("throws SessionExpiredError when there is no stored refresh token", async () => {
     mockGetItemAsync.mockResolvedValue(null);
 
     const { result } = renderWithProvider(null);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    await expect(result.current.refreshToken()).rejects.toThrow("No refresh token available");
+    const { SessionExpiredError } = jest.requireMock("@/lib/request");
+    await expect(result.current.refreshToken()).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("throws SessionExpiredError when the server rejects the refresh token (invalid_grant)", async () => {
+    mockGetItemAsync.mockImplementation(refreshTokenStored);
+    mockRequest.mockRejectedValue(new Error('Request failed: 400 {"error":"invalid_grant"}'));
+
+    const { result } = renderWithProvider(null);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const { SessionExpiredError } = jest.requireMock("@/lib/request");
+    await expect(result.current.refreshToken()).rejects.toBeInstanceOf(SessionExpiredError);
   });
 
   it("does NOT call logout when refresh fails (caller decides)", async () => {

--- a/tests/lib/use-api-request.test.tsx
+++ b/tests/lib/use-api-request.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import React from "react";
 
-import { KeychainUnavailableError, ServerError, UnauthorizedError, useAPIRequest } from "@/lib/request";
+import { KeychainUnavailableError, ServerError, SessionExpiredError, UnauthorizedError, useAPIRequest } from "@/lib/request";
 
 const mockRefreshToken = jest.fn();
 const mockLogout = jest.fn();
@@ -140,6 +140,18 @@ describe("useAPIRequest", () => {
     expect(result.current.error).toBeInstanceOf(UnauthorizedError);
   });
 
+  it("logs out without reporting to Sentry when refresh fails with SessionExpiredError", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+    mockRefreshToken.mockRejectedValueOnce(new SessionExpiredError("No refresh token available"));
+
+    const { result } = renderUseAPIRequest();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(result.current.error).toBeInstanceOf(UnauthorizedError);
+  });
+
   it("logs out when refresh fails with a raw keychain error (write-side after server rotation)", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
     const writeError = new Error("User interaction is not allowed");
@@ -157,7 +169,7 @@ describe("useAPIRequest", () => {
 
   it("logs out and reports to Sentry with auth_path tag when refresh fails with a non-keychain error", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
-    const refreshError = new Error("invalid_grant");
+    const refreshError = new Error("Unexpected refresh failure");
     mockRefreshToken.mockRejectedValueOnce(refreshError);
 
     const { result } = renderUseAPIRequest();


### PR DESCRIPTION
## What

Two refresh-flow conditions that just mean **"the session is permanently expired"** were thrown as plain `Error`s, so `useAPIRequest`'s refresh handler reported them to Sentry (`auth_path: refresh_failed`) before logging out:

- **No refresh token available** — [Sentry issue 7508166559](https://gumroad-to.sentry.io/issues/7508166559/) (~644 ev)
- **`invalid_grant` 400** from the token endpoint (revoked/expired refresh token) — [Sentry issue 7377311526](https://gumroad-to.sentry.io/issues/7377311526/) (~4.3k ev)

~5k events of expected, logout-handled auth state.

## Change (2 files)

- `lib/request.ts`: add a typed `SessionExpiredError`; in `useAPIRequest`'s refresh `catch`, treat it like `UnauthorizedError` (warn + logout, **no** `captureException`).
- `lib/auth-context.tsx`: `refreshTokenFn` throws `SessionExpiredError` for the missing-token case, and converts an `invalid_grant` response from the token request into `SessionExpiredError`.

**Genuine/unexpected** refresh failures still report to Sentry with the `auth_path` tag — only the two permanently-expired conditions are reclassified.

## Tests

- `tests/lib/use-api-request.test.tsx`: new case — `SessionExpiredError` → logout, no Sentry capture; de-confused the generic-error sample (was misleadingly named `invalid_grant`).
- `tests/lib/auth-context.test.tsx`: `refreshToken` throws `SessionExpiredError` for missing token **and** for an `invalid_grant` response.

40/40 pass across both suites; `tsc` clean; eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785188212&installation_id=134400930&pr_number=279&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F279&signature=27e2afebf17229298faeabe8426660bb457bfe6c9275cf71b157472083568868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow auth observability change; logout behavior is unchanged and only expected session-expiry cases are reclassified away from Sentry.
> 
> **Overview**
> Introduces **`SessionExpiredError`** so expected “session is gone” refresh failures are not reported as bugs.
> 
> **`refreshToken`** now throws `SessionExpiredError` when there is no stored refresh token, and when the token endpoint returns **`invalid_grant`** (mapped from the request error message).
> 
> **`useAPIRequest`** handles `SessionExpiredError` like **`UnauthorizedError`**: warn, **logout**, and **skip** `Sentry.captureException` with `auth_path: refresh_failed`. Unexpected refresh failures still go to Sentry.
> 
> Tests cover both `SessionExpiredError` paths in auth-context and the no-Sentry logout path in use-api-request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea73c974dceed65485eceec3e163c45074556cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->