### PR TITLE
Enable Android fullscreen for videos playing inline in WebViews

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -278,6 +278,7 @@ export default function PostScreen() {
                 style={{ height: bodyHeight, width: width - 32, backgroundColor: "transparent" }}
                 scrollEnabled={false}
                 showsVerticalScrollIndicator={false}
+                allowsFullscreenVideo
                 onMessage={handleHeightMessage}
                 injectedJavaScript={`
                   const sendHeight = () => window.ReactNativeWebView.postMessage(String(document.body.scrollHeight));

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -234,6 +234,8 @@ export default function DownloadScreen() {
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
         mediaPlaybackRequiresUserAction={false}
+        // Android blocks the HTML5 fullscreen API in WebViews unless this is enabled, so videos playing inline (like embedded players in rich content) would have a fullscreen button that does nothing. iOS ignores this prop.
+        allowsFullscreenVideo
         originWhitelist={["*"]}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}
         onMessage={handleMessage}

--- a/tests/app/purchase-token.test.tsx
+++ b/tests/app/purchase-token.test.tsx
@@ -111,4 +111,10 @@ describe("DownloadScreen", () => {
     expect(shouldStart({ url: "intent://pay#Intent;scheme=upi;end", navigationType: "click" })).toBe(false);
     expect(mockSafeOpenURL).toHaveBeenCalledWith("intent://pay#Intent;scheme=upi;end");
   });
+
+  it("allows fullscreen video for content playing inline in the WebView", () => {
+    render(<DownloadScreen />);
+
+    expect(screen.getByTestId("purchase-webview").props.allowsFullscreenVideo).toBe(true);
+  });
 });


### PR DESCRIPTION
Fixes #298

## What

Adds `allowsFullscreenVideo` to the two WebViews that can host inline video playback:

- `app/purchase/[token].tsx` — the purchase content (download page) WebView
- `app/post/[id].tsx` — the post body WebView (rich content can embed videos too)

## Root cause

The native `expo-video` player path is healthy — #244 already ships `fullscreenOptions={{ enable: true, orientation: "landscape", autoExitOnRotate: true }}` and nothing has regressed in `app/video-player.tsx` since. The buyers' reports match the **second playback path**: videos that play **inline inside the purchase WebView** (JW Player embedded in the download page / rich content pages), where the tap starts inline playback in the WebView instead of routing to the native player.

On Android, `react-native-webview` only wires up `WebChromeClient.onShowCustomView` — the callback the HTML5 fullscreen API needs — when `allowsFullscreenVideo` is set (it defaults to `false`). Without it, `requestFullscreen()` from the page silently no-ops: the fullscreen button does nothing, no error, and rotation has no effect because the activity stays locked to the app's portrait orientation (`app.config.ts` sets `orientation: "portrait"`; react-native-webview's fullscreen handler is what temporarily unlocks orientation while the custom view is showing). That exactly matches both buyer reports: fullscreen button dead in the app, same videos fullscreen fine in Chrome.

iOS ignores this prop (fullscreen works there via `allowsInlineMediaPlayback` semantics), so this is an Android-only behavior change.

## Expected behavior change

On Android, tapping the fullscreen button on a video playing inline in the purchase content page (or an embedded video in a post) now enters true fullscreen: the video view covers the screen, system UI hides, and the device may rotate to landscape while fullscreen (react-native-webview sets `SCREEN_ORIENTATION_UNSPECIFIED` during fullscreen and restores portrait on exit). Exiting fullscreen returns to the normal page. The native player path (file-row tap → `app/video-player.tsx`) is unchanged.

## QA steps

On an Android device (Samsung/One UI ideally, to match the reports):

1. Log in as a buyer with a purchase containing stream-only video files.
2. Open the purchase from Library → tap play on the video **inline** in the content page (do not open the native player).
3. Tap the fullscreen button on the player → video should go fullscreen; rotate the device → landscape should work while fullscreen.
4. Exit fullscreen → page returns to normal, portrait lock restored.
5. Open a post with an embedded video and repeat steps 3–4.
6. Regression check: tap a video file row so it opens the native `expo-video` player → fullscreen there still works (per #244).

I can't run an Android emulator in this environment, so the above needs a maintainer device pass before release; root cause was verified by reading `react-native-webview`'s Android source (`RNCWebViewManagerImpl.kt` — `setupWebChromeClient` only installs the `onShowCustomView` fullscreen handler when `mAllowsFullscreenVideo` is true).

## Test Results

- `jest tests/app/purchase-token.test.tsx`: 4 passed (new test `allows fullscreen video for content playing inline in the WebView`; verified red on the old code via `git stash` of the source file, green after).
- Full `yarn jest`: 318 passed, 2 failed — both failures are in `tests/lib/expo-fetch-stream-close.test.ts` and are pre-existing on `main` (unrelated to this change).
- `tsc --noEmit`: clean (exit 0).
- `yarn lint`: 0 errors, 1 pre-existing warning (unused `isCreator`, untouched file).

## AI disclosure

This PR was authored by an AI agent (Hermes/Claude, operated by gumclaw). Root-cause analysis, code change, and tests were produced by the agent; on-device Android verification is pending a maintainer.
