### PR TITLE
Stream agent replies token-by-token in the Agent tab

### DIFF
--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -2,7 +2,7 @@ import { LineIcon } from "@/components/icon";
 import { Button } from "@/components/ui/button";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Text } from "@/components/ui/text";
-import { type ChatMessage, type ProposedAction, executeAgentAction, sendAgentMessage } from "@/lib/agent";
+import { type ChatMessage, type ProposedAction, executeAgentAction, streamAgentMessage } from "@/lib/agent";
 import { useAuthedRequest } from "@/lib/authed-request";
 import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
@@ -117,15 +117,28 @@ const MessageBubble = ({
 export const AgentChat = ({ greeting, suggestions }: Props) => {
   const authedRequest = useAuthedRequest();
   const [messages, setMessages] = useState<DisplayMessage[]>([{ role: "assistant", content: greeting }]);
+  const [streamingReply, setStreamingReply] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [pendingActionIndex, setPendingActionIndex] = useState<number | null>(null);
+  const conversationIdRef = useRef<string | null>(null);
   const mutedColor = useCSSVariable("--color-muted") as string;
   const listRef = useRef<FlatList<DisplayMessage>>(null);
 
   const sendMutation = useMutation({
     mutationFn: (history: ChatMessage[]) =>
-      authedRequest((token) => sendAgentMessage({ messages: history, accessToken: token })),
-    onSuccess: ({ reply, proposedAction }) => {
+      authedRequest((token) =>
+        streamAgentMessage({
+          messages: history,
+          conversationId: conversationIdRef.current,
+          accessToken: token,
+          handlers: {
+            onToken: (text) => setStreamingReply((prev) => (prev ?? "") + text),
+            onReset: () => setStreamingReply(null),
+          },
+        }),
+      ),
+    onSuccess: ({ reply, proposedAction, conversationId }) => {
+      conversationIdRef.current = conversationId;
       setMessages((prev) => [
         ...prev,
         { role: "assistant", content: reply, ...(proposedAction ? { proposedAction } : {}) },
@@ -137,11 +150,14 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         { role: "assistant", content: "Sorry, I ran into a problem. Please try again." },
       ]);
     },
+    onSettled: () => setStreamingReply(null),
   });
 
   const executeMutation = useMutation({
     mutationFn: (action: ProposedAction) =>
-      authedRequest((token) => executeAgentAction({ action, accessToken: token })),
+      authedRequest((token) =>
+        executeAgentAction({ action, conversationId: conversationIdRef.current, accessToken: token }),
+      ),
   });
 
   const isSending = sendMutation.isPending;
@@ -150,7 +166,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   useEffect(() => {
     const timeout = setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 100);
     return () => clearTimeout(timeout);
-  }, [messages, isSending]);
+  }, [messages, isSending, streamingReply]);
 
   const send = (text: string) => {
     const trimmed = text.trim();
@@ -213,10 +229,18 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
         )}
         ListFooterComponent={
           isSending ? (
-            <View className="flex-row items-center gap-2" role="status" accessibilityLabel="Working on it">
-              <LoadingSpinner size="small" />
-              <Text className="text-sm text-muted">Working on it...</Text>
-            </View>
+            streamingReply ? (
+              <View className="items-start">
+                <View className="w-full">
+                  <Text className="text-foreground">{streamingReply}</Text>
+                </View>
+              </View>
+            ) : (
+              <View className="flex-row items-center gap-2" role="status" accessibilityLabel="Working on it">
+                <LoadingSpinner size="small" />
+                <Text className="text-sm text-muted">Working on it...</Text>
+              </View>
+            )
           ) : null
         }
       />

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl, requestAPI } from "@/lib/request";
+import { buildApiUrl, REQUEST_TIMEOUT_MS, requestAPI, UnauthorizedError } from "@/lib/request";
 import { fetch as streamingFetch } from "expo/fetch";
 
 export type ChatRole = "user" | "assistant";
@@ -108,83 +108,102 @@ export const streamAgentMessage = async ({
   accessToken: string;
   handlers?: AgentStreamHandlers;
 }): Promise<AgentStreamResult> => {
-  const response = await streamingFetch(buildApiUrl("mobile/agent/messages/stream"), {
-    method: "POST",
-    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ messages, ...(conversationId ? { conversation_id: conversationId } : {}) }),
-  });
-
-  const body = response.body;
-  if (!response.ok || !response.headers.get("content-type")?.includes("text/event-stream") || !body) {
-    throw new Error(`Agent stream request failed: ${response.status}`);
-  }
-
-  let done: AgentStreamResult | null = null;
-
-  const handleFrame = (frame: string): AgentStreamResult | null => {
-    let event = "message";
-    const dataLines: string[] = [];
-    for (const line of frame.split("\n")) {
-      if (line.startsWith("event:")) event = line.slice(6).trim();
-      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
-    }
-    if (dataLines.length === 0) return null;
-    const raw: unknown = JSON.parse(dataLines.join("\n"));
-
-    switch (event) {
-      case "token": {
-        const { text } = raw as { text: string };
-        handlers.onToken?.(text);
-        return null;
-      }
-      case "reset": {
-        handlers.onReset?.();
-        return null;
-      }
-      case "done": {
-        const data = raw as DoneEventData;
-        return {
-          reply: data.reply,
-          proposedAction: data.proposed_action,
-          conversationId: data.conversation_id ?? conversationId ?? null,
-        };
-      }
-      case "error": {
-        throw new Error((raw as { message: string }).message);
-      }
-      default:
-        return null;
-    }
+  // Abort the request if the server goes quiet for too long. The timer restarts on every
+  // received chunk, so a long reply streams fine — only a stalled connection gets cut off.
+  const controller = new AbortController();
+  let timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  const resetIdleTimeout = () => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   };
 
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
   try {
-    for (;;) {
-      const { value, done: streamDone } = await reader.read();
-      if (streamDone) break;
-      buffer += decoder.decode(value, { stream: true });
-      let separator = buffer.indexOf("\n\n");
-      while (separator !== -1) {
-        const frame = buffer.slice(0, separator);
-        buffer = buffer.slice(separator + 2);
-        if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
-        separator = buffer.indexOf("\n\n");
+    const response = await streamingFetch(buildApiUrl("mobile/agent/messages/stream"), {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ messages, ...(conversationId ? { conversation_id: conversationId } : {}) }),
+      signal: controller.signal,
+    });
+
+    if (response.status === 401) throw new UnauthorizedError("Unauthorized");
+    const body = response.body;
+    if (!response.ok || !response.headers.get("content-type")?.includes("text/event-stream") || !body) {
+      throw new Error(`Agent stream request failed: ${response.status}`);
+    }
+
+    let done: AgentStreamResult | null = null;
+
+    const handleFrame = (frame: string): AgentStreamResult | null => {
+      let event = "message";
+      const dataLines: string[] = [];
+      for (const line of frame.split("\n")) {
+        if (line.startsWith("event:")) event = line.slice(6).trim();
+        else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
       }
+      if (dataLines.length === 0) return null;
+      const raw: unknown = JSON.parse(dataLines.join("\n"));
+
+      switch (event) {
+        case "token": {
+          const { text } = raw as { text: string };
+          handlers.onToken?.(text);
+          return null;
+        }
+        case "reset": {
+          handlers.onReset?.();
+          return null;
+        }
+        case "done": {
+          const data = raw as DoneEventData;
+          return {
+            reply: data.reply,
+            proposedAction: data.proposed_action,
+            conversationId: data.conversation_id ?? conversationId ?? null,
+          };
+        }
+        case "error": {
+          throw new Error((raw as { message: string }).message);
+        }
+        default:
+          return null;
+      }
+    };
+
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      for (;;) {
+        const { value, done: streamDone } = await reader.read();
+        if (streamDone) break;
+        resetIdleTimeout();
+        buffer += decoder.decode(value, { stream: true });
+        let separator = buffer.indexOf("\n\n");
+        while (separator !== -1) {
+          const frame = buffer.slice(0, separator);
+          buffer = buffer.slice(separator + 2);
+          if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
+          separator = buffer.indexOf("\n\n");
+        }
+      }
+    } finally {
+      reader.cancel().catch(() => {});
     }
     if (buffer.trim().length > 0) {
       try {
         done = handleFrame(buffer) ?? done;
       } catch (error) {
+        // Data left in the buffer after the stream closes means the last frame was cut off
+        // mid-transmission, so failing to parse it as JSON is expected — we fall through to
+        // the "ended without a done event" error below. Anything else is a real error.
         if (!(error instanceof SyntaxError)) throw error;
       }
     }
-  } finally {
-    reader.cancel().catch(() => {});
-  }
 
-  if (!done) throw new Error("Agent stream ended without a done event");
-  return done;
+    if (!done) throw new Error("Agent stream ended without a done event");
+    return done;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 };

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,5 @@
-import { requestAPI } from "@/lib/request";
+import { buildApiUrl, requestAPI } from "@/lib/request";
+import { fetch as streamingFetch } from "expo/fetch";
 
 export type ChatRole = "user" | "assistant";
 
@@ -13,7 +14,7 @@ export interface ProposedActionField {
 }
 
 export interface ProposedAction {
-  type: "create_discount" | "update_product_price" | "publish_product" | "unpublish_product";
+  type: "api_write" | "create_discount" | "update_product_price" | "publish_product" | "unpublish_product";
   params: Record<string, unknown>;
   summary: string;
   title?: string;
@@ -28,7 +29,8 @@ interface AgentMetaResponse {
 }
 
 type SendMessageResponse =
-  { success: true; reply: string; proposed_action: ProposedAction | null } | { success: false; error: string };
+  | { success: true; reply: string; proposed_action: ProposedAction | null; conversation_id?: string }
+  | { success: false; error: string };
 
 interface ExecuteActionResponse {
   success: boolean;
@@ -40,32 +42,145 @@ export const fetchAgentMeta = (accessToken: string) =>
 
 export const sendAgentMessage = async ({
   messages,
+  conversationId,
   accessToken,
 }: {
   messages: ChatMessage[];
+  conversationId?: string | null;
   accessToken: string;
-}): Promise<{ reply: string; proposedAction: ProposedAction | null }> => {
+}): Promise<{ reply: string; proposedAction: ProposedAction | null; conversationId: string | null }> => {
   const json = await requestAPI<SendMessageResponse>("mobile/agent/messages", {
     method: "POST",
-    data: { messages },
+    data: { messages, ...(conversationId ? { conversation_id: conversationId } : {}) },
     accessToken,
   });
   if (!json.success) throw new Error(json.error);
-  return { reply: json.reply, proposedAction: json.proposed_action };
+  return { reply: json.reply, proposedAction: json.proposed_action, conversationId: json.conversation_id ?? null };
 };
 
 export const executeAgentAction = async ({
   action,
+  conversationId,
   accessToken,
 }: {
   action: ProposedAction;
+  conversationId?: string | null;
   accessToken: string;
 }): Promise<string> => {
   const json = await requestAPI<ExecuteActionResponse>("mobile/agent/actions", {
     method: "POST",
-    data: { type: action.type, params: action.params },
+    data: {
+      type: action.type,
+      params: action.params,
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+    },
     accessToken,
   });
   if (!json.success) throw new Error(json.message);
   return json.message;
+};
+
+export interface AgentStreamHandlers {
+  onToken?: (text: string) => void;
+  onReset?: () => void;
+}
+
+export interface AgentStreamResult {
+  reply: string;
+  proposedAction: ProposedAction | null;
+  conversationId: string | null;
+}
+
+interface DoneEventData {
+  reply: string;
+  proposed_action: ProposedAction | null;
+  conversation_id?: string;
+}
+
+export const streamAgentMessage = async ({
+  messages,
+  conversationId,
+  accessToken,
+  handlers = {},
+}: {
+  messages: ChatMessage[];
+  conversationId?: string | null;
+  accessToken: string;
+  handlers?: AgentStreamHandlers;
+}): Promise<AgentStreamResult> => {
+  const response = await streamingFetch(buildApiUrl("mobile/agent/messages/stream"), {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ messages, ...(conversationId ? { conversation_id: conversationId } : {}) }),
+  });
+
+  const body = response.body;
+  if (!response.ok || !response.headers.get("content-type")?.includes("text/event-stream") || !body) {
+    throw new Error(`Agent stream request failed: ${response.status}`);
+  }
+
+  let done: AgentStreamResult | null = null;
+
+  const handleFrame = (frame: string): AgentStreamResult | null => {
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) dataLines.push(line.slice(5).trim());
+    }
+    if (dataLines.length === 0) return null;
+    const raw: unknown = JSON.parse(dataLines.join("\n"));
+
+    switch (event) {
+      case "token": {
+        const { text } = raw as { text: string };
+        handlers.onToken?.(text);
+        return null;
+      }
+      case "reset": {
+        handlers.onReset?.();
+        return null;
+      }
+      case "done": {
+        const data = raw as DoneEventData;
+        return {
+          reply: data.reply,
+          proposedAction: data.proposed_action,
+          conversationId: data.conversation_id ?? conversationId ?? null,
+        };
+      }
+      case "error": {
+        throw new Error((raw as { message: string }).message);
+      }
+      default:
+        return null;
+    }
+  };
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for (;;) {
+    const { value, done: streamDone } = await reader.read();
+    if (streamDone) break;
+    buffer += decoder.decode(value, { stream: true });
+    let separator = buffer.indexOf("\n\n");
+    while (separator !== -1) {
+      const frame = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
+      separator = buffer.indexOf("\n\n");
+    }
+  }
+  if (buffer.trim().length > 0) {
+    try {
+      done = handleFrame(buffer) ?? done;
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+    }
+  }
+
+  if (!done) throw new Error("Agent stream ended without a done event");
+  return done;
 };

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -161,24 +161,28 @@ export const streamAgentMessage = async ({
   const decoder = new TextDecoder();
   let buffer = "";
 
-  for (;;) {
-    const { value, done: streamDone } = await reader.read();
-    if (streamDone) break;
-    buffer += decoder.decode(value, { stream: true });
-    let separator = buffer.indexOf("\n\n");
-    while (separator !== -1) {
-      const frame = buffer.slice(0, separator);
-      buffer = buffer.slice(separator + 2);
-      if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
-      separator = buffer.indexOf("\n\n");
+  try {
+    for (;;) {
+      const { value, done: streamDone } = await reader.read();
+      if (streamDone) break;
+      buffer += decoder.decode(value, { stream: true });
+      let separator = buffer.indexOf("\n\n");
+      while (separator !== -1) {
+        const frame = buffer.slice(0, separator);
+        buffer = buffer.slice(separator + 2);
+        if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
+        separator = buffer.indexOf("\n\n");
+      }
     }
-  }
-  if (buffer.trim().length > 0) {
-    try {
-      done = handleFrame(buffer) ?? done;
-    } catch (error) {
-      if (!(error instanceof SyntaxError)) throw error;
+    if (buffer.trim().length > 0) {
+      try {
+        done = handleFrame(buffer) ?? done;
+      } catch (error) {
+        if (!(error instanceof SyntaxError)) throw error;
+      }
     }
+  } finally {
+    reader.cancel().catch(() => {});
   }
 
   if (!done) throw new Error("Agent stream ended without a done event");

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -35,7 +35,7 @@ export class RequestError extends Error {
   }
 }
 
-const REQUEST_TIMEOUT_MS = 30_000;
+export const REQUEST_TIMEOUT_MS = 30_000;
 const RETRY_BASE_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;
 

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -7,11 +7,13 @@ jest.mock("@/lib/auth-context", () => ({
   useAuth: () => ({ accessToken: "test-token" }),
 }));
 
-const mockSendAgentMessage = jest.fn();
+jest.mock("expo/fetch", () => ({ fetch: jest.fn() }));
+
+const mockStreamAgentMessage = jest.fn();
 const mockExecuteAgentAction = jest.fn();
 jest.mock("@/lib/agent", () => ({
   ...jest.requireActual("@/lib/agent"),
-  sendAgentMessage: (...args: unknown[]) => mockSendAgentMessage(...args),
+  streamAgentMessage: (...args: unknown[]) => mockStreamAgentMessage(...args),
   executeAgentAction: (...args: unknown[]) => mockExecuteAgentAction(...args),
 }));
 
@@ -34,7 +36,11 @@ describe("AgentChat", () => {
   });
 
   it("sends a typed message and shows the assistant reply", async () => {
-    mockSendAgentMessage.mockResolvedValue({ reply: "You have 3 products.", proposedAction: null });
+    mockStreamAgentMessage.mockResolvedValue({
+      reply: "You have 3 products.",
+      proposedAction: null,
+      conversationId: "conv-123",
+    });
 
     renderChat();
 
@@ -44,8 +50,10 @@ describe("AgentChat", () => {
     });
 
     await waitFor(() => expect(screen.getByText("You have 3 products.")).toBeTruthy());
-    expect(mockSendAgentMessage).toHaveBeenCalledWith({
+    expect(mockStreamAgentMessage).toHaveBeenCalledWith({
       accessToken: "test-token",
+      conversationId: null,
+      handlers: { onToken: expect.any(Function), onReset: expect.any(Function) },
       messages: [
         { role: "assistant", content: GREETING },
         { role: "user", content: "How many products do I have?" },
@@ -54,7 +62,7 @@ describe("AgentChat", () => {
   });
 
   it("hides suggestions once a message is sent", async () => {
-    mockSendAgentMessage.mockResolvedValue({ reply: "Done.", proposedAction: null });
+    mockStreamAgentMessage.mockResolvedValue({ reply: "Done.", proposedAction: null, conversationId: "conv-123" });
 
     renderChat();
 
@@ -66,8 +74,9 @@ describe("AgentChat", () => {
   });
 
   it("applies a proposed action when confirmed", async () => {
-    mockSendAgentMessage.mockResolvedValue({
+    mockStreamAgentMessage.mockResolvedValue({
       reply: "I've prepared a discount.",
+      conversationId: "conv-123",
       proposedAction: {
         type: "create_discount",
         params: { code: "LAUNCH", percent_off: 20 },
@@ -92,6 +101,7 @@ describe("AgentChat", () => {
     await waitFor(() => expect(screen.getByText("Applied")).toBeTruthy());
     expect(mockExecuteAgentAction).toHaveBeenCalledWith({
       accessToken: "test-token",
+      conversationId: "conv-123",
       action: {
         type: "create_discount",
         params: { code: "LAUNCH", percent_off: 20 },
@@ -101,8 +111,9 @@ describe("AgentChat", () => {
   });
 
   it("dismisses a proposed action without applying it", async () => {
-    mockSendAgentMessage.mockResolvedValue({
+    mockStreamAgentMessage.mockResolvedValue({
       reply: "I've prepared a discount.",
+      conversationId: "conv-123",
       proposedAction: {
         type: "create_discount",
         params: { code: "LAUNCH", percent_off: 20 },
@@ -128,8 +139,9 @@ describe("AgentChat", () => {
   });
 
   it("renders the action title and structured fields when provided", async () => {
-    mockSendAgentMessage.mockResolvedValue({
+    mockStreamAgentMessage.mockResolvedValue({
       reply: "I've prepared a discount.",
+      conversationId: "conv-123",
       proposedAction: {
         type: "create_discount",
         params: { code: "LAUNCH", percent_off: 20 },
@@ -158,7 +170,7 @@ describe("AgentChat", () => {
   });
 
   it("shows a fallback assistant message when the request fails", async () => {
-    mockSendAgentMessage.mockRejectedValue(new Error("network down"));
+    mockStreamAgentMessage.mockRejectedValue(new Error("network down"));
 
     renderChat();
 
@@ -171,8 +183,9 @@ describe("AgentChat", () => {
   });
 
   it("shows an error message when applying a confirmed action fails", async () => {
-    mockSendAgentMessage.mockResolvedValue({
+    mockStreamAgentMessage.mockResolvedValue({
       reply: "I've prepared a discount.",
+      conversationId: "conv-123",
       proposedAction: {
         type: "create_discount",
         params: { code: "LAUNCH", percent_off: 20 },

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -1,0 +1,133 @@
+/* eslint-disable import/first -- jest.mock must precede imports */
+jest.mock("@/lib/env", () => ({
+  env: { EXPO_PUBLIC_GUMROAD_API_URL: "https://api.example.com/", EXPO_PUBLIC_MOBILE_TOKEN: "mobile-token" },
+}));
+
+const mockFetch = jest.fn();
+jest.mock("expo/fetch", () => ({ fetch: (...args: unknown[]) => mockFetch(...args) }));
+
+import { streamAgentMessage } from "@/lib/agent";
+
+const encoder = new TextEncoder();
+
+const streamResponse = (frames: string[], { ok = true, contentType = "text/event-stream" } = {}) => {
+  let index = 0;
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null) },
+    body: {
+      getReader: () => ({
+        read: () =>
+          index < frames.length
+            ? Promise.resolve({ value: encoder.encode(frames[index++]), done: false })
+            : Promise.resolve({ value: undefined, done: true }),
+      }),
+    },
+  };
+};
+
+describe("streamAgentMessage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("delivers tokens as they arrive and resolves with the done payload", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse([
+        'event: token\ndata: {"text":"You have "}\n\n',
+        'event: token\ndata: {"text":"3 products."}\n\n',
+        'event: done\ndata: {"reply":"You have 3 products.","proposed_action":null,"conversation_id":"conv-1"}\n\n',
+      ]),
+    );
+    const onToken = jest.fn();
+
+    const result = await streamAgentMessage({
+      messages: [{ role: "user", content: "How many products?" }],
+      accessToken: "token",
+      handlers: { onToken },
+    });
+
+    expect(onToken.mock.calls.map(([text]) => text)).toEqual(["You have ", "3 products."]);
+    expect(result).toEqual({ reply: "You have 3 products.", proposedAction: null, conversationId: "conv-1" });
+  });
+
+  it("reassembles frames split across chunks", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse([
+        'event: token\ndata: {"te',
+        'xt":"Hello"}\n\nevent: done\ndata: {"reply":"Hello","proposed_a',
+        'ction":null,"conversation_id":"conv-2"}\n\n',
+      ]),
+    );
+    const onToken = jest.fn();
+
+    const result = await streamAgentMessage({
+      messages: [{ role: "user", content: "Hi" }],
+      accessToken: "token",
+      handlers: { onToken },
+    });
+
+    expect(onToken).toHaveBeenCalledWith("Hello");
+    expect(result.conversationId).toBe("conv-2");
+  });
+
+  it("signals a reset so the UI can drop intermediate preamble text", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse([
+        'event: token\ndata: {"text":"Let me check..."}\n\n',
+        "event: reset\ndata: {}\n\n",
+        'event: token\ndata: {"text":"Sales are up."}\n\n',
+        'event: done\ndata: {"reply":"Sales are up.","proposed_action":null}\n\n',
+      ]),
+    );
+    const onReset = jest.fn();
+
+    const result = await streamAgentMessage({
+      messages: [{ role: "user", content: "Sales?" }],
+      accessToken: "token",
+      handlers: { onReset },
+    });
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(result.reply).toBe("Sales are up.");
+  });
+
+  it("keeps the conversation id being resumed when done omits one", async () => {
+    mockFetch.mockResolvedValue(streamResponse(['event: done\ndata: {"reply":"Ok.","proposed_action":null}\n\n']));
+
+    const result = await streamAgentMessage({
+      messages: [{ role: "user", content: "Hi" }],
+      conversationId: "conv-existing",
+      accessToken: "token",
+    });
+
+    expect(result.conversationId).toBe("conv-existing");
+  });
+
+  it("throws the server's message on an error event", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: error\ndata: {"message":"That conversation could not be found."}\n\n']),
+    );
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow("That conversation could not be found.");
+  });
+
+  it("throws when the response is not an event stream", async () => {
+    mockFetch.mockResolvedValue(streamResponse([], { ok: false, contentType: "application/json" }));
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow("Agent stream request failed");
+  });
+
+  it("throws when the stream ends without a done event", async () => {
+    mockFetch.mockResolvedValue(streamResponse(['event: token\ndata: {"text":"Half a re']));
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow("Agent stream ended without a done event");
+  });
+});

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -7,15 +7,23 @@ const mockFetch = jest.fn();
 jest.mock("expo/fetch", () => ({ fetch: (...args: unknown[]) => mockFetch(...args) }));
 
 import { streamAgentMessage } from "@/lib/agent";
+import { UnauthorizedError } from "@/lib/request";
 
 const encoder = new TextEncoder();
 
-const streamResponse = (frames: string[], { ok = true, contentType = "text/event-stream" } = {}) => {
+const streamResponse = (
+  frames: string[],
+  {
+    ok = true,
+    status,
+    contentType = "text/event-stream",
+  }: { ok?: boolean; status?: number; contentType?: string } = {},
+) => {
   let index = 0;
-  const cancel = jest.fn(() => Promise.resolve());
+  const cancel = jest.fn().mockResolvedValue(undefined);
   return {
     ok,
-    status: ok ? 200 : 500,
+    status: status ?? (ok ? 200 : 500),
     headers: { get: (name: string) => (name.toLowerCase() === "content-type" ? contentType : null) },
     body: {
       getReader: () => ({
@@ -116,6 +124,14 @@ describe("streamAgentMessage", () => {
       streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
     ).rejects.toThrow("That conversation could not be found.");
     expect(response.cancel).toHaveBeenCalled();
+  });
+
+  it("throws UnauthorizedError on a 401 so the caller can refresh the token and retry", async () => {
+    mockFetch.mockResolvedValue(streamResponse([], { ok: false, status: 401, contentType: "application/json" }));
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow(UnauthorizedError);
   });
 
   it("throws when the response is not an event stream", async () => {

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -12,6 +12,7 @@ const encoder = new TextEncoder();
 
 const streamResponse = (frames: string[], { ok = true, contentType = "text/event-stream" } = {}) => {
   let index = 0;
+  const cancel = jest.fn(() => Promise.resolve());
   return {
     ok,
     status: ok ? 200 : 500,
@@ -22,8 +23,10 @@ const streamResponse = (frames: string[], { ok = true, contentType = "text/event
           index < frames.length
             ? Promise.resolve({ value: encoder.encode(frames[index++]), done: false })
             : Promise.resolve({ value: undefined, done: true }),
+        cancel,
       }),
     },
+    cancel,
   };
 };
 
@@ -106,13 +109,13 @@ describe("streamAgentMessage", () => {
   });
 
   it("throws the server's message on an error event", async () => {
-    mockFetch.mockResolvedValue(
-      streamResponse(['event: error\ndata: {"message":"That conversation could not be found."}\n\n']),
-    );
+    const response = streamResponse(['event: error\ndata: {"message":"That conversation could not be found."}\n\n']);
+    mockFetch.mockResolvedValue(response);
 
     await expect(
       streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
     ).rejects.toThrow("That conversation could not be found.");
+    expect(response.cancel).toHaveBeenCalled();
   });
 
   it("throws when the response is not an event stream", async () => {


### PR DESCRIPTION
Issue: antiwork/gumroad#5835

## What

The Agent tab now streams the assistant's reply token-by-token instead of showing a "Working on it..." spinner until the whole turn finishes. `lib/agent.ts` gains `streamAgentMessage`, which calls the new mobile SSE endpoint (`POST /api/mobile/agent/messages/stream`, added in antiwork/gumroad#5836) using `expo/fetch` (React Native's built-in `fetch` doesn't expose a readable response body stream), parses the `token` / `reset` / `done` / `error` events, and surfaces tokens to the chat as they arrive. The chat renders the accumulating text in the list footer while the turn is in flight, then commits the final assembled reply as a normal message on `done`.

Turns now also carry the stored `conversation_id` returned by the server: the chat sends it on every subsequent message and on action confirmation, so a conversation persists server-side as one shared transcript (the same store the web Agent chat writes to — a chat started on mobile resumes on web and vice versa).

## Why

The web Agent chat has streamed since it shipped; on mobile a long agent turn (tool calls plus a long generation) left the seller staring at a spinner for up to a minute with no signal that anything was happening. Streaming shows progress immediately and matches the web experience. The `reset` event handling mirrors the web client: an intermediate tool-use turn can stream preamble text that isn't the final answer, and the server tells the client to discard it so only the real reply survives on screen.

The conversation id plumbing rides along because the streaming endpoint's `done` event is where the server hands the id back — without sending it on the next turn, every mobile message would start a brand-new stored conversation.

## Before/After

Before: sending a message shows the "Working on it..." spinner until the entire turn completes, then the full reply appears at once.

After: the reply text renders progressively as the model generates it; the spinner only shows before the first token arrives.

https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-agent-streaming.mp4

Video walkthrough of the full flow (greeting → send → spinner → token-by-token streaming → committed reply → proposed-action card → confirm → applied). Captured from the real Agent tab components rendered via Expo web with a scripted token stream standing in for the backend (the SSE client itself is exercised by `tests/lib/agent.test.ts`); the streaming footer, spinner, and action-card states shown are the exact code paths this PR ships.

| Greeting | Spinner (pre-first-token) | Streaming mid-reply | Reply committed |
|---|---|---|---|
| ![greeting](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-1-greeting.png) | ![spinner](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-2-spinner.png) | ![streaming](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-3-streaming.png) | ![reply](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-4-reply.png) |

| Proposed action | Applying | Applied |
|---|---|---|
| ![action card](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-6-action-card.png) | ![applying](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-7-applying.png) | ![applied](https://raw.githubusercontent.com/gumclaw/gumroad/assets-pr290-mobile/pr290-8-applied.png) |

## Test Results

```
PASS tests/lib/agent.test.ts
PASS tests/components/agent/agent-chat.test.tsx

Test Suites: 2 passed, 2 total
Tests:       15 passed, 15 total
```

`npx tsc --noEmit` and `npx eslint` clean on the touched files.

Note: this depends on antiwork/gumroad#5836 being deployed — until then `streamAgentMessage` fails on the missing route and the chat shows the standard error message. If we want a safety net for older backends, a buffered fallback on stream failure is a small follow-up.

---

AI Disclosure: Written by Claude (claude-fable-5) running as the Gumclaw agent, prompted by Sahil's "Do mobile in a followup" on antiwork/gumroad#5832. The agent wrote the streaming client, chat changes, and tests, and ran the test suite, typecheck, and lint locally.


