### PR TITLE
Agent chat: structured proposed-action card matching web

### DIFF
--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -36,27 +36,42 @@ const ProposedActionCard = ({
   onConfirm: () => void;
   onDismiss: () => void;
 }) => (
-  <View className="mt-2 gap-2 rounded-2xl border border-dashed border-border p-4">
-    <Text className="font-sans font-semibold text-foreground">Proposed change</Text>
-    <Text className="text-foreground">{action.summary}</Text>
-    {status === "applied" ? (
-      <Text className="text-accent" role="status">
-        Applied
-      </Text>
-    ) : status === "dismissed" ? (
-      <Text className="text-muted" role="status">
-        Dismissed
-      </Text>
-    ) : (
-      <View className="flex-row gap-2">
-        <Button variant="accent" size="sm" disabled={isPending} onPress={onConfirm}>
-          <Text>{isApplying ? "Applying..." : "Confirm"}</Text>
-        </Button>
-        <Button variant="outline" size="sm" disabled={isPending} onPress={onDismiss}>
-          <Text>Dismiss</Text>
-        </Button>
-      </View>
-    )}
+  <View className="mt-2 rounded border border-border bg-card">
+    <View className="gap-2 p-4">
+      <Text className="font-sans font-semibold text-foreground">{action.title ?? "Proposed change"}</Text>
+      {action.fields && action.fields.length > 0 ? (
+        <View className="gap-1">
+          {action.fields.map((field) => (
+            <View key={field.label} className="flex-row gap-2">
+              <Text className="text-sm text-muted">{field.label}</Text>
+              <Text className="flex-1 text-right text-sm text-foreground">{field.value}</Text>
+            </View>
+          ))}
+        </View>
+      ) : (
+        <Text className="text-foreground">{action.summary}</Text>
+      )}
+    </View>
+    <View className="flex-row items-center justify-end gap-2 border-t border-border p-3">
+      {status === "applied" ? (
+        <Text className="mr-auto text-accent" role="status">
+          Applied
+        </Text>
+      ) : status === "dismissed" ? (
+        <Text className="mr-auto text-muted" role="status">
+          Dismissed
+        </Text>
+      ) : (
+        <>
+          <Button variant="outline" size="sm" disabled={isPending} onPress={onDismiss}>
+            <Text>Dismiss</Text>
+          </Button>
+          <Button variant="accent" size="sm" disabled={isPending} onPress={onConfirm}>
+            <Text>{isApplying ? "Applying..." : "Confirm"}</Text>
+          </Button>
+        </>
+      )}
+    </View>
   </View>
 );
 

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -7,10 +7,17 @@ export interface ChatMessage {
   content: string;
 }
 
+export interface ProposedActionField {
+  label: string;
+  value: string;
+}
+
 export interface ProposedAction {
   type: "create_discount" | "update_product_price" | "publish_product" | "unpublish_product";
   params: Record<string, unknown>;
   summary: string;
+  title?: string;
+  fields?: ProposedActionField[];
 }
 
 interface AgentMetaResponse {

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -127,6 +127,36 @@ describe("AgentChat", () => {
     expect(mockExecuteAgentAction).not.toHaveBeenCalled();
   });
 
+  it("renders the action title and structured fields when provided", async () => {
+    mockSendAgentMessage.mockResolvedValue({
+      reply: "I've prepared a discount.",
+      proposedAction: {
+        type: "create_discount",
+        params: { code: "LAUNCH", percent_off: 20 },
+        summary: "Create a 20% off code called LAUNCH",
+        title: "Create discount",
+        fields: [
+          { label: "Code", value: "LAUNCH" },
+          { label: "Discount", value: "20% off" },
+        ],
+      },
+    });
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "Create a launch discount");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Create discount")).toBeTruthy());
+    expect(screen.getByText("Code")).toBeTruthy();
+    expect(screen.getByText("LAUNCH")).toBeTruthy();
+    expect(screen.getByText("Discount")).toBeTruthy();
+    expect(screen.getByText("20% off")).toBeTruthy();
+    expect(screen.queryByText("Create a 20% off code called LAUNCH")).toBeNull();
+  });
+
   it("shows a fallback assistant message when the request fails", async () => {
     mockSendAgentMessage.mockRejectedValue(new Error("network down"));
 


### PR DESCRIPTION
## What
Restyles the Agent chat's proposed-action card to match the web Agent page's structured confirmation card (antiwork/gumroad#5630):

- **Solid card, not a dashed box** — standard small-radius `Card` treatment (`rounded border border-border bg-card`), same as the web card and the rest of the app's cards.
- **Structured fields** — when the backend provides `title` + `fields` (the same shape the web card consumes), the card renders a proper definition list (label left, value right) instead of a prose summary. Falls back to `summary` when fields are absent, so nothing breaks against the current API.
- **Divided footer** — actions sit in a bordered footer row: Dismiss (outline) left of Confirm (accent), matching the web layout. Applied/Dismissed status renders left-aligned in the footer.

## Why
The mobile card predates the web redesign in antiwork/gumroad#5630, which moved proposed changes into a structured confirmation card with key/value rows. This brings the two surfaces back into visual parity, and structured rows are much easier to scan before confirming a store mutation than a sentence.

## Screenshots
Real captures of this branch's `AgentChat` rendered via Expo web (iPhone 390×844, dark), canned data:

| Structured action card | Plain-text replies + composer |
| --- | --- |
| <img width="380" src="https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr274-mobile/5-proposed-action-card-v2.png" /> | <img width="380" src="https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr274-mobile/4-plain-text-reply.png?v=3" /> |

## Test plan
- New test: renders `title` + structured `fields` when provided and hides the prose summary.
- Existing confirm/dismiss/failure tests still pass — full suite green (282 tests, 38 suites).
- `tsc --noEmit` clean, prettier formatted.

Stacked on #274 (`gumclaw/agent-tab`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785587945&installation_id=134400930&pr_number=283&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F283&signature=5f70a98d0951ef678189a29e469033d3dd2c91a615d27b8368ee3eee03f01521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->