### PR TITLE
docs: clarify AGENTS.md comment-rule precedence vs CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 @CONTRIBUTING.md
+
 ## Code comments
 
-The default from CONTRIBUTING.md still applies: don't add explanatory comments — code should speak for itself. This section is only about the rare comment that genuinely earns its place (a non-obvious invariant, a gotcha, a link to a decision).
+The default from CONTRIBUTING.md still applies: don't add explanatory comments — code should speak for itself. This section does not create a new exception to that rule.
 
-When a comment is warranted, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+If you are explicitly asked to add or update a comment, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain _why_ the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 @CONTRIBUTING.md
-
 ## Code comments
 
-The default from CONTRIBUTING.md still applies: don't add explanatory comments — code should speak for itself. This section does not create a new exception to that rule.
+The default from CONTRIBUTING.md still applies: don't add explanatory comments — code should speak for itself. This section is only about the rare comment that genuinely earns its place (a non-obvious invariant, a gotcha, a link to a decision).
 
-If you are explicitly asked to add or update a comment, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain _why_ the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+When a comment is warranted, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
 @CONTRIBUTING.md
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+The default from CONTRIBUTING.md still applies: don't add explanatory comments — code should speak for itself. This section is only about the rare comment that genuinely earns its place (a non-obvious invariant, a gotcha, a link to a decision).
+
+When a comment is warranted, write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.


### PR DESCRIPTION
## What

Clarifies the `Code comments` section added to AGENTS.md in #285 so it no longer reads as contradicting CONTRIBUTING.md's "Don't leave comments in the code / No explanatory comments" rule. The section now states the no-comments default still applies, and the plain-language style guidance only kicks in for the rare comment that genuinely earns its place (a non-obvious invariant, a gotcha, a link to a decision).

## Why

Greptile flagged on #285 that the new guidance ("here's how to write comments") conflicts with the included CONTRIBUTING.md guidance ("don't write comments"), which could make agents apply the wrong rule inconsistently. Making the precedence explicit resolves the ambiguity: default is still no comments; when one is warranted, write it for a reader new to the codebase.

## Before/After

Not applicable — docs-only change to an agent instruction file; no app code, UI, or behavior changes, nothing to record.

## Test Results

Not applicable — no code changed, no tests to run.

---

AI disclosure: authored by Claude (Hermes Agent) in response to Greptile's review on #285. Prompt: address the review finding that the new comment-style rule conflicts with CONTRIBUTING.md's no-comments guidance.
