### PR TITLE
docs: reconcile comment rules between AGENTS.md and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
 @CONTRIBUTING.md
 ## Code comments
 
-Write comments for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+Default to no comments — most code should explain itself (see CONTRIBUTING.md). When a comment is genuinely warranted (a non-obvious invariant, gotcha, or decision the code can't convey), write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 @CONTRIBUTING.md
+
 ## Code comments
 
-Default to no comments — most code should explain itself (see CONTRIBUTING.md). When a comment is genuinely warranted (a non-obvious invariant, gotcha, or decision the code can't convey), write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain *why* the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.
+Default to no comments — most code should explain itself (see CONTRIBUTING.md). When a comment is genuinely warranted (a non-obvious invariant, gotcha, or decision the code can't convey), write it for a reader who is new to the codebase but familiar with the goal of the project. Avoid jargon-dense shorthand: explain _why_ the code does what it does in plain language, spell out non-obvious context (invariants, gotchas, links to the decision), and don't assume the reader knows internal nicknames, prior incidents, or module history. A good test: someone on day one who knows what the product does should understand the comment without grepping elsewhere.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,7 @@ Do not push code with failing tests. CI is not a substitute for local verificati
 - Always use the latest version of TypeScript and React Native
 - Sentence case headers and buttons and stuff, not title case
 - Always write the code
-- Don't leave comments in the code
-- No explanatory comments please
+- Default to no comments in the code; when one is genuinely needed, follow the comment style in AGENTS.md
 - Don't apologize for errors, fix them
 - Assign raw numbers to named constants (e.g., `MAX_CHARACTER_LIMIT` instead of `500`) to clarify their purpose.
 - Avoid abstracting code into shared components if the duplication is coincidental. If two interfaces look similar but serve different purposes, keep them separate to allow independent evolution.


### PR DESCRIPTION
## What

Reconciles the code-comment guidance between AGENTS.md, CONTRIBUTING.md, and CLAUDE.md so they say the same thing: default to no comments, and when one is genuinely needed, write it in plain language for a reader new to the codebase (per the style in AGENTS.md). CLAUDE.md was added after Greptile flagged that it still had the old absolute wording.

## Why

Greptile flagged a real conflict on #285: CONTRIBUTING.md said "Don't leave comments in the code / No explanatory comments please" while the new AGENTS.md section told agents how to write comments. An agent loading both got contradictory instructions, and which one wins would be arbitrary. This makes the default (no comments) explicit in both files and frames the AGENTS.md section as the style to use for the rare comment that earns its place.

Follow-up to #285 (Greptile review [P1 finding](https://github.com/antiwork/gumroad-mobile/pull/285#pullrequestreview-4627143203)).

## Before/After

Not applicable — documentation-only change, no UI.

## Test Results

Not applicable — no code changed. Ran `prettier --write` on both files.

## AI Disclosure

Written by Hermes (Claude) — drafted the wording, edited the files, and opened the PR.

