### PR TITLE
Fix audio playback not resuming from saved position on iOS

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -182,6 +182,7 @@ export default function PostScreen() {
         title: f.name ?? post.name,
         urlRedirectId: post.url_redirect_external_id,
         purchaseId: purchase.purchase_id,
+        resumeAt: f.latest_media_location?.location,
       }));
       const file = allAudioFiles.find((f) => f.id === fileId);
       await playAudio({

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -158,6 +158,7 @@ export default function DownloadScreen() {
             title: fileData.name ?? purchase?.name,
             urlRedirectId: purchase?.url_redirect_external_id,
             purchaseId: purchase?.purchase_id,
+            resumeAt: fileData.latest_media_location?.location,
           }));
           await playAudio({
             resourceId: message.payload.resourceId,

--- a/components/track-player-service.ts
+++ b/components/track-player-service.ts
@@ -1,5 +1,5 @@
 import { getAudioAccessToken, getAudioContext } from "@/lib/audio-player-store";
-import { updateMediaLocation } from "@/lib/media-location";
+import { isMeaningfulLocation, updateMediaLocation } from "@/lib/media-location";
 import TrackPlayer, { Event, State } from "react-native-track-player";
 import { isPlayerInitialized } from "./use-audio-player-sync";
 
@@ -9,6 +9,7 @@ const syncCurrentPosition = async (isEnd = false) => {
   if (!context || !context.urlRedirectId || !accessToken) return;
 
   const { position } = await TrackPlayer.getProgress();
+  if (!isMeaningfulLocation(position, isEnd)) return;
   const location = isEnd && context.contentLength ? context.contentLength : Math.floor(position);
 
   await updateMediaLocation({

--- a/components/track-player-service.ts
+++ b/components/track-player-service.ts
@@ -3,14 +3,14 @@ import { isMeaningfulLocation, updateMediaLocation } from "@/lib/media-location"
 import TrackPlayer, { Event, State } from "react-native-track-player";
 import { isPlayerInitialized } from "./use-audio-player-sync";
 
-const syncCurrentPosition = async (isEnd = false) => {
+const syncCurrentPosition = async () => {
   const context = getAudioContext();
   const accessToken = getAudioAccessToken();
   if (!context || !context.urlRedirectId || !accessToken) return;
 
   const { position } = await TrackPlayer.getProgress();
-  if (!isMeaningfulLocation(position, isEnd)) return;
-  const location = isEnd && context.contentLength ? context.contentLength : Math.floor(position);
+  if (!isMeaningfulLocation(position, false)) return;
+  const location = Math.floor(position);
 
   await updateMediaLocation({
     urlRedirectId: context.urlRedirectId,

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -133,7 +133,11 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
           setAudioContext(currentAudioRef.current);
           if (state !== State.Playing && state !== State.Buffering) {
             const { position } = await TrackPlayer.getProgress();
-            if (position < 3 && track.resumeAt && track.resumeAt >= 3) {
+            if (
+              !isMeaningfulLocation(position, false) &&
+              track.resumeAt &&
+              isMeaningfulLocation(track.resumeAt, false)
+            ) {
               await TrackPlayer.seekTo(track.resumeAt);
             }
           }

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -1,5 +1,5 @@
-import { useAuth } from "@/lib/auth-context";
 import { setAudioAccessToken, setAudioContext } from "@/lib/audio-player-store";
+import { useAuth } from "@/lib/auth-context";
 import { isMeaningfulLocation, updateMediaLocation } from "@/lib/media-location";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import TrackPlayer, { Capability, Event, RepeatMode, State } from "react-native-track-player";
@@ -23,6 +23,7 @@ export type AudioTrackInfo = {
 
 let isPlayerSetup = false;
 let playerSetupListeners: (() => void)[] = [];
+let hasRestoredSavedPosition = false;
 
 export const isPlayerInitialized = () => isPlayerSetup;
 
@@ -131,7 +132,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
         if (track) {
           currentAudioRef.current = { ...track, contentLength: activeTrack.duration };
           setAudioContext(currentAudioRef.current);
-          if (state !== State.Playing && state !== State.Buffering) {
+          if (!hasRestoredSavedPosition && state !== State.Playing && state !== State.Buffering) {
             const { position } = await TrackPlayer.getProgress();
             if (
               !isMeaningfulLocation(position, false) &&
@@ -139,6 +140,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
               isMeaningfulLocation(track.resumeAt, false)
             ) {
               await TrackPlayer.seekTo(track.resumeAt);
+              hasRestoredSavedPosition = true;
             }
           }
         }

--- a/components/use-audio-player-sync.ts
+++ b/components/use-audio-player-sync.ts
@@ -1,6 +1,6 @@
-import { setAudioAccessToken, setAudioContext } from "@/lib/audio-player-store";
 import { useAuth } from "@/lib/auth-context";
-import { updateMediaLocation } from "@/lib/media-location";
+import { setAudioAccessToken, setAudioContext } from "@/lib/audio-player-store";
+import { isMeaningfulLocation, updateMediaLocation } from "@/lib/media-location";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import TrackPlayer, { Capability, Event, RepeatMode, State } from "react-native-track-player";
 import type { WebView } from "react-native-webview";
@@ -18,6 +18,7 @@ export type AudioTrackInfo = {
   title?: string;
   urlRedirectId?: string;
   purchaseId?: string;
+  resumeAt?: number;
 };
 
 let isPlayerSetup = false;
@@ -120,6 +121,9 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
           uri: t.url?.toString() ?? "",
           resourceId: t.id ?? "",
           title: t.title,
+          urlRedirectId: t.urlRedirectId,
+          purchaseId: t.purchaseId,
+          resumeAt: t.resumeAt,
         }));
       }
       if (activeTrack?.id) {
@@ -127,6 +131,12 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
         if (track) {
           currentAudioRef.current = { ...track, contentLength: activeTrack.duration };
           setAudioContext(currentAudioRef.current);
+          if (state !== State.Playing && state !== State.Buffering) {
+            const { position } = await TrackPlayer.getProgress();
+            if (position < 3 && track.resumeAt && track.resumeAt >= 3) {
+              await TrackPlayer.seekTo(track.resumeAt);
+            }
+          }
         }
       }
     };
@@ -137,8 +147,7 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
     async (position: number, isEnd = false) => {
       const currentAudio = currentAudioRef.current;
       if (!currentAudio || !currentAudio.urlRedirectId) return;
-      // Avoid saving the location 0:01, it's not useful
-      if (!isEnd && position > 0 && position < 3) return;
+      if (!isMeaningfulLocation(position, isEnd)) return;
 
       const location = isEnd && currentAudio.contentLength ? currentAudio.contentLength : Math.floor(position);
 
@@ -301,6 +310,9 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
             artist: artist || "Gumroad",
             artistUrl,
             artwork: artwork || undefined,
+            urlRedirectId: track.urlRedirectId,
+            purchaseId: track.purchaseId,
+            resumeAt: track.resumeAt,
           })),
         );
 
@@ -309,14 +321,16 @@ export const useAudioPlayerSync = (webViewRef: React.RefObject<WebView | null>) 
           await TrackPlayer.skip(trackIndex);
         }
 
-        if (resumeAt) {
-          await TrackPlayer.seekTo(resumeAt);
+        const resumePosition = resumeAt ?? audio.resumeAt;
+        if (resumePosition) {
+          await TrackPlayer.seekTo(resumePosition);
         }
       } else if (previousContext?.resourceId !== audio.resourceId) {
         const trackIndex = tracks.findIndex((t) => t.resourceId === audio.resourceId);
         if (trackIndex >= 0) {
           await TrackPlayer.skip(trackIndex);
-          if (resumeAt) await TrackPlayer.seekTo(resumeAt);
+          const resumePosition = resumeAt ?? audio.resumeAt;
+          if (resumePosition) await TrackPlayer.seekTo(resumePosition);
         }
       }
 

--- a/lib/media-location.ts
+++ b/lib/media-location.ts
@@ -10,6 +10,11 @@ type MediaLocationRequest = {
   location: number;
 };
 
+// Positions under 3 seconds are treated as noise: saving them would overwrite a
+// listener's real progress whenever a track restarts from the beginning (for
+// example after a failed resume). End-of-track saves are always meaningful.
+export const isMeaningfulLocation = (position: number, isEnd: boolean) => isEnd || position >= 3;
+
 export const updateMediaLocation = async ({
   urlRedirectId,
   productFileId,

--- a/tests/lib/media-location.test.ts
+++ b/tests/lib/media-location.test.ts
@@ -27,7 +27,7 @@ jest.mock("@/lib/auth-context", () => ({
   useAuth: jest.fn(() => ({ accessToken: "test" })),
 }));
 
-import { updateMediaLocation } from "@/lib/media-location";
+import { isMeaningfulLocation, updateMediaLocation } from "@/lib/media-location";
 import { ServerError } from "@/lib/request";
 
 beforeEach(() => {
@@ -111,8 +111,6 @@ describe("updateMediaLocation", () => {
     );
   });
 });
-
-import { isMeaningfulLocation } from "@/lib/media-location";
 
 describe("isMeaningfulLocation", () => {
   it("rejects positions under 3 seconds so a restarted track cannot overwrite saved progress", () => {

--- a/tests/lib/media-location.test.ts
+++ b/tests/lib/media-location.test.ts
@@ -111,3 +111,23 @@ describe("updateMediaLocation", () => {
     );
   });
 });
+
+import { isMeaningfulLocation } from "@/lib/media-location";
+
+describe("isMeaningfulLocation", () => {
+  it("rejects positions under 3 seconds so a restarted track cannot overwrite saved progress", () => {
+    expect(isMeaningfulLocation(0, false)).toBe(false);
+    expect(isMeaningfulLocation(1, false)).toBe(false);
+    expect(isMeaningfulLocation(2.9, false)).toBe(false);
+  });
+
+  it("accepts positions of 3 seconds or more", () => {
+    expect(isMeaningfulLocation(3, false)).toBe(true);
+    expect(isMeaningfulLocation(1501, false)).toBe(true);
+  });
+
+  it("always accepts end-of-track saves", () => {
+    expect(isMeaningfulLocation(0, true)).toBe(true);
+    expect(isMeaningfulLocation(1, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes #288 — audio playback restarted at 0:00 instead of the saved position, and pausing shortly after a failed resume overwrote the listener's real progress with ~1s.

Three changes:

1. **Resume works on every playback path, not just the webview tap.** Each track added to the TrackPlayer queue now carries its `resumeAt` (from `latest_media_location`), `urlRedirectId`, and `purchaseId`. `playAudio` falls back to the track's own `resumeAt` when the webview payload doesn't provide one (e.g. stale webview state) — this is the path that fixes the buyer's kill-and-reopen scenario, since `latest_media_location` is re-fetched from the API on screen load. `initFromPlayer` additionally seeks a paused track back to its saved position when the JS layer remounts over a still-alive native player (screen navigation / JS reload); this runs at most once per app session so it can never yank a position the user deliberately scrubbed. Note: react-native-track-player does not persist the queue across process death (verified in the vendored native source), so the queue-restore path only applies within a process lifetime.

2. **A failed resume can no longer clobber real progress.** `syncCurrentPosition` in `track-player-service.ts` (fires on lock-screen pause/stop) had no minimum-position guard, unlike the in-app sync path. Both paths now share a single `isMeaningfulLocation` guard in `lib/media-location.ts` that skips saves under 3 seconds (end-of-track saves always go through). Behavior change to be aware of: saving position `0` is now skipped too (previously allowed). Scrub-to-0:00-and-pause no longer persists a reset-to-start; that trade-off is deliberate — a restart-at-0 is indistinguishable from a failed resume, which is exactly the clobbering bug. End-of-track saves route through the hook's `State.Ended`/`PlaybackQueueEnded` handlers, unchanged.

3. Track switches within an existing queue (`skip`) also seek to the saved position.

## Why

A buyer with a ~4h audiobook lost their place every time they reopened the app. Production `MediaLocation` rows confirmed the server-side write path works; the app failed to read the position on resume paths outside the webview click, then overwrote the saved progress (`location: 1` observed minutes after real progress was recorded). Details in #288.

## Test plan

- New unit tests for `isMeaningfulLocation` (positions under 3s rejected, ≥3s accepted, end-of-track always accepted)
- Full suite: 38 suites / 285 tests passing, `yarn typecheck` and `yarn lint` clean
- Adversarial review completed (verdict: approve-with-nits; all findings addressed — see review comment)
- ⚠️ **Video pending:** this needs a device smoke test (play → kill app → reopen → resume via mini player and lock screen) that I can't record headlessly — flagging for a maintainer with a device before merge

---

🤖 Authored by Gumclaw (AI agent) on behalf of @nyomanjyotisa; production data referenced in #288 came from the audited console.
