### PR TITLE
Sanitize square brackets in cache filenames (fixes native download crash)

### DIFF
--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -1,9 +1,15 @@
 import { Directory, File, Paths } from "expo-file-system";
 
-const sanitizeFileName = (name: string) => name.replace(/[/\\:*?"<>|%#]/g, "_").trim();
+const MAX_FILE_NAME_LENGTH = 200;
+const UNSAFE_FILE_NAME_CHARS = /[/\\:*?"<>|%#[\]{}^`]/g;
+
+const sanitizeFileName = (name: string) =>
+  name.replace(UNSAFE_FILE_NAME_CHARS, "_").slice(0, MAX_FILE_NAME_LENGTH).trim() || "file";
 
 export const cacheFileDestination = (uniqueKey: string, fileName: string) => {
   const dir = new Directory(Paths.cache, uniqueKey);
-  if (!dir.exists) dir.create({ idempotent: true });
+  try {
+    if (!dir.exists) dir.create({ idempotent: true });
+  } catch {}
   return new File(dir, sanitizeFileName(fileName));
 };

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -3,13 +3,16 @@ import { Directory, File, Paths } from "expo-file-system";
 const MAX_FILE_NAME_LENGTH = 200;
 const UNSAFE_FILE_NAME_CHARS = /[/\\:*?"<>|%#[\]{}^`]/g;
 
-const sanitizeFileName = (name: string) =>
-  name.replace(UNSAFE_FILE_NAME_CHARS, "_").slice(0, MAX_FILE_NAME_LENGTH).trim() || "file";
+const sanitizeFileName = (name: string) => {
+  const cleaned = name.replace(UNSAFE_FILE_NAME_CHARS, "_").trim();
+  if (cleaned.length <= MAX_FILE_NAME_LENGTH) return cleaned || "file";
+  const dotIndex = cleaned.lastIndexOf(".");
+  const extension = dotIndex > 0 && cleaned.length - dotIndex <= 16 ? cleaned.slice(dotIndex) : "";
+  return cleaned.slice(0, MAX_FILE_NAME_LENGTH - extension.length) + extension;
+};
 
 export const cacheFileDestination = (uniqueKey: string, fileName: string) => {
   const dir = new Directory(Paths.cache, uniqueKey);
-  try {
-    if (!dir.exists) dir.create({ idempotent: true });
-  } catch {}
+  if (!dir.exists) dir.create({ idempotent: true });
   return new File(dir, sanitizeFileName(fileName));
 };

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -51,4 +51,11 @@ describe("cacheFileDestination", () => {
 
     expect(destination.name).toBe("my great file.pdf");
   });
+
+  it("clamps overly long names while preserving the extension", () => {
+    const destination = cacheFileDestination("file-id", `${"a".repeat(250)}.pdf`);
+
+    expect(destination.name).toHaveLength(200);
+    expect(destination.name.endsWith(".pdf")).toBe(true);
+  });
 });

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -39,6 +39,13 @@ describe("cacheFileDestination", () => {
     expect(destination.name).not.toMatch(/[/\\:*?"<>|]/);
   });
 
+  it("neutralizes square brackets and other URI delimiters that crash native path parsing", () => {
+    const destination = cacheFileDestination("file-id", "301 [NSFW] Rider [2023].png");
+
+    expect(destination.name).toBe("301 _NSFW_ Rider _2023_.png");
+    expect(destination.name).not.toMatch(/[[\]{}^`]/);
+  });
+
   it("preserves spaces, which are valid in file URIs", () => {
     const destination = cacheFileDestination("file-id", "my great file.pdf");
 


### PR DESCRIPTION
## What

Downloading a file whose name contains `[` or `]` crashes natively — [Sentry 7540265665](https://gumroad-to.sentry.io/issues/7540265665/): `java.lang.IllegalArgumentException: Illegal character in path` on Android. expo-file-system percent-encodes spaces (legal `%20`) but leaves brackets **raw**, and `java.net.URI` rejects them. Real filenames hit this — e.g. `301 [NSFW] Rider [2023].png`.

## Change (`lib/file-utils.ts`)

- Extend `sanitizeFileName` to also replace `[ ] { } ^ \`` — the URI path delimiters expo doesn't encode — on top of the existing `/ \ : * ? " < > | % #`. **Spaces, dashes, parentheses, and unicode are preserved.**
- Clamp to 200 chars **while preserving the file extension** (so very long names still open with the right type).

## Tests

`tests/lib/file-utils.test.ts` — asserts `301 [NSFW] Rider [2023].png` → `301 _NSFW_ Rider _2023_.png`, the existing cases (other illegal chars, spaces preserved), and that long names clamp while keeping the extension. 5/5 pass; `tsc` clean.

## Verified on a real Android emulator (API 36)

Before/after with the same input filename (`crash[test] (2).pdf`) via the real `File.downloadFileAsync` path:
- **Before (no fix):** `crash[test]%20(2).pdf` → `IllegalArgumentException: Illegal character in path at index 70` (the exact Sentry crash).
- **After (this fix):** `crash_test_%20(2).pdf` → download **succeeds**, no crash.

## Review feedback addressed

- *Extension lost on clamp* — fixed: the clamp now preserves the extension.
- *Create try/catch masked failures* — removed; reverted to the plain `dir.create` call (the create failure stays visible/reported). The separate iOS create-failure (Sentry 7512648927) will be handled in its own investigated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)