### PR TITLE
Guard react-native-pdf against nil file path (fixes FATAL iOS crash)

### DIFF
--- a/patches/react-native-pdf+7.0.4.patch
+++ b/patches/react-native-pdf+7.0.4.patch
@@ -1,8 +1,20 @@
 diff --git a/node_modules/react-native-pdf/ios/RNPDFPdf/RNPDFPdfView.mm b/node_modules/react-native-pdf/ios/RNPDFPdf/RNPDFPdfView.mm
-index de46c98..ddc97f2 100644
+index de46c98..eb132ce 100644
 --- a/node_modules/react-native-pdf/ios/RNPDFPdf/RNPDFPdfView.mm
 +++ b/node_modules/react-native-pdf/ios/RNPDFPdf/RNPDFPdfView.mm
-@@ -390,7 +390,11 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
+@@ -375,6 +375,11 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
+             
+                 // decode file path
+                 _path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
++                if (_path == nil || _path.length == 0) {
++                    [self notifyOnChangeWithMessage:@"error|Load pdf failed. Invalid file path."];
++                    _pdfDocument = Nil;
++                    return;
++                }
+                 NSURL *fileURL = [NSURL fileURLWithPath:_path];
+                 _pdfDocument = [[PDFDocument alloc] initWithURL:fileURL];
+             }
+@@ -390,7 +395,11 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
                      return;
                  }
  
@@ -15,7 +27,7 @@ index de46c98..ddc97f2 100644
              } else {
  
                  [self notifyOnChangeWithMessage:[[NSString alloc] initWithString:[NSString stringWithFormat:@"error|Load pdf failed. path=%s",_path.UTF8String]]];
-@@ -540,13 +544,17 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
+@@ -540,13 +549,17 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
              PDFPage *pdfPage = [_pdfDocument pageAtIndex:_page-1];
              if (pdfPage && _page == 1) {
                  dispatch_async(dispatch_get_main_queue(), ^{
@@ -39,7 +51,7 @@ index de46c98..ddc97f2 100644
                      }
                  });
              } else if (pdfPage) {
-@@ -559,8 +567,12 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
+@@ -559,8 +572,12 @@ - (void)didSetProps:(NSArray<NSString *> *)changedProps
  
                  CGPoint pointLeftTop = CGPointMake(0, pdfPageRect.size.height);
                  PDFDestination *pdfDest = [[PDFDestination alloc] initWithPage:pdfPage atPoint:pointLeftTop];
@@ -54,7 +66,7 @@ index de46c98..ddc97f2 100644
              }
          }
  
-@@ -620,15 +632,19 @@ - (void)dealloc{
+@@ -620,15 +637,19 @@ - (void)dealloc{
  - (void)onDocumentChanged:(NSNotification *)noti
  {
  
@@ -81,7 +93,7 @@ index de46c98..ddc97f2 100644
      }
  
  }
-@@ -722,12 +738,16 @@ -(NSString *) getTableContents
+@@ -722,12 +743,16 @@ -(NSString *) getTableContents
  - (void)onPageChanged:(NSNotification *)noti
  {
  


### PR DESCRIPTION
## What

[Sentry 7539006346](https://gumroad-to.sentry.io/issues/7539006346/) — **FATAL**, ~15 events, iOS: `NSInvalidArgumentException: -[NSURL initFileURLWithPath:]: nil string parameter` in `-[RNPDFPdfView didSetProps:]`.

**Root cause (in react-native-pdf 7.0.4):** `RNPDFPdfView.mm` decodes the file path with `CFURLCreateStringByReplacingPercentEscapes`, which returns **nil** for a malformed percent-escape — and the path is also momentarily nil/empty during react-native-pdf's own transient source-resolution state (`index.js` sets `path: ''`). The nil is passed straight to `[NSURL fileURLWithPath:]`, which throws and crashes the app. The app's `<Pdf>` render guard (`!cachedUri`) can't prevent this — it originates inside the library's prop handling.

## Change

Extends the **existing** `patches/react-native-pdf+7.0.4.patch` (the team already hardens this file with `@try/@catch`). After the percent-decode, if `_path` is nil/empty, bail out via the library's normal `error|Load pdf failed` notification instead of constructing `[NSURL fileURLWithPath:nil]`:

```objc
_path = (__bridge_transfer NSString *)CFURLCreateStringByReplacingPercentEscapes(NULL, (CFStringRef)_path, CFSTR(""));
if (_path == nil || _path.length == 0) {
    [self notifyOnChangeWithMessage:@"error|Load pdf failed. Invalid file path."];
    _pdfDocument = Nil;
    return;
}
NSURL *fileURL = [NSURL fileURLWithPath:_path];
```

`app/pdf-viewer.tsx`'s `onError` handler already renders the user-facing "Unable to load this PDF" fallback, so the crash becomes a graceful error.

## Verification

- Patch regenerated via `patch-package` scoped to `RNPDFPdfView.mm` (+18/−6 to the existing patch; existing guards preserved).
- Normal PDF viewing confirmed working on the iOS simulator (opened a PDF from the Library — renders, no crash). The specific nil-path race is rare (~15 events) and not deterministically reproducible, but the guard provably prevents `fileURLWithPath:nil`.
- ⚠️ Native patch — a clean `pod install`/rebuild applies it via the `postinstall` hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785190971&installation_id=134400930&pr_number=281&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F281&signature=7c44b5c33cefd11ab4a62e3d976f44c997663213a9e0779af8cfb638be59b049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted native guard in a vendored patch with graceful error reporting; no auth, data, or broad logic changes.
> 
> **Overview**
> Extends **`patches/react-native-pdf+7.0.4.patch`** so iOS no longer calls `[NSURL fileURLWithPath:]` when the decoded path is nil or empty (malformed escapes or transient empty `path` from the library). In that case the native view emits **`error|Load pdf failed. Invalid file path.`** and returns instead of throwing **`NSInvalidArgumentException`**.
> 
> Existing **`@try/@catch`** hardening in the same patch file is unchanged in behavior; the patch hunks were refreshed around the new early exit. **`pdf-viewer.tsx`** already handles PDF **`onError`** with the “Unable to load this PDF” UI, so this turns a fatal crash into a handled error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1626828c1d95a34f71858ec8da78f466918ede7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->