### PR TITLE
Fix Android audio pitch rising when playback speed increased

### DIFF
--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -69,6 +69,16 @@ export const setupPlayer = async () => {
     ],
     forwardJumpInterval: 30,
     backwardJumpInterval: 15,
+    android: {
+      // Disable ExoPlayer audio offload. When a track is offloaded to the
+      // device's audio HAL, playback-rate changes bypass the Sonic audio
+      // processor that preserves pitch, so speeding up (e.g. 1.5x) raises the
+      // pitch ("chipmunk" effect). Offload eligibility is codec/sample-rate
+      // dependent, which is why only *some* media exhibited the bug while
+      // others on the same device played correctly. Forcing offload off routes
+      // every track through Sonic so pitch is preserved at all speeds.
+      audioOffload: false,
+    },
   });
   const loopEnabled = await getStoredLoopEnabled();
   await TrackPlayer.setRepeatMode(loopEnabled ? RepeatMode.Queue : RepeatMode.Off);

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -70,13 +70,6 @@ export const setupPlayer = async () => {
     forwardJumpInterval: 30,
     backwardJumpInterval: 15,
     android: {
-      // Disable ExoPlayer audio offload. When a track is offloaded to the
-      // device's audio HAL, playback-rate changes bypass the Sonic audio
-      // processor that preserves pitch, so speeding up (e.g. 1.5x) raises the
-      // pitch ("chipmunk" effect). Offload eligibility is codec/sample-rate
-      // dependent, which is why only *some* media exhibited the bug while
-      // others on the same device played correctly. Forcing offload off routes
-      // every track through Sonic so pitch is preserved at all speeds.
       audioOffload: false,
     },
   });

--- a/tests/components/setup-player.test.ts
+++ b/tests/components/setup-player.test.ts
@@ -1,13 +1,3 @@
-/**
- * Regression test for the Android "chipmunk" playback bug: increasing playback
- * speed raised the audio pitch on some media because ExoPlayer audio offload
- * bypasses the Sonic pitch-correction processor. The fix disables offload in
- * setupPlayer via `updateOptions({ android: { audioOffload: false } })`, which
- * forces every track through Sonic so pitch is preserved at all speeds.
- *
- * See antiwork/gumroad-private#802.
- */
-
 jest.mock("react-native-track-player", () => ({
   __esModule: true,
   default: {

--- a/tests/components/setup-player.test.ts
+++ b/tests/components/setup-player.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Regression test for the Android "chipmunk" playback bug: increasing playback
+ * speed raised the audio pitch on some media because ExoPlayer audio offload
+ * bypasses the Sonic pitch-correction processor. The fix disables offload in
+ * setupPlayer via `updateOptions({ android: { audioOffload: false } })`, which
+ * forces every track through Sonic so pitch is preserved at all speeds.
+ *
+ * See antiwork/gumroad-private#802.
+ */
+
+jest.mock("react-native-track-player", () => ({
+  __esModule: true,
+  default: {
+    setupPlayer: jest.fn().mockResolvedValue(undefined),
+    updateOptions: jest.fn().mockResolvedValue(undefined),
+    setRepeatMode: jest.fn().mockResolvedValue(undefined),
+  },
+  Capability: {
+    Play: "play",
+    Pause: "pause",
+    Stop: "stop",
+    SkipToNext: "skip-to-next",
+    SkipToPrevious: "skip-to-previous",
+    JumpForward: "jump-forward",
+    JumpBackward: "jump-backward",
+  },
+  Event: {},
+  RepeatMode: { Off: "off", Queue: "queue" },
+  State: {},
+}));
+
+jest.mock("../../components/full-audio-player", () => ({
+  getStoredLoopEnabled: jest.fn().mockResolvedValue(false),
+  getStoredPlaybackSpeed: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/lib/audio-player-store", () => ({
+  setAudioAccessToken: jest.fn(),
+  setAudioContext: jest.fn(),
+}));
+
+jest.mock("@/lib/auth-context", () => ({ useAuth: jest.fn() }));
+jest.mock("@/lib/media-location", () => ({ updateMediaLocation: jest.fn() }));
+
+/* eslint-disable import/first -- jest.mock calls must precede the imports they affect */
+import TrackPlayer from "react-native-track-player";
+import { setupPlayer } from "../../components/use-audio-player-sync";
+
+const mockTrackPlayer = TrackPlayer as jest.Mocked<typeof TrackPlayer>;
+
+describe("setupPlayer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("disables Android audio offload so playback-speed changes preserve pitch", async () => {
+    await setupPlayer();
+
+    expect(mockTrackPlayer.updateOptions).toHaveBeenCalledTimes(1);
+    const options = (mockTrackPlayer.updateOptions as jest.Mock).mock.calls[0][0];
+    expect(options.android).toBeDefined();
+    expect(options.android.audioOffload).toBe(false);
+  });
+});


### PR DESCRIPTION
## What
Increasing playback speed (e.g. 1.5x) raised the audio **pitch** ("chipmunk" effect) on some media in the Android app, while other media played correctly with pitch preserved — same app, same seller, same device. Reported via support: antiwork/gumroad-private#802.

## Root cause
**ExoPlayer audio offload.** When a track is offloaded to the device's audio HAL, playback-rate changes bypass the **Sonic** audio processor that does time-stretch / pitch-correction — so the hardware just resamples and the pitch rises with speed. Offload eligibility is **codec / sample-rate dependent**, which is exactly why only *some* files chipmunked while others did not (the buyer's "Endgame" course was fine; "Chess Giant's Hippo" / "Advanced Hippo" were not).

`setupPlayer()` never set the offload option, so ExoPlayer fell back to its platform-default offload behavior — non-deterministic across media.

## Fix
Explicitly disable audio offload in `setupPlayer` so every track routes through Sonic and pitch is preserved at all speeds:

```ts
await TrackPlayer.updateOptions({
  // ...
  android: { audioOffload: false },
});
```

`react-native-track-player` maps this to `setAudioOffload(false)` →
`AudioOffloadPreferences.AUDIO_OFFLOAD_MODE_DISABLED` on the ExoPlayer track selector. Trade-off: offload's marginal battery savings are lost, but correct pitch at all speeds is the right call for a podcast/course player.

## Testing
- Added `tests/components/setup-player.test.ts` — asserts `setupPlayer` passes `android.audioOffload === false`.
- Full suite green: **37 suites / 269 tests pass** (`yarn jest`). Lint + Prettier clean on changed files.
- ⚠️ Needs a **device smoke test** before release: play an affected course at 1.5x on Android and confirm pitch is now preserved. iOS uses a different path (`AVPlayer` defaults to `AVAudioTimePitchAlgorithm` pitch-correction) and was not affected.

## Notes
- This ships to users via a mobile release (TestFlight + Play internal → promote). It is **not** live just by merging.
- No iOS change needed.

Closes antiwork/gumroad-private#802

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785447005&installation_id=134400930&pr_number=282&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F282&signature=7cfcd91e737555393c272e50e67f18944cebdc9b202c272d6a6aa1dfda7c87f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->