### PR TITLE
Hand non-web schemes in purchase content WebView to the OS

### DIFF
--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -45,6 +45,13 @@ type TocDataMessage = {
   };
 };
 
+const webViewInternalSchemes = ["about:", "data:", "blob:", "javascript:"];
+
+const isWebViewInternalUrl = (url: string) => {
+  const lower = url.toLowerCase();
+  return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
+};
+
 const downloadUrl = (token: string, productFileId: string) =>
   buildApiUrl(`/mobile/url_redirects/download/${token}/${productFileId}`);
 
@@ -88,7 +95,7 @@ export default function DownloadScreen() {
         request.url.startsWith(env.EXPO_PUBLIC_GUMROAD_URL) ||
         request.url.startsWith("https://challenges.cloudflare.com/") ||
         request.url.startsWith("https://connect-js.stripe.com/") ||
-        !/^https?:\/\//.test(request.url)
+        isWebViewInternalUrl(request.url)
       )
         return true;
       safeOpenURL(request.url);

--- a/tests/app/purchase-token.test.tsx
+++ b/tests/app/purchase-token.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from "@testing-library/react-native";
+
+const mockUseAuth = jest.fn();
+const mockSafeOpenURL = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock("@/lib/open-url", () => ({
+  safeOpenURL: (url: string) => mockSafeOpenURL(url),
+}));
+
+jest.mock("expo-router", () => ({
+  Stack: {
+    Screen: () => null,
+  },
+  useLocalSearchParams: () => ({ token: "test-token", urlRedirectExternalId: "redirect-id" }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("expo-file-system", () => ({
+  File: { downloadFileAsync: jest.fn() },
+  Paths: { cache: "/cache" },
+}));
+
+jest.mock("expo-sharing", () => ({
+  isAvailableAsync: jest.fn(),
+  shareAsync: jest.fn(),
+}));
+
+jest.mock("@/components/library/use-purchases", () => ({
+  usePurchase: () => undefined,
+}));
+
+jest.mock("@/components/library/use-recent-products", () => ({
+  useAddRecentPurchase: () => jest.fn(),
+}));
+
+jest.mock("@/components/use-audio-player-sync", () => ({
+  useAudioPlayerSync: () => ({ pauseAudio: jest.fn(), playAudio: jest.fn() }),
+}));
+
+jest.mock("@/components/mini-audio-player", () => ({
+  MiniAudioPlayer: () => null,
+}));
+
+jest.mock("@/components/content-page-nav", () => ({
+  ContentPageNav: () => null,
+}));
+
+jest.mock("@/components/styled", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    StyledWebView: React.forwardRef(function MockWebView(props: Record<string, unknown>, ref: unknown) {
+      React.useImperativeHandle(ref, () => ({ postMessage: jest.fn() }));
+      return React.createElement(View, { testID: "purchase-webview", ...props });
+    }),
+  };
+});
+
+import DownloadScreen from "@/app/purchase/[token]";
+
+const expectedUrl =
+  "https://example.com/d/test-token?display=mobile_app&access_token=test-access-token&mobile_token=test-mobile-token";
+
+const getShouldStart = () =>
+  screen.getByTestId("purchase-webview").props.onShouldStartLoadWithRequest as (request: {
+    url: string;
+    navigationType: string;
+    mainDocumentURL?: string;
+  }) => boolean;
+
+describe("DownloadScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseAuth.mockReturnValue({ isLoading: false, accessToken: "test-access-token" });
+  });
+
+  it("keeps Gumroad navigation and WebView-internal schemes in the WebView", () => {
+    render(<DownloadScreen />);
+    const shouldStart = getShouldStart();
+
+    expect(shouldStart({ url: expectedUrl, navigationType: "other" })).toBe(true);
+    expect(shouldStart({ url: "https://example.com/library", navigationType: "click" })).toBe(true);
+    expect(shouldStart({ url: "about:blank", navigationType: "other" })).toBe(true);
+    expect(shouldStart({ url: "https://challenges.cloudflare.com/turnstile", navigationType: "other" })).toBe(true);
+    expect(
+      shouldStart({ url: "https://cdn.example.test/embed", navigationType: "other", mainDocumentURL: expectedUrl }),
+    ).toBe(true);
+    expect(mockSafeOpenURL).not.toHaveBeenCalled();
+  });
+
+  it("opens external web links outside the WebView", () => {
+    render(<DownloadScreen />);
+    const shouldStart = getShouldStart();
+
+    expect(shouldStart({ url: "https://external.example/test", navigationType: "click" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("https://external.example/test");
+  });
+
+  it("hands non-web scheme navigations to the OS instead of loading them in the WebView", () => {
+    render(<DownloadScreen />);
+    const shouldStart = getShouldStart();
+
+    expect(shouldStart({ url: "mailto:support@example.com", navigationType: "click" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("mailto:support@example.com");
+
+    mockSafeOpenURL.mockClear();
+    expect(shouldStart({ url: "intent://pay#Intent;scheme=upi;end", navigationType: "click" })).toBe(false);
+    expect(mockSafeOpenURL).toHaveBeenCalledWith("intent://pay#Intent;scheme=upi;end");
+  });
+});


### PR DESCRIPTION
Issue: antiwork/gumroad-mobile#293

## What

Fixes the last WebView still loading non-web URL schemes internally: the purchase content screen (`app/purchase/[token].tsx`). Its navigation gate used the old negated check (`!/^https?:\/\//`), so `mailto:` / `intent://` links inside purchased content loaded in the WebView and failed with `net::ERR_UNKNOWN_URL_SCHEME` instead of opening in the OS handler app.

Same fix shape as #292: allowlist only the schemes the WebView must handle internally (`about:`, `data:`, `blob:`, `javascript:`) and hand everything else to `safeOpenURL`, which resolves the handler app and alerts gracefully when none exists.

## Why

Follow-up from the fable-5 review of #292 (P3 finding). #292 fixed the payouts/profile/sales-export screens but this screen has its own separate handler that kept the buggy guard.

## Test results

- New `tests/app/purchase-token.test.tsx` (3 tests) covering: same-page/Gumroad/`about:blank`/Cloudflare/iframe navigations stay in the WebView; external web links and `mailto:`/`intent://` schemes go to `safeOpenURL` and return `false`.
- Red-first verified: with the source change stashed, the non-web-scheme test fails on the old code; passes with the fix.
- Full suite: 40 suites / 302 tests passing.
- `tsc --noEmit` exit 0, `yarn lint` clean (one pre-existing unrelated warning in `app/login.tsx`).

## Video

No UI/layout change — this is navigation-gating logic identical to what shipped in #292. Device QA note for the next Expo release: tap a `mailto:` link inside purchased content on Android → should open the mail app instead of an in-WebView error. Flagging the demo video as outstanding-for-a-maintainer since I can't record device video headlessly.

---

This PR was written by an AI agent (Hermes/gumclaw) and reviewed before submission.
