### PR TITLE
Scope stale-blob Sentry filtering to frameless events (follow-up to #300)

### DIFF
--- a/lib/sentry.ts
+++ b/lib/sentry.ts
@@ -39,9 +39,14 @@ const DOWNLOAD_CONTEXT_MARKERS = ["downloadFileAsync", "ExpoAsset.downloadAsync"
 // response storage while the app is suspended, and something later tries to read that body.
 // Reads that go through lib/request.ts are converted to StaleResponseError and retried; what
 // reaches Sentry is the frameless leftover surfaced via onunhandledrejection from native code
-// (no app frames, nothing to fix, the rejection is already handled by RN). 4,771 events / 0
-// crashes as of 2026-07: https://gumroad-to.sentry.io/issues/7376092087/
+// (no app frames, nothing to fix, the rejection is already handled by RN). Only those frameless
+// leftovers are dropped — a stale-blob read that carries app stack frames points at a call site
+// outside lib/request.ts and must still report. 4,771 events / 0 crashes as of 2026-07:
+// https://gumroad-to.sentry.io/issues/7376092087/
 const STALE_BLOB_MARKER = "Unable to resolve data for blob";
+
+const hasAppFrames = (event: ErrorEvent) =>
+  (event.exception?.values ?? []).some((value) => (value.stacktrace?.frames ?? []).some((frame) => frame.in_app));
 
 const isNonActionableError = (event: ErrorEvent) => {
   const values = event.exception?.values;
@@ -50,7 +55,7 @@ const isNonActionableError = (event: ErrorEvent) => {
   if (primaryType === "AbortError" || primaryType === "UnauthorizedError") return true;
   const text = values.map((value) => `${value.type ?? ""}: ${value.value ?? ""}`).join("\n");
   if (TRANSIENT_MARKERS.some((marker) => text.includes(marker))) return true;
-  if (text.includes(STALE_BLOB_MARKER)) return true;
+  if (text.includes(STALE_BLOB_MARKER) && !hasAppFrames(event)) return true;
   return (
     DOWNLOAD_CONTEXT_MARKERS.some((marker) => text.includes(marker)) &&
     NATIVE_NETWORK_MARKERS.some((marker) => text.includes(marker))

--- a/tests/lib/sentry.test.ts
+++ b/tests/lib/sentry.test.ts
@@ -24,13 +24,35 @@ describe("sentry beforeSend", () => {
 
   describe("drops non-actionable transient errors (gumroad-to issue 7336845703)", () => {
     const dropped: [string, ErrorEvent][] = [
-      ["iOS network lost", errorEvent([{ type: "Error", value: "Unable to download a file: The network connection was lost." }])],
       [
-        "stale blob after app suspension (gumroad-to issue 7376092087)",
+        "iOS network lost",
+        errorEvent([{ type: "Error", value: "Unable to download a file: The network connection was lost." }]),
+      ],
+      [
+        "stale blob after app suspension, frameless (gumroad-to issue 7376092087)",
         errorEvent([{ type: "Error", value: "Unable to resolve data for blob: 8e39a7c2-1f4b-4b6e-9a70-000000000000" }]),
       ],
+      [
+        "stale blob with only native (non-app) frames",
+        {
+          exception: {
+            values: [
+              {
+                type: "Error",
+                value: "Unable to resolve data for blob: 8e39a7c2-1f4b-4b6e-9a70-000000000000",
+                stacktrace: { frames: [{ function: "readAsText", in_app: false }] },
+              },
+            ],
+          },
+        } as ErrorEvent,
+      ],
       ["iOS timeout", errorEvent([{ type: "Error", value: "Unable to download a file: The request timed out." }])],
-      ["iOS offline", errorEvent([{ type: "Error", value: "Unable to download a file: The Internet connection appears to be offline." }])],
+      [
+        "iOS offline",
+        errorEvent([
+          { type: "Error", value: "Unable to download a file: The Internet connection appears to be offline." },
+        ]),
+      ],
       [
         "Android socket timeout in chained cause",
         errorEvent([
@@ -69,7 +91,10 @@ describe("sentry beforeSend", () => {
           },
         ]),
       ],
-      ["notifications not allowed", errorEvent([{ type: "Error", value: "Notifications are not allowed for this application" }])],
+      [
+        "notifications not allowed",
+        errorEvent([{ type: "Error", value: "Notifications are not allowed for this application" }]),
+      ],
       ["generic network failure", errorEvent([{ type: "TypeError", value: "Network request failed" }])],
       ["aborted request", errorEvent([{ type: "AbortError", value: "Aborted" }])],
       ["user interaction not allowed", errorEvent([{ type: "Error", value: "User interaction is not allowed" }])],
@@ -83,7 +108,10 @@ describe("sentry beforeSend", () => {
 
   describe("keeps actionable errors", () => {
     const kept: [string, ErrorEvent][] = [
-      ["download 404 (real missing file)", errorEvent([{ type: "Error", value: "Unable to download a file: response has status 404" }])],
+      [
+        "download 404 (real missing file)",
+        errorEvent([{ type: "Error", value: "Unable to download a file: response has status 404" }]),
+      ],
       [
         "illegal path character (real bug, not transient)",
         errorEvent([
@@ -91,7 +119,10 @@ describe("sentry beforeSend", () => {
           { type: "Error", value: "java.lang.IllegalArgumentException: Illegal character in path at index 92" },
         ]),
       ],
-      ["generic application error", errorEvent([{ type: "TypeError", value: "Cannot read property 'id' of undefined" }])],
+      [
+        "generic application error",
+        errorEvent([{ type: "TypeError", value: "Cannot read property 'id' of undefined" }]),
+      ],
       [
         "persistent TLS failure (actionable cert/config bug)",
         errorEvent([{ type: "Error", value: "javax.net.ssl.SSLException: Connection closed by peer" }]),
@@ -124,6 +155,25 @@ describe("sentry beforeSend", () => {
           { type: "TypeError", value: "Cannot read property 'x' of undefined" },
           { type: "AbortError", value: "Aborted" },
         ]),
+      ],
+      [
+        "stale blob read WITH app frames (call site outside lib/request.ts must still report)",
+        {
+          exception: {
+            values: [
+              {
+                type: "Error",
+                value: "Unable to resolve data for blob: 8e39a7c2-1f4b-4b6e-9a70-000000000000",
+                stacktrace: {
+                  frames: [
+                    { function: "readAsText", in_app: false },
+                    { function: "loadReceipt", in_app: true },
+                  ],
+                },
+              },
+            ],
+          },
+        } as ErrorEvent,
       ],
     ];
 


### PR DESCRIPTION
## What

Follow-up to #300, addressing Greptile's P2 review on that PR (the review landed after the merge). Scopes the stale-blob Sentry filter so `beforeSend` only drops events that carry **no app stack frames**.

## Why

As merged, `isNonActionableError` dropped every event whose exception text contained `Unable to resolve data for blob` — including events with `in_app` frames. The intent (per #300's description) was to filter only the frameless `onunhandledrejection` leftovers from React Native internals; a stale-blob read that carries app frames points at a body-read call site outside `lib/request.ts` (one that bypasses the `StaleResponseError` retry layer) and needs to surface with its stack trace so it can be fixed.

The drop condition is now `text.includes(STALE_BLOB_MARKER) && !hasAppFrames(event)`, where `hasAppFrames` checks `exception.values[].stacktrace.frames[].in_app`. Events with only native (non-app) frames are still treated as frameless leftovers and dropped.

## Test Results

- `tests/lib/sentry.test.ts` — 25/25 passing locally:
  - drops: frameless stale-blob event (unchanged behavior)
  - drops: stale-blob event with only native (`in_app: false`) frames
  - keeps: stale-blob event WITH app frames (new regression case)
- `npx tsc --noEmit` clean
- `eslint` + `prettier` clean on both touched files (1 pre-existing `no-require-imports` warning in the test file, present on main)

## Before/After

Not applicable — no user-facing change. This only affects which Sentry events are reported; no UI surface is adjacent. The behavioral delta is observability-only: framed stale-blob errors now reach Sentry instead of being silently dropped.

## QA steps

Covered by the unit tests above (the filter is pure logic over the event shape). Post-release check: Sentry issue 7376092087 stays quiet for frameless events, while any framed stale-blob error appears as a new, actionable issue.

---

## AI disclosure

🤖 Generated with claude-fable-5 (Hermes agent). Trigger: Greptile P2 review comment on merged PR #300 ("Scope stale-blob filtering"). Instructions: fix the finding directly — gate the drop on absence of app frames, add regression tests, open a follow-up PR.
