### PR TITLE
fix(agent): composite key for proposed-action field rows (Greptile #283)

### DIFF
--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -41,8 +41,8 @@ const ProposedActionCard = ({
       <Text className="font-sans font-semibold text-foreground">{action.title ?? "Proposed change"}</Text>
       {action.fields && action.fields.length > 0 ? (
         <View className="gap-1">
-          {action.fields.map((field) => (
-            <View key={field.label} className="flex-row gap-2">
+          {action.fields.map((field, i) => (
+            <View key={`${i}-${field.label}`} className="flex-row gap-2">
               <Text className="text-sm text-muted">{field.label}</Text>
               <Text className="flex-1 text-right text-sm text-foreground">{field.value}</Text>
             </View>


### PR DESCRIPTION
## What
Follow-up to #283. Uses a composite `index + label` key for the proposed-action card's field rows instead of `field.label` alone.

## Why
Greptile flagged (P2) that keying on `field.label` is fragile: if the backend returns two fields with the same label (e.g. an old-value/new-value pair both labeled "Price", or any repeated row), React silently deduplicates them and drops a row from the rendered list. Keying on `${i}-${field.label}` keeps every row stable.

## Test plan
- `npx tsc --noEmit` — no new errors in `components/agent/agent-chat.tsx` (pre-existing unrelated errors elsewhere untouched).
- `prettier --write` clean.
- Rendering unaffected for the common (unique-label) case; duplicate-label rows now render correctly instead of collapsing.

Targets `gumclaw/agent-tab` (the base #283 merged into), not main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/antiwork/codesmith/gumroad-mobile/pr/284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785588301&installation_id=134400930&pr_number=284&repository=antiwork%2Fgumroad-mobile&return_to=https%3A%2F%2Fgithub.com%2Fantiwork%2Fgumroad-mobile%2Fpull%2F284&signature=9b92264cf2ab8845683f92dab1d9a23500d1fbb0855f4be32d7a1b6f603c525d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->