### PR TITLE
Patch expo/fetch to guard stream controller against late native events (fixes GUMROAD-MOBILE-ZN TypeError)

### DIFF
--- a/patches/expo+55.0.9.patch
+++ b/patches/expo+55.0.9.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/expo/src/winter/fetch/FetchResponse.ts b/node_modules/expo/src/winter/fetch/FetchResponse.ts
+index 647d803..d02bea9 100644
+--- a/node_modules/expo/src/winter/fetch/FetchResponse.ts
++++ b/node_modules/expo/src/winter/fetch/FetchResponse.ts
+@@ -42,13 +42,19 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
+           });
+ 
+           response.addListener('didComplete', () => {
+-            controller.close();
++            if (isControllerClosed) {
++              return;
++            }
+             isControllerClosed = true;
++            controller.close();
+           });
+ 
+           response.addListener('didFailWithError', (error: string) => {
+-            controller.error(new Error(error));
++            if (isControllerClosed) {
++              return;
++            }
+             isControllerClosed = true;
++            controller.error(new Error(error));
+           });
+         },
+         async pull(controller) {

--- a/tests/lib/expo-fetch-stream-close.test.ts
+++ b/tests/lib/expo-fetch-stream-close.test.ts
@@ -1,0 +1,90 @@
+// Regression test for Sentry issue GUMROAD-MOBILE-ZN:
+// "TypeError: The stream is not in a state that permits close" raised from
+// expo/fetch's FetchResponse when native delivers `didComplete` (or
+// `didFailWithError`) after the JS consumer has already canceled the body
+// stream. Our agent streaming client (lib/agent.ts) always calls
+// `reader.cancel()` when it stops reading, so a late native completion event
+// used to call `controller.close()` on an already-closed stream controller.
+//
+// The fix (patches/expo+55.0.9.patch, backport of expo/expo#44909) makes the
+// listeners check the closed flag before touching the controller.
+
+import { FetchResponse } from "expo/src/winter/fetch/FetchResponse";
+
+jest.mock("expo/src/winter/fetch/ExpoFetchModule", () => {
+  class StubNativeResponse {
+    private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+    get status() {
+      return 200;
+    }
+    get statusText() {
+      return "OK";
+    }
+    get url() {
+      return "https://example.com/stream";
+    }
+    get redirected() {
+      return false;
+    }
+    get _rawHeaders(): [string, string][] {
+      return [["content-type", "text/event-stream"]];
+    }
+    get bodyUsed() {
+      return false;
+    }
+
+    addListener(event: string, listener: (...args: unknown[]) => void) {
+      if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+      this.listeners.get(event)?.add(listener);
+    }
+    removeListener(event: string, listener: (...args: unknown[]) => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+    removeAllListeners(event: string) {
+      this.listeners.delete(event);
+    }
+    emit(event: string, ...args: unknown[]) {
+      for (const listener of this.listeners.get(event) ?? []) listener(...args);
+    }
+
+    startStreaming(): Promise<Uint8Array | null> {
+      return Promise.resolve(null);
+    }
+    cancelStreaming(_reason: string) {}
+  }
+
+  return { ExpoFetchModule: { NativeResponse: StubNativeResponse } };
+});
+
+const makeResponse = () =>
+  new FetchResponse(() => {}) as FetchResponse & { emit: (event: string, ...args: unknown[]) => void };
+
+describe("expo/fetch FetchResponse late native events after cancel", () => {
+  it("does not throw when native emits didComplete after the stream was canceled", async () => {
+    const response = makeResponse();
+    const reader = response.body!.getReader();
+
+    await reader.cancel("consumer canceled");
+    expect(() => response.emit("didComplete")).not.toThrow();
+  });
+
+  it("does not throw when native emits didFailWithError after the stream was canceled", async () => {
+    const response = makeResponse();
+    const reader = response.body!.getReader();
+
+    await reader.cancel("consumer canceled");
+    expect(() => response.emit("didFailWithError", "late error")).not.toThrow();
+  });
+
+  it("does not throw when native emits didComplete twice", async () => {
+    const response = makeResponse();
+    const reader = response.body!.getReader();
+    const readPromise = reader.read();
+
+    response.emit("didComplete");
+    expect(() => response.emit("didComplete")).not.toThrow();
+
+    await readPromise;
+  });
+});


### PR DESCRIPTION
## What

Adds a `patch-package` patch for `expo@55.0.9` that guards `expo/fetch`'s `FetchResponse` body-stream controller against late native events, and a regression test reproducing the crash.

Stock expo registers `didComplete` / `didFailWithError` listeners that call `controller.close()` / `controller.error()` unconditionally. The patch makes each listener check the `isControllerClosed` flag first (and set it before touching the controller), so late or duplicate native events become no-ops. This is a backport of the upstream fix ([expo/expo#44909](https://github.com/expo/expo/pull/44909)), which is only in expo's unpublished changelog and not released for SDK 55.

## Why

Sentry [GUMROAD-MOBILE-ZN](https://gumroad-to.sentry.io/issues/7613344805/) — `TypeError: The stream is not in a state that permits close`, thrown from `close(expo/virtual/streams)` on Android 12, release `2026.07.13+355`.

Root cause: the agent chat client (`lib/agent.ts`) reads the SSE body via `body.getReader()` and always calls `reader.cancel()` in a `finally` block when it stops consuming (idle-timeout abort, done-event received, error). Canceling closes the JS stream controller, but the native layer can still deliver a `didComplete` / `didFailWithError` event afterwards — expo's listener then calls `controller.close()` on the already-closed controller and throws. The error surfaces out of the event listener where we have no way to catch it in app code, so a library-level guard (the same one upstream shipped) is the correct fix rather than a workaround in `lib/agent.ts`.

The patch drops out automatically when we upgrade to an expo release containing #44909 (patch-package warns on version mismatch).

## Problem

Streaming an agent reply and canceling the reader (which our client does on every stream teardown) races with native stream completion, crashing with an uncatchable `TypeError` in `expo/fetch`.

## Solution

Backport expo/expo#44909 via `patches/expo+55.0.9.patch`: check-and-set the `isControllerClosed` flag before calling `controller.close()` / `controller.error()` in the `didComplete` / `didFailWithError` listeners.

---

# Before/After

Not a UI change — dependency patch. Terminal walkthrough (regression test failing on stock expo@55.0.9, passing with the patch, then full unit suite green):

https://raw.githubusercontent.com/gumclaw/gumroad/assets-expo-fetch-stream-close/pr-expo-fetch-stream-close-walkthrough.mp4

---

# Test Results

`tests/lib/expo-fetch-stream-close.test.ts` reproduces the cancel-then-`didComplete` sequence: 2 of 3 cases fail against unpatched expo with exactly the Sentry error, all 3 pass with the patch. Full unit suite: 41 suites / 305 tests passing.

![tests passing](https://raw.githubusercontent.com/gumclaw/gumroad/assets-expo-fetch-stream-close/pr-expo-fetch-tests-passing.png)

---

# AI Disclosure

This PR was authored by Gumclaw (Hermes agent running Claude) in response to a Sentry alert webhook: root-cause analysis from the Sentry stack trace, upstream fix identification, patch generation, and regression test authoring.
