### PR TITLE
Fix net::ERR_UNKNOWN_URL_SCHEME errors in payouts/profile/export WebViews

### DIFF
--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -16,7 +16,12 @@ import { Alert, View } from "react-native";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
-const isWebUrl = (url: string) => /^https?:\/\//.test(url);
+const webViewInternalSchemes = ["about:", "data:", "blob:", "javascript:"];
+
+const isWebViewInternalUrl = (url: string) => {
+  const lower = url.toLowerCase();
+  return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
+};
 
 const isGumroadUrl = (url: string) => {
   try {
@@ -66,7 +71,7 @@ export default function SalesExportScreen() {
   const handleShouldStartLoadWithRequest = useCallback(
     (request: { url: string; mainDocumentURL?: string }) => {
       if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
-      if (request.url === url || !isWebUrl(request.url) || isGumroadUrl(request.url)) return true;
+      if (request.url === url || isWebViewInternalUrl(request.url) || isGumroadUrl(request.url)) return true;
       safeOpenURL(request.url);
       return false;
     },

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -11,13 +11,22 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent, WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
+import type {
+  WebViewErrorEvent,
+  WebViewHttpErrorEvent,
+  WebViewOpenWindowEvent,
+} from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
 const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
 
-const isWebUrl = (url: string) => /^https?:\/\//.test(url);
+const webViewInternalSchemes = ["about:", "data:", "blob:", "javascript:"];
+
+const isWebViewInternalUrl = (url: string) => {
+  const lower = url.toLowerCase();
+  return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
+};
 
 const isPaymentProviderUrl = (url: string) => {
   try {
@@ -68,7 +77,7 @@ export default function PayoutSettingsScreen() {
   const handleShouldStartLoadWithRequest = useCallback(
     (request: { url: string; mainDocumentURL?: string }) => {
       if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
-      if (request.url === url || !isWebUrl(request.url) || isAllowedInWebView(request.url)) return true;
+      if (request.url === url || isWebViewInternalUrl(request.url) || isAllowedInWebView(request.url)) return true;
       safeOpenURL(request.url);
       return false;
     },

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -11,13 +11,22 @@ import { Stack } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, View } from "react-native";
 import { WebView as BaseWebView, WebViewMessageEvent } from "react-native-webview";
-import type { WebViewErrorEvent, WebViewHttpErrorEvent, WebViewOpenWindowEvent } from "react-native-webview/lib/WebViewTypes";
+import type {
+  WebViewErrorEvent,
+  WebViewHttpErrorEvent,
+  WebViewOpenWindowEvent,
+} from "react-native-webview/lib/WebViewTypes";
 
 const gumroadOrigin = new URL(env.EXPO_PUBLIC_GUMROAD_URL).origin;
 
 const allowedHostSuffixes = [".stripe.com", ".paypal.com", ".cloudflare.com"];
 
-const isWebUrl = (url: string) => /^https?:\/\//.test(url);
+const webViewInternalSchemes = ["about:", "data:", "blob:", "javascript:"];
+
+const isWebViewInternalUrl = (url: string) => {
+  const lower = url.toLowerCase();
+  return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
+};
 
 const isPaymentProviderUrl = (url: string) => {
   try {
@@ -68,7 +77,7 @@ export default function ProfileSettingsScreen() {
   const handleShouldStartLoadWithRequest = useCallback(
     (request: { url: string; mainDocumentURL?: string }) => {
       if (request.mainDocumentURL && request.url !== request.mainDocumentURL) return true;
-      if (request.url === url || !isWebUrl(request.url) || isAllowedInWebView(request.url)) return true;
+      if (request.url === url || isWebViewInternalUrl(request.url) || isAllowedInWebView(request.url)) return true;
       safeOpenURL(request.url);
       return false;
     },

--- a/tests/app/payments.test.tsx
+++ b/tests/app/payments.test.tsx
@@ -71,9 +71,26 @@ describe("PayoutSettingsScreen", () => {
 
     expect(shouldStart({ url: "https://connect-js.stripe.com/v1.0/connect.js" })).toBe(true);
     expect(shouldStart({ url: "https://example.com/settings/payments" })).toBe(true);
+    expect(shouldStart({ url: "about:blank" })).toBe(true);
 
     expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+
+  it("hands non-web scheme navigations to the OS instead of loading them in the WebView", () => {
+    render(<PayoutSettingsScreen />);
+
+    const shouldStart = screen.getByTestId("payments-webview").props.onShouldStartLoadWithRequest as (request: {
+      url: string;
+      mainDocumentURL?: string;
+    }) => boolean;
+
+    expect(shouldStart({ url: "intent://pay/#Intent;scheme=upi;end" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("intent://pay/#Intent;scheme=upi;end");
+
+    mockSafeOpenURL.mockClear();
+    expect(shouldStart({ url: "mailto:support@example.com" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("mailto:support@example.com");
   });
 
   it("opens target=_blank help links externally but keeps provider popups in the WebView", () => {

--- a/tests/app/profile.test.tsx
+++ b/tests/app/profile.test.tsx
@@ -70,9 +70,22 @@ describe("ProfileSettingsScreen", () => {
     }) => boolean;
 
     expect(shouldStart({ url: "https://example.com/settings/profile" })).toBe(true);
+    expect(shouldStart({ url: "about:blank" })).toBe(true);
 
     expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+
+  it("hands non-web scheme navigations to the OS instead of loading them in the WebView", () => {
+    render(<ProfileSettingsScreen />);
+
+    const shouldStart = screen.getByTestId("profile-webview").props.onShouldStartLoadWithRequest as (request: {
+      url: string;
+      mainDocumentURL?: string;
+    }) => boolean;
+
+    expect(shouldStart({ url: "mailto:support@example.com" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("mailto:support@example.com");
   });
 
   it("opens target=_blank help links externally but keeps provider popups in the WebView", () => {

--- a/tests/app/sales-export.test.tsx
+++ b/tests/app/sales-export.test.tsx
@@ -89,7 +89,7 @@ describe("SalesExportScreen", () => {
     }) => boolean;
 
     expect(shouldStart({ url: "https://example.com/settings" })).toBe(true);
-    expect(shouldStart({ url: "mailto:support@example.com" })).toBe(true);
+    expect(shouldStart({ url: "about:blank" })).toBe(true);
     expect(
       shouldStart({
         url: "https://cdn.example.test/embed",
@@ -100,6 +100,10 @@ describe("SalesExportScreen", () => {
 
     expect(shouldStart({ url: "https://external.example/test" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+
+    mockSafeOpenURL.mockClear();
+    expect(shouldStart({ url: "mailto:support@example.com" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("mailto:support@example.com");
   });
 
   it("downloads the sales export and opens the native share sheet", async () => {
@@ -181,10 +185,7 @@ describe("SalesExportScreen", () => {
     fireEvent.press(screen.getByText("Download CSV"));
 
     await waitFor(() => {
-      expect(NativeAlert.alert).toHaveBeenCalledWith(
-        "Download failed",
-        "Sharing is not available on this device",
-      );
+      expect(NativeAlert.alert).toHaveBeenCalledWith("Download failed", "Sharing is not available on this device");
     });
     expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error));
   });


### PR DESCRIPTION
Sentry issue: [GUMROAD-MOBILE-Z8](https://gumroad-to.sentry.io/issues/7609481032/)

## Problem

The payouts, profile, and sales-export screens each gate WebView navigation with `!isWebUrl(request.url) → return true`, i.e. any non-http(s) URL is allowed to load *inside* the WebView. On Android the WebView cannot handle app-link schemes (`intent://`, `upi://`, bank/wallet deep links that payment provider pages emit), so it fails with `net::ERR_UNKNOWN_URL_SCHEME`. On the payouts screen that error hits `onError`, flips the screen into the full-screen "Something went wrong" overlay, and reports to Sentry — the seller is kicked out of their payout setup flow by a link that should have opened another app.

## Solution

Replace the allow-all non-web check with a small allowlist of schemes the WebView must handle internally (`about:`, `data:`, `blob:`, `javascript:`). Every other non-web scheme is routed to the OS via `safeOpenURL` (which already resolves the handler app and shows a graceful alert when none exists) and blocked from loading in the WebView, so the error overlay never triggers.

Applied to all three screens that share the copy-pasted pattern: `app/settings/payments.tsx`, `app/settings/profile.tsx`, `app/sales-export.tsx`. The `purchase/[token].tsx` WebView uses a different handler and is unaffected.

---

# Before/After

Not a visual change — behavior fix for external-scheme navigation. Before: tapping a provider link using an app scheme showed the full-screen "Something went wrong" error overlay. After: the link opens in the corresponding app (or shows the existing "Couldn't open link" alert) and the WebView stays on the payout settings page.

Video pending — reproducing requires a physical device mid-Stripe/PayPal onboarding emitting an `intent://`/`upi://` navigation, which can't be captured from this environment. Flagging for a maintainer with a device; the jest tests below cover the routing decision directly.

---

# Test Results

```
npx jest tests/app/payments.test.tsx tests/app/profile.test.tsx tests/app/sales-export.test.tsx
Test Suites: 3 passed, 3 total
Tests:       15 passed, 15 total
```

Full suite: 39 suites / 299 tests passed. `tsc --noEmit` clean.

New tests assert that `intent://` and `mailto:` navigations return `false` from `onShouldStartLoadWithRequest` and are handed to `safeOpenURL`, while `about:blank` stays in the WebView. Verified red-first: the new tests fail against the previous implementation.

---

# AI Disclosure

This PR was authored by an AI agent (Claude via Hermes/Gumclaw) end-to-end: root-cause analysis from the Sentry event, code changes, and tests. All tests were run locally and verified.
