### PR TITLE
Always show Dashboard, Analytics, and Agent tabs with getting-started placeholder states

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -207,7 +207,6 @@ const LibraryHeaderRight = () => (
 );
 
 export default function TabsLayout() {
-  const { isCreator } = useAuth();
   const [isSearchActive, setSearchActive] = useState(false);
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const pathname = usePathname();
@@ -250,7 +249,6 @@ export default function TabsLayout() {
               headerLeft: () => <LogoIcon />,
               headerRight: () => <DashboardHeaderRight />,
               tabBarIcon: ({ color, size }) => <SolidIcon name="home-alt-2" size={size} color={color} />,
-              href: isCreator ? undefined : null,
             }}
           />
           <Tabs.Screen
@@ -260,7 +258,6 @@ export default function TabsLayout() {
               headerLeft: () => <LogoIcon />,
               headerRight: () => <LibraryHeaderRight />,
               tabBarIcon: ({ color, size }) => <SolidIcon name="bar-chart-big" size={size} color={color} />,
-              href: isCreator ? undefined : null,
             }}
           />
           <Tabs.Screen
@@ -270,7 +267,6 @@ export default function TabsLayout() {
               headerLeft: () => <LogoIcon />,
               headerRight: () => <LibraryHeaderRight />,
               tabBarIcon: ({ color, size }) => <SolidIcon name="message-bubble-dots" size={size} color={color} />,
-              href: isCreator ? undefined : null,
             }}
           />
           <Tabs.Screen

--- a/app/(tabs)/analytics.tsx
+++ b/app/(tabs)/analytics.tsx
@@ -2,9 +2,11 @@ import { SalesTab } from "@/components/analytics/sales-tab";
 import { TrafficTab } from "@/components/analytics/traffic-tab";
 import { AnalyticsTimeRange } from "@/components/analytics/use-analytics-by-date";
 import { ExportAllSalesButton } from "@/components/export-all-sales-button";
+import { GettingStartedPlaceholder } from "@/components/getting-started-placeholder";
 import { Button } from "@/components/ui/button";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
+import { useAuth } from "@/lib/auth-context";
 import { useState } from "react";
 import { View } from "react-native";
 
@@ -27,8 +29,17 @@ const TabButton = <ValueType extends string>({
 );
 
 export default function Analytics() {
+  const { isCreator } = useAuth();
   const [activeTab, setActiveTab] = useState<TabType>("sales");
   const [timeRange, setTimeRange] = useState<AnalyticsTimeRange>("1w");
+
+  if (!isCreator) {
+    return (
+      <Screen>
+        <GettingStartedPlaceholder message="You don't have any sales yet. Once you do, you'll see them here, along with powerful data that can help you see what's working, and what could be working better." />
+      </Screen>
+    );
+  }
 
   return (
     <Screen>

--- a/app/(tabs)/dashboard.tsx
+++ b/app/(tabs)/dashboard.tsx
@@ -3,6 +3,7 @@ import { SaleDetailModal } from "@/components/dashboard/sale-detail-modal";
 import { SaleItem } from "@/components/dashboard/sale-item";
 import { SalePurchase, TimeRange, useSalesAnalytics } from "@/components/dashboard/use-sales-analytics";
 import { ExportAllSalesButton } from "@/components/export-all-sales-button";
+import { GettingStartedPlaceholder } from "@/components/getting-started-placeholder";
 import { LineIcon } from "@/components/icon";
 import { useSales } from "@/components/sales/use-sales";
 import { Button } from "@/components/ui/button";
@@ -31,7 +32,7 @@ const TimeRangeButton = ({
 );
 
 export default function Dashboard() {
-  const { isLoading: isAuthLoading } = useAuth();
+  const { isLoading: isAuthLoading, isCreator } = useAuth();
   const {
     data,
     isLoading: isLoadingAnalytics,
@@ -40,15 +41,15 @@ export default function Dashboard() {
     isRefetching,
     timeRange,
     setTimeRange,
-  } = useSalesAnalytics();
+  } = useSalesAnalytics({ enabled: isCreator });
   const accentColor = useCSSVariable("--color-accent") as string;
   const mutedColor = useCSSVariable("--color-muted") as string;
   const [selectedSaleId, setSelectedSaleId] = useState<string | null>(null);
   const { isSearchActive, setSearchActive } = useDashboardSearch();
   const [searchText, setSearchText] = useState("");
   const isAllRange = timeRange === "all";
-  const salesSearch = useSales(searchText, isSearchActive, { requireQuery: true });
-  const allSales = useSales("", isAllRange && !isSearchActive);
+  const salesSearch = useSales(searchText, isCreator && isSearchActive, { requireQuery: true });
+  const allSales = useSales("", isCreator && isAllRange && !isSearchActive);
   const inputRef = useRef<TextInput>(null);
 
   useEffect(() => {
@@ -78,6 +79,14 @@ export default function Dashboard() {
         <View className="flex-1 items-center justify-center">
           <LoadingSpinner size="large" />
         </View>
+      </Screen>
+    );
+  }
+
+  if (!isCreator) {
+    return (
+      <Screen>
+        <GettingStartedPlaceholder message="Create your first product and your sales will show up here." />
       </Screen>
     );
   }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -71,11 +71,9 @@ export default function Index() {
       const savedTab = await getSavedTab();
       if (cancelled) return;
 
-      const effectiveSavedTab: TabName | null = savedTab && !isCreator && savedTab !== "library" ? null : savedTab;
-
       let defaultRoute: TabRoute;
-      if (effectiveSavedTab) {
-        defaultRoute = `/(tabs)/${effectiveSavedTab}`;
+      if (savedTab) {
+        defaultRoute = `/(tabs)/${savedTab}`;
       } else if (notificationResponse) {
         defaultRoute = isCreator ? "/(tabs)/analytics" : "/(tabs)/library";
       } else {

--- a/components/dashboard/use-sales-analytics.ts
+++ b/components/dashboard/use-sales-analytics.ts
@@ -25,13 +25,14 @@ interface AnalyticsResponse {
 export const buildSalesAnalyticsPath = (timeRange: TimeRange, endTime: string) =>
   `mobile/analytics/data_by_date.json?range=${timeRange}&end_time=${encodeURIComponent(endTime)}`;
 
-export const useSalesAnalytics = () => {
+export const useSalesAnalytics = ({ enabled = true } = {}) => {
   const [timeRange, setTimeRange] = useState<TimeRange>("day");
   const endTime = new Date().toISOString();
 
   const query = useAPIRequest<AnalyticsResponse>({
     queryKey: ["analytics", timeRange],
     url: buildSalesAnalyticsPath(timeRange, endTime),
+    enabled,
   });
 
   return {

--- a/components/getting-started-placeholder.tsx
+++ b/components/getting-started-placeholder.tsx
@@ -1,0 +1,19 @@
+import { Button } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { env } from "@/lib/env";
+import { safeOpenURL } from "@/lib/open-url";
+import { View } from "react-native";
+
+export const GettingStartedPlaceholder = ({ message }: { message: string }) => (
+  <View className="flex-1 items-center justify-center gap-4 p-8">
+    <Text className="text-center font-sans text-2xl text-foreground">You&apos;re just getting started.</Text>
+    <Text className="text-center font-sans text-base text-muted">{message}</Text>
+    <Button
+      variant="accent"
+      className="mt-2"
+      onPress={() => safeOpenURL(`${env.EXPO_PUBLIC_GUMROAD_URL}/products/new`)}
+    >
+      <Text>Create your first product</Text>
+    </Button>
+  </View>
+);

--- a/lib/tab-preference.ts
+++ b/lib/tab-preference.ts
@@ -2,9 +2,9 @@ import * as SecureStore from "expo-secure-store";
 
 const LAST_TAB_KEY = "gumroad_last_tab";
 
-export type TabName = "agent" | "analytics" | "library";
+export type TabName = "agent" | "analytics" | "dashboard" | "library";
 
-const VALID_TABS: TabName[] = ["agent", "analytics", "library"];
+const VALID_TABS: TabName[] = ["agent", "analytics", "dashboard", "library"];
 
 export const getSavedTab = async (): Promise<TabName | null> => {
   try {

--- a/tests/app/index.test.tsx
+++ b/tests/app/index.test.tsx
@@ -171,7 +171,7 @@ describe("Index", () => {
     expect(mockPush).toHaveBeenCalledWith("/post/fast1");
   });
 
-  it("does not restore a creator-only saved tab for non-creators", async () => {
+  it("restores the saved tab for non-creators", async () => {
     mockUseAuth.mockReturnValue({ isLoading: false, isAuthenticated: true, isCreator: false, accessToken: "t" });
     mockGetSavedTab.mockResolvedValue("agent");
     render(<Index />);
@@ -180,7 +180,7 @@ describe("Index", () => {
       await flushRaf();
     });
 
-    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/library");
+    expect(mockReplace).toHaveBeenCalledWith("/(tabs)/agent");
   });
 
   it("restores the saved tab on subsequent launches", async () => {


### PR DESCRIPTION
Issue: N/A (support-ticket driven; Sahil: "We can update to always show these tabs. Can have placeholder states à la web.")

## What

Always show the Dashboard, Analytics, and Agent tabs for every authenticated user, with web-style getting-started placeholder states on Dashboard and Analytics for accounts with zero products.

## Why

New users signing in with a fresh account saw an app containing only the Library tab (the other three tabs were hidden via `href: isCreator ? undefined : null`), which read as broken/empty and generated support confusion. The web app instead shows the surfaces with a welcoming placeholder — this brings mobile in line.

## Changes

- **`app/(tabs)/_layout.tsx`** — removed the `href: isCreator ? undefined : null` gating from the dashboard, analytics, and agent `Tabs.Screen` entries; all four tabs now always render. (The `isCreator` gate on the settings-sheet Edit profile / Payout settings buttons is untouched.)
- **`components/getting-started-placeholder.tsx`** (new) — shared empty state: headline **"You're just getting started."**, supporting copy, and an accent CTA **"Create your first product"** that opens `gumroad.com/products/new` via `safeOpenURL`.
- **`app/(tabs)/analytics.tsx`** — zero-product accounts short-circuit to the placeholder with the web Analytics copy: *"You don't have any sales yet. Once you do, you'll see them here, along with powerful data that can help you see what's working, and what could be working better."*
- **`app/(tabs)/dashboard.tsx`** — same short-circuit with *"Create your first product and your sales will show up here."*; the sales/analytics/search queries are disabled (`enabled: isCreator`) so we don't fire requests that would just return nothing for zero-product accounts.
- **`components/dashboard/use-sales-analytics.ts`** — `useSalesAnalytics` accepts an `enabled` option.
- **`app/index.tsx`** — cold-start routing no longer discards a non-creator's saved tab; every user restores their last-used tab. First-launch default for a brand-new user stays Library (their purchases are the only populated surface — the other tabs are one tap away and now visible).
- **`lib/tab-preference.ts`** — `dashboard` added to the valid saved-tab names so it round-trips like the other tabs.
- **`tests/app/index.test.tsx`** — updated the non-creator saved-tab test to the new behavior.

## Test plan

- `yarn typecheck` — clean
- `yarn lint` — 0 errors (1 pre-existing warning in `app/login.tsx`, present on main)
- `npx jest` — 40 suites / 302 tests passing
- Manual: log in with a zero-product account → all four tabs visible; Dashboard and Analytics show the getting-started placeholder; CTA opens the web product-creation page; last-used tab is restored on relaunch.

## Screenshots

Before/after screenshots (iOS Simulator, zero-product account) are attached in [this comment](https://github.com/antiwork/gumroad-mobile/pull/295#issuecomment-4973087595): main shows only the Library tab; this branch shows all four tabs with the "You're just getting started." placeholders on Dashboard and Analytics. A video walkthrough on a real device with a live account is still welcome from a maintainer, but the visual states are covered by the screenshots.

🤖 Generated with Hermes Agent (claude-fable-5)

