### PR TITLE
Treat invalid_grant across all token flows as session expiry, not Sentry errors

### DIFF
--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,7 +1,13 @@
 import { assertDefined } from "@/lib/assert";
 import { queryClient } from "@/lib/query-client";
 import { env } from "@/lib/env";
-import { KeychainUnavailableError, request, SessionExpiredError, UnauthorizedError } from "@/lib/request";
+import {
+  isInvalidGrantError,
+  KeychainUnavailableError,
+  request,
+  SessionExpiredError,
+  UnauthorizedError,
+} from "@/lib/request";
 import { clearSavedTab } from "@/lib/tab-preference";
 import * as Sentry from "@sentry/react-native";
 import * as AuthSession from "expo-auth-session";
@@ -140,8 +146,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           const creatorStatus = await fetchCreatorStatus(tokenResponse.access_token);
           setIsCreator(creatorStatus);
         } catch (error) {
-          console.error("Failed to exchange code for tokens:", error);
-          Sentry.captureException(error);
+          if (isInvalidGrantError(error)) {
+            console.warn("Authorization code expired or already used:", error);
+          } else {
+            console.error("Failed to exchange code for tokens:", error);
+            Sentry.captureException(error);
+          }
         } finally {
           setIsLoading(false);
         }
@@ -212,7 +222,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
             },
           });
         } catch (requestError) {
-          if (requestError instanceof Error && requestError.message.includes("invalid_grant")) {
+          if (isInvalidGrantError(requestError)) {
             throw new SessionExpiredError("Refresh token is invalid or expired");
           }
           throw requestError;

--- a/lib/auth-context.tsx
+++ b/lib/auth-context.tsx
@@ -1,7 +1,7 @@
 import { assertDefined } from "@/lib/assert";
 import { queryClient } from "@/lib/query-client";
 import { env } from "@/lib/env";
-import { KeychainUnavailableError, request, UnauthorizedError } from "@/lib/request";
+import { KeychainUnavailableError, request, SessionExpiredError, UnauthorizedError } from "@/lib/request";
 import { clearSavedTab } from "@/lib/tab-preference";
 import * as Sentry from "@sentry/react-native";
 import * as AuthSession from "expo-auth-session";
@@ -199,16 +199,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           if (isKeychainUnavailableError(readError)) throw new KeychainUnavailableError();
           throw readError;
         }
-        if (!storedRefreshToken) throw new Error("No refresh token available");
+        if (!storedRefreshToken) throw new SessionExpiredError("No refresh token available");
 
-        const tokenResponse = await request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
-          method: "POST",
-          data: {
-            grant_type: "refresh_token",
-            refresh_token: storedRefreshToken,
-            client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
-          },
-        });
+        let tokenResponse: { access_token: string; refresh_token?: string };
+        try {
+          tokenResponse = await request<{ access_token: string; refresh_token?: string }>(tokenEndpoint, {
+            method: "POST",
+            data: {
+              grant_type: "refresh_token",
+              refresh_token: storedRefreshToken,
+              client_id: env.EXPO_PUBLIC_GUMROAD_CLIENT_ID,
+            },
+          });
+        } catch (requestError) {
+          if (requestError instanceof Error && requestError.message.includes("invalid_grant")) {
+            throw new SessionExpiredError("Refresh token is invalid or expired");
+          }
+          throw requestError;
+        }
         await storeTokens(tokenResponse.access_token, tokenResponse.refresh_token);
         return tokenResponse.access_token;
       } finally {

--- a/lib/authed-request.ts
+++ b/lib/authed-request.ts
@@ -1,6 +1,6 @@
 import { assertDefined } from "@/lib/assert";
 import { useAuth } from "@/lib/auth-context";
-import { KeychainUnavailableError, UnauthorizedError } from "@/lib/request";
+import { KeychainUnavailableError, SessionExpiredError, UnauthorizedError } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 
 export const useAuthedRequest = () => {
@@ -16,7 +16,7 @@ export const useAuthedRequest = () => {
         newToken = await refreshToken();
       } catch (refreshError) {
         if (refreshError instanceof KeychainUnavailableError) throw error;
-        if (refreshError instanceof UnauthorizedError) {
+        if (refreshError instanceof UnauthorizedError || refreshError instanceof SessionExpiredError) {
           console.warn(refreshError);
         } else {
           Sentry.captureException(refreshError, { tags: { auth_path: "refresh_failed" } });

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -10,6 +10,13 @@ export class UnauthorizedError extends Error {
   }
 }
 
+export class SessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SessionExpiredError";
+  }
+}
+
 export class KeychainUnavailableError extends Error {
   constructor() {
     super("Keychain unavailable");
@@ -124,7 +131,7 @@ export const useAPIRequest = <TResponse, TData = TResponse>(
           newAccessToken = await refreshToken();
         } catch (refreshError) {
           if (refreshError instanceof KeychainUnavailableError) throw error;
-          if (refreshError instanceof UnauthorizedError) {
+          if (refreshError instanceof UnauthorizedError || refreshError instanceof SessionExpiredError) {
             console.warn(refreshError);
           } else {
             Sentry.captureException(refreshError, { tags: { auth_path: "refresh_failed" } });

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -42,6 +42,11 @@ export class RequestError extends Error {
   }
 }
 
+// A 400 with "invalid_grant" from the OAuth token endpoint means the grant (refresh token or
+// authorization code) is expired or revoked — an expected end-of-session state, not a bug.
+export const isInvalidGrantError = (error: unknown): boolean =>
+  error instanceof RequestError && error.statusCode === 400 && error.message.includes('"invalid_grant"');
+
 export const REQUEST_TIMEOUT_MS = 30_000;
 const RETRY_BASE_DELAY_MS = 1_000;
 const MAX_RETRY_DELAY_MS = 30_000;

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -28,6 +28,12 @@ jest.mock("@/lib/request", () => ({
       this.name = "UnauthorizedError";
     }
   },
+  SessionExpiredError: class SessionExpiredError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "SessionExpiredError";
+    }
+  },
   KeychainUnavailableError: class KeychainUnavailableError extends Error {
     constructor() {
       super("Keychain unavailable");
@@ -157,13 +163,25 @@ describe("refreshToken", () => {
     );
   });
 
-  it("throws when there is no stored refresh token", async () => {
+  it("throws SessionExpiredError when there is no stored refresh token", async () => {
     mockGetItemAsync.mockResolvedValue(null);
 
     const { result } = renderWithProvider(null);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    await expect(result.current.refreshToken()).rejects.toThrow("No refresh token available");
+    const { SessionExpiredError } = jest.requireMock("@/lib/request");
+    await expect(result.current.refreshToken()).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("throws SessionExpiredError when the server rejects the refresh token (invalid_grant)", async () => {
+    mockGetItemAsync.mockImplementation(refreshTokenStored);
+    mockRequest.mockRejectedValue(new Error('Request failed: 400 {"error":"invalid_grant"}'));
+
+    const { result } = renderWithProvider(null);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const { SessionExpiredError } = jest.requireMock("@/lib/request");
+    await expect(result.current.refreshToken()).rejects.toBeInstanceOf(SessionExpiredError);
   });
 
   it("does NOT call logout when refresh fails (caller decides)", async () => {

--- a/tests/lib/auth-context.test.tsx
+++ b/tests/lib/auth-context.test.tsx
@@ -20,27 +20,40 @@ jest.mock("expo-web-browser", () => ({
 jest.mock("expo-router", () => ({
   useRouter: () => ({ replace: jest.fn() }),
 }));
-jest.mock("@/lib/request", () => ({
-  request: jest.fn(),
-  UnauthorizedError: class UnauthorizedError extends Error {
-    constructor(message: string) {
+jest.mock("@/lib/request", () => {
+  class RequestError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
       super(message);
-      this.name = "UnauthorizedError";
+      this.name = "RequestError";
+      this.statusCode = statusCode;
     }
-  },
-  SessionExpiredError: class SessionExpiredError extends Error {
-    constructor(message: string) {
-      super(message);
-      this.name = "SessionExpiredError";
-    }
-  },
-  KeychainUnavailableError: class KeychainUnavailableError extends Error {
-    constructor() {
-      super("Keychain unavailable");
-      this.name = "KeychainUnavailableError";
-    }
-  },
-}));
+  }
+  return {
+    request: jest.fn(),
+    RequestError,
+    isInvalidGrantError: (error: unknown) =>
+      error instanceof RequestError && error.statusCode === 400 && error.message.includes('"invalid_grant"'),
+    UnauthorizedError: class UnauthorizedError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "UnauthorizedError";
+      }
+    },
+    SessionExpiredError: class SessionExpiredError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "SessionExpiredError";
+      }
+    },
+    KeychainUnavailableError: class KeychainUnavailableError extends Error {
+      constructor() {
+        super("Keychain unavailable");
+        this.name = "KeychainUnavailableError";
+      }
+    },
+  };
+});
 jest.mock("@/lib/query-client", () => ({
   queryClient: { clear: jest.fn() },
 }));
@@ -102,6 +115,41 @@ describe("AuthProvider handleAuthResponse", () => {
     await waitFor(() => {
       expect(Sentry.captureException).toHaveBeenCalledWith(serverError);
     });
+  });
+
+  it("does not report invalid_grant during the code exchange to Sentry", async () => {
+    const { RequestError } = jest.requireMock("@/lib/request");
+    mockRequest.mockRejectedValue(new RequestError(400, 'Request failed: 400 {"error":"invalid_grant"}'));
+
+    const { result } = renderWithProvider({
+      type: "success",
+      errorCode: null,
+      error: null,
+      params: { code: "auth-code" },
+      authentication: null,
+      url: "",
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockRequest).toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("reports unexpected code-exchange failures to Sentry", async () => {
+    const exchangeError = new Error("Network error");
+    mockRequest.mockRejectedValue(exchangeError);
+
+    const { result } = renderWithProvider({
+      type: "success",
+      errorCode: null,
+      error: null,
+      params: { code: "auth-code" },
+      authentication: null,
+      url: "",
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(Sentry.captureException).toHaveBeenCalledWith(exchangeError);
   });
 });
 
@@ -174,14 +222,27 @@ describe("refreshToken", () => {
   });
 
   it("throws SessionExpiredError when the server rejects the refresh token (invalid_grant)", async () => {
+    const { RequestError, SessionExpiredError } = jest.requireMock("@/lib/request");
     mockGetItemAsync.mockImplementation(refreshTokenStored);
-    mockRequest.mockRejectedValue(new Error('Request failed: 400 {"error":"invalid_grant"}'));
+    mockRequest.mockRejectedValue(new RequestError(400, 'Request failed: 400 {"error":"invalid_grant"}'));
 
     const { result } = renderWithProvider(null);
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const { SessionExpiredError } = jest.requireMock("@/lib/request");
     await expect(result.current.refreshToken()).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it("rethrows other 400 responses from the token endpoint unchanged", async () => {
+    const { RequestError, SessionExpiredError } = jest.requireMock("@/lib/request");
+    mockGetItemAsync.mockImplementation(refreshTokenStored);
+    const otherError = new RequestError(400, 'Request failed: 400 {"error":"invalid_request"}');
+    mockRequest.mockRejectedValue(otherError);
+
+    const { result } = renderWithProvider(null);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(result.current.refreshToken()).rejects.toBe(otherError);
+    await expect(result.current.refreshToken()).rejects.not.toBeInstanceOf(SessionExpiredError);
   });
 
   it("does NOT call logout when refresh fails (caller decides)", async () => {
@@ -256,9 +317,7 @@ describe("refreshToken keychain-unavailable handling", () => {
 
   it("throws KeychainUnavailableError when reading the refresh token hits 'No keychain is available'", async () => {
     mockGetItemAsync.mockImplementation((key: string) =>
-      key === "gumroad_refresh_token"
-        ? Promise.reject(new Error("No keychain is available"))
-        : Promise.resolve(null),
+      key === "gumroad_refresh_token" ? Promise.reject(new Error("No keychain is available")) : Promise.resolve(null),
     );
 
     const { result } = renderWithProvider(null);

--- a/tests/lib/authed-request.test.tsx
+++ b/tests/lib/authed-request.test.tsx
@@ -1,0 +1,72 @@
+/* eslint-disable import/first -- jest.mock must precede imports */
+import * as Sentry from "@sentry/react-native";
+import { renderHook } from "@testing-library/react-native";
+
+const mockRefreshToken = jest.fn();
+const mockLogout = jest.fn();
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    accessToken: "test-token",
+    refreshToken: mockRefreshToken,
+    logout: mockLogout,
+  }),
+}));
+
+jest.mock("@sentry/react-native", () => ({
+  captureException: jest.fn(),
+}));
+
+import { useAuthedRequest } from "@/lib/authed-request";
+import { KeychainUnavailableError, SessionExpiredError, UnauthorizedError } from "@/lib/request";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const renderAuthedRequest = () => renderHook(() => useAuthedRequest()).result.current;
+
+describe("useAuthedRequest", () => {
+  it("logs out without reporting to Sentry when refresh fails with SessionExpiredError", async () => {
+    const authedRequest = renderAuthedRequest();
+    const unauthorized = new UnauthorizedError("Unauthorized");
+    mockRefreshToken.mockRejectedValueOnce(new SessionExpiredError("Refresh token is invalid or expired"));
+
+    await expect(authedRequest(() => Promise.reject(unauthorized))).rejects.toBe(unauthorized);
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("logs out and reports to Sentry when refresh fails unexpectedly", async () => {
+    const authedRequest = renderAuthedRequest();
+    const unauthorized = new UnauthorizedError("Unauthorized");
+    const refreshError = new Error("Unexpected refresh failure");
+    mockRefreshToken.mockRejectedValueOnce(refreshError);
+
+    await expect(authedRequest(() => Promise.reject(unauthorized))).rejects.toBe(unauthorized);
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).toHaveBeenCalledWith(refreshError, {
+      tags: { auth_path: "refresh_failed" },
+    });
+  });
+
+  it("does not log out when the keychain is unavailable", async () => {
+    const authedRequest = renderAuthedRequest();
+    const unauthorized = new UnauthorizedError("Unauthorized");
+    mockRefreshToken.mockRejectedValueOnce(new KeychainUnavailableError());
+
+    await expect(authedRequest(() => Promise.reject(unauthorized))).rejects.toBe(unauthorized);
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it("retries with the new token after a successful refresh", async () => {
+    const authedRequest = renderAuthedRequest();
+    mockRefreshToken.mockResolvedValueOnce("new-token");
+    const run = jest.fn().mockRejectedValueOnce(new UnauthorizedError("Unauthorized")).mockResolvedValueOnce("result");
+
+    await expect(authedRequest(run)).resolves.toBe("result");
+    expect(run).toHaveBeenNthCalledWith(1, "test-token");
+    expect(run).toHaveBeenNthCalledWith(2, "new-token");
+  });
+});

--- a/tests/lib/use-api-request.test.tsx
+++ b/tests/lib/use-api-request.test.tsx
@@ -3,7 +3,13 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import React from "react";
 
-import { KeychainUnavailableError, ServerError, SessionExpiredError, UnauthorizedError, useAPIRequest } from "@/lib/request";
+import {
+  KeychainUnavailableError,
+  ServerError,
+  SessionExpiredError,
+  UnauthorizedError,
+  useAPIRequest,
+} from "@/lib/request";
 
 const mockRefreshToken = jest.fn();
 const mockLogout = jest.fn();

--- a/tests/lib/use-api-request.test.tsx
+++ b/tests/lib/use-api-request.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react-native";
 import React from "react";
 
-import { KeychainUnavailableError, ServerError, UnauthorizedError, useAPIRequest } from "@/lib/request";
+import { KeychainUnavailableError, ServerError, SessionExpiredError, UnauthorizedError, useAPIRequest } from "@/lib/request";
 
 const mockRefreshToken = jest.fn();
 const mockLogout = jest.fn();
@@ -140,6 +140,18 @@ describe("useAPIRequest", () => {
     expect(result.current.error).toBeInstanceOf(UnauthorizedError);
   });
 
+  it("logs out without reporting to Sentry when refresh fails with SessionExpiredError", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+    mockRefreshToken.mockRejectedValueOnce(new SessionExpiredError("No refresh token available"));
+
+    const { result } = renderUseAPIRequest();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(result.current.error).toBeInstanceOf(UnauthorizedError);
+  });
+
   it("logs out when refresh fails with a raw keychain error (write-side after server rotation)", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
     const writeError = new Error("User interaction is not allowed");
@@ -157,7 +169,7 @@ describe("useAPIRequest", () => {
 
   it("logs out and reports to Sentry with auth_path tag when refresh fails with a non-keychain error", async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
-    const refreshError = new Error("invalid_grant");
+    const refreshError = new Error("Unexpected refresh failure");
     mockRefreshToken.mockRejectedValueOnce(refreshError);
 
     const { result } = renderUseAPIRequest();


### PR DESCRIPTION
## What

Sentry issue [GUMROAD-MOBILE-Z5](https://gumroad-to.sentry.io/issues/7609030116/) (`RequestError: Request failed: 400 {"error":"invalid_grant"...}`, 622 events / 532 users, `auth_path: refresh_failed`, still firing today) is the same class of noise PR #279 targeted: a 400 `invalid_grant` from the OAuth token endpoint just means the session is permanently expired — the app already logs the user out, so it should never reach Sentry.

#279 was closed unmerged on 2026-06-27 with no rejection or review feedback (no human comments, only a 5/5 Greptile summary; the author closed it, likely as branch cleanup). This PR revives it (cherry-picked, conflict with the later `clearSavedTab` import resolved) and closes the gaps that let Z5 keep firing:

- **`lib/authed-request.ts`** (`useAuthedRequest`, added after #279 for mutations/agent chat) had its own refresh `catch` that still `captureException`'d `SessionExpiredError` — this is the exact path the live Z5 events take. It now warns + logs out, matching `useAPIRequest`.
- **Initial code exchange** (`handleAuthResponse` in `lib/auth-context.tsx`): an expired/reused authorization code also returns 400 `invalid_grant` and was reported to Sentry. Now warned, not captured; other exchange failures still report.
- **Tightened classification**: #279 matched `invalid_grant` anywhere in any `Error` message. A shared `isInvalidGrantError` helper in `lib/request.ts` now requires a `RequestError` with status 400 and `"invalid_grant"` in the body (addresses the Greptile note on #279 about over-broad matching).

Genuine/unexpected refresh failures still report to Sentry with the `auth_path: refresh_failed` tag.

## Progress

- [x] Investigate why PR #279 was closed (abandoned, not rejected)
- [x] Revive #279's `SessionExpiredError` change on current main
- [x] Cover the `useAuthedRequest` refresh path (the surface Z5 fires from today)
- [x] Cover the authorization-code exchange path
- [x] Tests: red without the fix, green with it
- [x] `tsc` clean, eslint clean, prettier clean

## Tests

- `tests/lib/auth-context.test.tsx`: refresh `invalid_grant` → `SessionExpiredError`; other 400s rethrown unchanged; code-exchange `invalid_grant` → no Sentry capture; unexpected exchange failure → still captured.
- `tests/lib/authed-request.test.tsx` (new): `SessionExpiredError` → logout, no capture; unexpected refresh error → logout + capture with `auth_path` tag; keychain-unavailable → no logout; successful refresh retry.
- `tests/lib/use-api-request.test.tsx`: `SessionExpiredError` → logout, no capture (from #279).

55/55 across the 4 auth/request suites; red-proof: stashing the lib changes fails exactly the 2 new-surface tests.

No UI change — video not applicable (auth/error-classification logic only).

Issue: GUMROAD-MOBILE-Z5 (Helper ticket 0dfd05f27ea3e9a4a5562d636d7f026a) — revives #279

🤖 Generated with Hermes (Claude)
