### PR TITLE
Refresh stale download URLs and retry once on 404 instead of reporting to Sentry

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -6,10 +6,11 @@ import { Screen } from "@/components/ui/screen";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Text } from "@/components/ui/text";
 import { useRefToLatest } from "@/components/use-ref-to-latest";
+import { fetchPurchaseDetail } from "@/components/library/use-purchases";
 import { useAuth } from "@/lib/auth-context";
-import { cacheFileDestination } from "@/lib/file-utils";
+import { productFileDownloadUrl } from "@/lib/download-url";
+import { cacheFileDestination, downloadFileWithRetry } from "@/lib/file-utils";
 import { updateMediaLocation } from "@/lib/media-location";
-import { File } from "expo-file-system";
 import * as Sharing from "expo-sharing";
 import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
@@ -58,12 +59,33 @@ export default function PdfViewerScreen() {
     [productFileId, fileName],
   );
 
+  // The uri param embeds a url_redirect token that can be stale by the time this screen
+  // downloads (for example when the app was backgrounded on the purchase screen). When we know
+  // which purchase and file this is, a fresh purchase fetch yields a current token to rebuild
+  // the URL from; otherwise the helper retries the original URL once.
+  const downloadPdfFile = useCallback(
+    () =>
+      downloadFileWithRetry(
+        uri,
+        downloadDestination(),
+        urlRedirectId && productFileId && accessToken
+          ? {
+              refreshUrl: async () => {
+                const detail = await fetchPurchaseDetail(urlRedirectId, accessToken);
+                return productFileDownloadUrl(detail.product.url_redirect_token, productFileId);
+              },
+            }
+          : undefined,
+      ),
+    [uri, downloadDestination, urlRedirectId, productFileId, accessToken],
+  );
+
   const downloadPdf = useCallback(() => {
     let cancelled = false;
     setDownloadError(false);
     setCachedUri(null);
     setIsDownloading(true);
-    File.downloadFileAsync(uri, downloadDestination(), { idempotent: true })
+    downloadPdfFile()
       .then((result) => {
         if (!cancelled) setCachedUri(result.uri);
       })
@@ -80,7 +102,7 @@ export default function PdfViewerScreen() {
     return () => {
       cancelled = true;
     };
-  }, [uri, downloadDestination]);
+  }, [downloadPdfFile]);
 
   useEffect(() => {
     cancelDownloadRef.current = downloadPdf();
@@ -150,8 +172,7 @@ export default function PdfViewerScreen() {
                   try {
                     const isAvailable = await Sharing.isAvailableAsync();
                     if (!isAvailable) return;
-                    const sharedUri =
-                      cachedUri ?? (await File.downloadFileAsync(uri, downloadDestination(), { idempotent: true })).uri;
+                    const sharedUri = cachedUri ?? (await downloadPdfFile()).uri;
                     await Sharing.shareAsync(sharedUri);
                   } finally {
                     setIsSharing(false);

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -1,5 +1,5 @@
 import { LineIcon } from "@/components/icon";
-import { useInstallment, usePurchase } from "@/components/library/use-purchases";
+import { fetchPurchaseDetail, useInstallment, usePurchase } from "@/components/library/use-purchases";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledImage } from "@/components/styled";
 import { Button } from "@/components/ui/button";
@@ -7,9 +7,11 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { Text } from "@/components/ui/text";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
-import { cacheFileDestination, downloadFileWithRetry } from "@/lib/file-utils";
+import { assertDefined } from "@/lib/assert";
+import { useAuth } from "@/lib/auth-context";
+import { productFileDownloadUrl } from "@/lib/download-url";
+import { cacheFileDestination, downloadFileWithRetry, FileUnavailableError } from "@/lib/file-utils";
 import { safeOpenURL } from "@/lib/open-url";
-import { buildApiUrl } from "@/lib/request";
 import * as Sentry from "@sentry/react-native";
 import { File } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
@@ -69,12 +71,6 @@ const fileIconName = (mediaType: FileMediaType) => {
   }
 };
 
-const downloadUrl = (urlRedirectToken: string, productFileId: string) =>
-  buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`);
-
-const downloadFile = (urlRedirectToken: string, productFileId: string, fileName: string) =>
-  downloadFileWithRetry(downloadUrl(urlRedirectToken, productFileId), cacheFileDestination(productFileId, fileName));
-
 const fontDataPromise = Promise.all(
   [
     { module: require("@/assets/fonts/ABCFavorit-Regular-custom.ttf"), weight: 400, style: "normal" },
@@ -100,6 +96,7 @@ export default function PostScreen() {
   const router = useRouter();
   const post = useInstallment(id, { purchaseId, subscriptionId, followerId });
   const purchase = usePurchase(post?.url_redirect_external_id);
+  const { accessToken } = useAuth();
   const webViewRef = useRef<BaseWebView>(null);
   const { playAudio, pauseAudio, activeResourceId, isPlaying } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
@@ -152,12 +149,23 @@ export default function PostScreen() {
         throw new Error("Missing URL redirect token");
       const file = post.files_data?.find((f) => f.id === fileId);
       if (!file) throw new Error("File metadata not found");
-      const downloadedFile = await downloadFile(purchase.url_redirect_token, fileId, file.name);
+      const urlRedirectExternalId = post.url_redirect_external_id;
+      const downloadedFile = await downloadFileWithRetry(
+        productFileDownloadUrl(purchase.url_redirect_token, fileId),
+        cacheFileDestination(fileId, file.name),
+        {
+          // A stale url_redirect token 404s; refetching the purchase yields a current one.
+          refreshUrl: async () => {
+            const detail = await fetchPurchaseDetail(urlRedirectExternalId, assertDefined(accessToken));
+            return productFileDownloadUrl(detail.product.url_redirect_token, fileId);
+          },
+        },
+      );
       const isAvailable = await Sharing.isAvailableAsync();
       if (!isAvailable) throw new Error("Sharing is not available on this device");
       await Sharing.shareAsync(downloadedFile.uri);
     } catch (error) {
-      Sentry.captureException(error);
+      if (!(error instanceof FileUnavailableError)) Sentry.captureException(error);
       Alert.alert("Download Failed", error instanceof Error ? error.message : "Failed to download file");
     } finally {
       setDownloadingFileId(null);
@@ -173,7 +181,7 @@ export default function PostScreen() {
       if (!post?.url_redirect_external_id || !purchase?.url_redirect_token) return;
       const allAudioFiles = post.files_data?.filter(isAudioFile) ?? [];
       const tracks = allAudioFiles.map((f) => ({
-        uri: downloadUrl(purchase.url_redirect_token, f.id),
+        uri: productFileDownloadUrl(purchase.url_redirect_token, f.id),
         resourceId: f.id,
         title: f.name ?? post.name,
         urlRedirectId: post.url_redirect_external_id,
@@ -201,7 +209,7 @@ export default function PostScreen() {
     router.push({
       pathname: "/video-player",
       params: {
-        uri: downloadUrl(purchase.url_redirect_token, fileId),
+        uri: productFileDownloadUrl(purchase.url_redirect_token, fileId),
         streamingUrl: file?.streaming_url,
         title: post.name,
         urlRedirectId: post.url_redirect_external_id,
@@ -218,7 +226,7 @@ export default function PostScreen() {
     router.push({
       pathname: "/pdf-viewer",
       params: {
-        uri: downloadUrl(purchase.url_redirect_token, fileId),
+        uri: productFileDownloadUrl(purchase.url_redirect_token, fileId),
         title: post.name,
         fileName: file?.name,
         urlRedirectId: post.url_redirect_external_id,

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -1,16 +1,17 @@
 import { ContentPageNav, TocPage } from "@/components/content-page-nav";
-import { usePurchase } from "@/components/library/use-purchases";
+import { fetchPurchaseDetail, usePurchase } from "@/components/library/use-purchases";
 import { MiniAudioPlayer } from "@/components/mini-audio-player";
 import { StyledWebView } from "@/components/styled";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Screen } from "@/components/ui/screen";
 import { useAddRecentPurchase } from "@/components/library/use-recent-products";
 import { useAudioPlayerSync } from "@/components/use-audio-player-sync";
+import { assertDefined } from "@/lib/assert";
 import { useAuth } from "@/lib/auth-context";
+import { productFileDownloadUrl } from "@/lib/download-url";
 import { env } from "@/lib/env";
-import { cacheFileDestination, downloadFileWithRetry } from "@/lib/file-utils";
+import { cacheFileDestination, downloadFileWithRetry, FileUnavailableError } from "@/lib/file-utils";
 import { safeOpenURL } from "@/lib/open-url";
-import { buildApiUrl } from "@/lib/request";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Sharing from "expo-sharing";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -51,12 +52,6 @@ const isWebViewInternalUrl = (url: string) => {
   return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
 };
 
-const downloadUrl = (token: string, productFileId: string) =>
-  buildApiUrl(`/mobile/url_redirects/download/${token}/${productFileId}`);
-
-const downloadFile = (token: string, productFileId: string, fileName: string) =>
-  downloadFileWithRetry(downloadUrl(token, productFileId), cacheFileDestination(productFileId, fileName));
-
 const shareFile = async (uri: string) => {
   const isAvailable = await Sharing.isAvailableAsync();
   if (!isAvailable) throw new Error("Sharing is not available on this device");
@@ -77,6 +72,22 @@ export default function DownloadScreen() {
 
   const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
+
+  // Download URLs embed the url_redirect token, which can go stale by the time the user taps a
+  // file (for example after the app sat backgrounded). Refetching the purchase yields a current
+  // token to rebuild the URL from.
+  const refreshDownloadUrl = useCallback(
+    async (productFileId: string) => {
+      const detail = await fetchPurchaseDetail(assertDefined(urlRedirectExternalId), assertDefined(accessToken));
+      return productFileDownloadUrl(detail.product.url_redirect_token, productFileId);
+    },
+    [urlRedirectExternalId, accessToken],
+  );
+
+  const downloadFile = (productFileId: string, fileName: string) =>
+    downloadFileWithRetry(productFileDownloadUrl(token, productFileId), cacheFileDestination(productFileId, fileName), {
+      refreshUrl: () => refreshDownloadUrl(productFileId),
+    });
 
   useEffect(() => {
     if (purchase) addRecentPurchase(purchase);
@@ -140,7 +151,7 @@ export default function DownloadScreen() {
         router.push({
           pathname: "/pdf-viewer",
           params: {
-            uri: downloadUrl(token, message.payload.resourceId),
+            uri: productFileDownloadUrl(token, message.payload.resourceId),
             title: purchase?.name,
             fileName: fileData?.name,
             urlRedirectId: purchase?.url_redirect_external_id,
@@ -157,7 +168,7 @@ export default function DownloadScreen() {
         } else {
           const allAudioFiles = purchase?.file_data?.filter((fileData) => fileData.filegroup === "audio") ?? [];
           const allAudioTracks = allAudioFiles.map((fileData) => ({
-            uri: downloadUrl(token, fileData.id),
+            uri: productFileDownloadUrl(token, fileData.id),
             resourceId: fileData.id,
             title: fileData.name ?? purchase?.name,
             urlRedirectId: purchase?.url_redirect_external_id,
@@ -180,7 +191,7 @@ export default function DownloadScreen() {
         router.push({
           pathname: "/video-player",
           params: {
-            uri: downloadUrl(token, message.payload.resourceId),
+            uri: productFileDownloadUrl(token, message.payload.resourceId),
             streamingUrl: purchase?.file_data?.find((f) => f.id === message.payload.resourceId)?.streaming_url,
             title: purchase?.name,
             urlRedirectId: purchase?.url_redirect_external_id,
@@ -196,11 +207,11 @@ export default function DownloadScreen() {
       const fallbackName = message.payload.extension
         ? `${message.payload.resourceId}.${message.payload.extension.toLowerCase()}`
         : message.payload.resourceId;
-      const downloadedFile = await downloadFile(token, message.payload.resourceId, fileData?.name ?? fallbackName);
+      const downloadedFile = await downloadFile(message.payload.resourceId, fileData?.name ?? fallbackName);
       await shareFile(downloadedFile.uri);
     } catch (error) {
       console.error("Download failed:", error, data);
-      Sentry.captureException(error);
+      if (!(error instanceof FileUnavailableError)) Sentry.captureException(error);
       Alert.alert("Download Failed", error instanceof Error ? error.message : "Failed to download file");
     } finally {
       setIsDownloading(false);

--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -6,6 +6,7 @@ import { Text } from "@/components/ui/text";
 import { useAuth } from "@/lib/auth-context";
 import { env } from "@/lib/env";
 import { safeOpenURL } from "@/lib/open-url";
+import { downloadFileWithRetry, FileUnavailableError } from "@/lib/file-utils";
 import { getExportAllSalesUrl } from "@/lib/sales-export";
 import * as Sentry from "@sentry/react-native";
 import { File, Paths } from "expo-file-system";
@@ -37,7 +38,9 @@ const LARGE_EXPORT_MESSAGE = "Large exports arrive by email.";
 
 const downloadSalesExportFile = async (url: string) => {
   const file = new File(Paths.cache, SALES_CSV_FILE_NAME);
-  await File.downloadFileAsync(url, file, { idempotent: true });
+  // The export URL is derived from the access token, so there is no fresher URL to fetch on a
+  // 404 — the helper retries the same URL once.
+  await downloadFileWithRetry(url, file);
 
   const handle = file.open();
   let firstByte: number | undefined;
@@ -93,7 +96,7 @@ export default function SalesExportScreen() {
       if (error instanceof Error && error.message === LARGE_EXPORT_MESSAGE) {
         Alert.alert("Large export", LARGE_EXPORT_MESSAGE);
       } else {
-        Sentry.captureException(error);
+        if (!(error instanceof FileUnavailableError)) Sentry.captureException(error);
         Alert.alert("Download failed", error instanceof Error ? error.message : "Failed to download file");
       }
     } finally {

--- a/components/library/use-purchases.ts
+++ b/components/library/use-purchases.ts
@@ -88,6 +88,11 @@ interface PurchaseDetailResponse {
 
 const PER_PAGE = 24;
 
+export const fetchPurchaseDetail = (urlRedirectExternalId: string, accessToken: string) =>
+  requestAPI<PurchaseDetailResponse>(`mobile/url_redirects/get_url_redirect_attributes/${urlRedirectExternalId}`, {
+    accessToken,
+  });
+
 export const buildSearchPath = (page: number, filters: ApiFilters) => {
   const params = new URLSearchParams();
   params.set("items", String(PER_PAGE));
@@ -191,11 +196,7 @@ export const usePurchase = (url_redirect_external_id: string | undefined): Purch
 
   const detailQuery = useQuery<PurchaseDetailResponse>({
     queryKey: ["purchase", url_redirect_external_id],
-    queryFn: () =>
-      requestAPI<PurchaseDetailResponse>(
-        `mobile/url_redirects/get_url_redirect_attributes/${url_redirect_external_id}`,
-        { accessToken: assertDefined(accessToken) },
-      ),
+    queryFn: () => fetchPurchaseDetail(assertDefined(url_redirect_external_id), assertDefined(accessToken)),
     enabled: !!accessToken && !!url_redirect_external_id,
     placeholderData: cachedPurchase ? { success: true, product: cachedPurchase, purchase_valid: true } : undefined,
   });

--- a/components/pdf-navigation-sheet.tsx
+++ b/components/pdf-navigation-sheet.tsx
@@ -7,7 +7,8 @@ import { memo, useCallback, useEffect, useState } from "react";
 import { ActivityIndicator, FlatList, TouchableOpacity, View } from "react-native";
 import { TableContent } from "react-native-pdf";
 import { generateThumbnail } from "@/modules/pdf-thumbnail";
-import { File, Paths } from "expo-file-system";
+import { downloadFileWithRetry } from "@/lib/file-utils";
+import { Paths } from "expo-file-system";
 
 const THUMBNAIL_COLUMNS = 3;
 const THUMBNAIL_GAP = 12;
@@ -116,7 +117,9 @@ export const PdfNavigationSheet = ({
     }
 
     setCachedUri(null);
-    File.downloadFileAsync(uri, Paths.cache, { idempotent: true })
+    // The uri prop is usually the viewer's already-downloaded local file; a remote uri here has
+    // no purchase context to derive a fresh URL from, so a stale-token 404 retries the same URL.
+    downloadFileWithRetry(uri, Paths.cache)
       .then((result) => {
         if (!cancelled) setCachedUri(result.uri);
       })

--- a/lib/download-url.ts
+++ b/lib/download-url.ts
@@ -1,0 +1,4 @@
+import { buildApiUrl } from "@/lib/request";
+
+export const productFileDownloadUrl = (urlRedirectToken: string, productFileId: string) =>
+  buildApiUrl(`/mobile/url_redirects/download/${urlRedirectToken}/${productFileId}`);

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-native";
 import { Directory, File, Paths } from "expo-file-system";
 
 const MAX_FILE_NAME_LENGTH = 200;
@@ -17,17 +18,73 @@ export const cacheFileDestination = (uniqueKey: string, fileName: string) => {
   return new File(dir, sanitizeFileName(fileName));
 };
 
-// HTTP status failures (expo-file-system reports them as "response has status: <code>") are
-// deterministic, so retrying only wastes time; everything else is a dropped connection or
-// timeout, which on mobile networks usually succeeds on a second attempt.
-const isRetryableDownloadError = (error: unknown) =>
-  !(error instanceof Error && error.message.includes("response has status"));
+// expo-file-system reports HTTP failures as "response has status: <code>" in the error message.
+const httpStatusFromError = (error: unknown) => {
+  if (!(error instanceof Error)) return null;
+  const match = /response has status:? (\d{3})/.exec(error.message);
+  return match ? Number(match[1]) : null;
+};
 
-export const downloadFileWithRetry = async (url: string, destination: File): Promise<File> => {
+const isNotFoundError = (error: unknown) => httpStatusFromError(error) === 404;
+
+// Thrown when a download still 404s after fetching a fresh URL and retrying: the file is
+// gone or unpublished, which is a content problem, not an app bug — callers show their
+// error state and must not report this to Sentry.
+export class FileUnavailableError extends Error {
+  constructor() {
+    super("This file is unavailable right now. Please try again later.");
+    this.name = "FileUnavailableError";
+  }
+}
+
+type DownloadOptions = {
+  refreshUrl?: () => Promise<string>;
+};
+
+const download = (url: string, destination: File | Directory) =>
+  File.downloadFileAsync(url, destination, { idempotent: true });
+
+// Download URLs go stale (the redirect token can rotate while the app is backgrounded), so a
+// 404 gets one retry against a freshly derived URL from the caller's refreshUrl callback.
+const retryAfterNotFound = async (
+  url: string,
+  destination: File | Directory,
+  refreshUrl?: () => Promise<string>,
+): Promise<File> => {
+  let freshUrl = url;
+  if (refreshUrl) {
+    try {
+      freshUrl = await refreshUrl();
+    } catch {
+      // Refreshing needs its own network call; when it fails, the original URL is still worth one retry.
+    }
+  }
   try {
-    return await File.downloadFileAsync(url, destination, { idempotent: true });
+    return await download(freshUrl, destination);
+  } catch (retryError) {
+    if (!isNotFoundError(retryError)) throw retryError;
+    Sentry.addBreadcrumb({
+      category: "download",
+      level: "warning",
+      message: "Download returned 404 after URL refresh and retry",
+      data: { urlRefreshed: freshUrl !== url },
+    });
+    throw new FileUnavailableError();
+  }
+};
+
+export const downloadFileWithRetry = async (
+  url: string,
+  destination: File | Directory,
+  options?: DownloadOptions,
+): Promise<File> => {
+  try {
+    return await download(url, destination);
   } catch (error) {
-    if (!isRetryableDownloadError(error)) throw error;
-    return await File.downloadFileAsync(url, destination, { idempotent: true });
+    if (isNotFoundError(error)) return await retryAfterNotFound(url, destination, options?.refreshUrl);
+    // Other HTTP status failures are deterministic, so retrying only wastes time; everything else
+    // is a dropped connection or timeout, which on mobile networks usually succeeds on a second attempt.
+    if (httpStatusFromError(error) !== null) throw error;
+    return await download(url, destination);
   }
 };

--- a/tests/app/pdf-viewer.test.tsx
+++ b/tests/app/pdf-viewer.test.tsx
@@ -172,7 +172,9 @@ describe("PdfViewerScreen", () => {
 
   it("shows error view when PDF download fails", async () => {
     const { File } = require("expo-file-system");
-    File.downloadFileAsync.mockRejectedValueOnce(new Error("Network error"));
+    File.downloadFileAsync
+      .mockRejectedValueOnce(new Error("Network error"))
+      .mockRejectedValueOnce(new Error("Network error"));
 
     renderWithProviders();
 
@@ -186,7 +188,7 @@ describe("PdfViewerScreen", () => {
     const slowFailure = deferred<{ uri: string }>();
     const fastSuccess = deferred<{ uri: string }>();
     File.downloadFileAsync
-      .mockRejectedValueOnce(new Error("Initial network error"))
+      .mockRejectedValueOnce(new Error("response has status: 403"))
       .mockReturnValueOnce(slowFailure.promise)
       .mockReturnValueOnce(fastSuccess.promise);
 

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -1,3 +1,8 @@
+jest.mock("@sentry/react-native", () => ({
+  addBreadcrumb: jest.fn(),
+  captureException: jest.fn(),
+}));
+
 jest.mock("expo-file-system", () => {
   const Paths = { cache: "/cache" };
   class Directory {
@@ -24,7 +29,8 @@ jest.mock("expo-file-system", () => {
 });
 
 import { File } from "expo-file-system";
-import { cacheFileDestination, downloadFileWithRetry } from "@/lib/file-utils";
+import * as Sentry from "@sentry/react-native";
+import { cacheFileDestination, downloadFileWithRetry, FileUnavailableError } from "@/lib/file-utils";
 
 describe("cacheFileDestination", () => {
   it("neutralizes URL-significant characters that break native file URI parsing", () => {
@@ -66,6 +72,7 @@ describe("downloadFileWithRetry", () => {
   let downloadMock: jest.Mock;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     downloadMock = jest.fn();
     (File as unknown as { downloadFileAsync: jest.Mock }).downloadFileAsync = downloadMock;
   });
@@ -84,13 +91,66 @@ describe("downloadFileWithRetry", () => {
     expect(downloadMock).toHaveBeenCalledTimes(2);
   });
 
-  it("does not retry HTTP status failures, which are deterministic", async () => {
-    downloadMock.mockRejectedValue(new Error("response has status: 404"));
+  it("does not retry non-404 HTTP status failures, which are deterministic", async () => {
+    downloadMock.mockRejectedValue(new Error("response has status: 403"));
 
     await expect(downloadFileWithRetry("https://example.com/f", destination)).rejects.toThrow(
-      "response has status: 404",
+      "response has status: 403",
     );
     expect(downloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the URL and retries once on a 404", async () => {
+    downloadMock.mockRejectedValueOnce(new Error("response has status: 404")).mockResolvedValue(destination);
+    const refreshUrl = jest.fn().mockResolvedValue("https://example.com/fresh");
+
+    await expect(downloadFileWithRetry("https://example.com/stale", destination, { refreshUrl })).resolves.toBe(
+      destination,
+    );
+    expect(refreshUrl).toHaveBeenCalledTimes(1);
+    expect(downloadMock).toHaveBeenNthCalledWith(1, "https://example.com/stale", destination, { idempotent: true });
+    expect(downloadMock).toHaveBeenNthCalledWith(2, "https://example.com/fresh", destination, { idempotent: true });
+  });
+
+  it("throws FileUnavailableError with a breadcrumb, not a raw 404, when the refreshed retry also 404s", async () => {
+    downloadMock.mockRejectedValue(new Error("response has status: 404"));
+    const refreshUrl = jest.fn().mockResolvedValue("https://example.com/fresh");
+
+    await expect(downloadFileWithRetry("https://example.com/stale", destination, { refreshUrl })).rejects.toThrow(
+      FileUnavailableError,
+    );
+    expect(downloadMock).toHaveBeenCalledTimes(2);
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(expect.objectContaining({ category: "download" }));
+  });
+
+  it("retries the original URL once on a 404 when no refreshUrl is provided", async () => {
+    downloadMock.mockRejectedValueOnce(new Error("response has status: 404")).mockResolvedValue(destination);
+
+    await expect(downloadFileWithRetry("https://example.com/f", destination)).resolves.toBe(destination);
+    expect(downloadMock).toHaveBeenCalledTimes(2);
+    expect(downloadMock).toHaveBeenNthCalledWith(2, "https://example.com/f", destination, { idempotent: true });
+  });
+
+  it("falls back to retrying the original URL when refreshing the URL fails", async () => {
+    downloadMock.mockRejectedValueOnce(new Error("response has status: 404")).mockResolvedValue(destination);
+    const refreshUrl = jest.fn().mockRejectedValue(new Error("Network request failed"));
+
+    await expect(downloadFileWithRetry("https://example.com/f", destination, { refreshUrl })).resolves.toBe(
+      destination,
+    );
+    expect(downloadMock).toHaveBeenNthCalledWith(2, "https://example.com/f", destination, { idempotent: true });
+  });
+
+  it("surfaces a non-404 failure from the post-404 retry unchanged", async () => {
+    downloadMock
+      .mockRejectedValueOnce(new Error("response has status: 404"))
+      .mockRejectedValueOnce(new Error("Network request failed"));
+    const refreshUrl = jest.fn().mockResolvedValue("https://example.com/fresh");
+
+    await expect(downloadFileWithRetry("https://example.com/f", destination, { refreshUrl })).rejects.toThrow(
+      "Network request failed",
+    );
+    expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
   });
 
   it("surfaces the second failure when the retry also fails", async () => {


### PR DESCRIPTION
## What

Fixes the app's biggest Sentry issue: `FileSystem.downloadFileAsync` rejecting with "response has status: 404" — [Sentry 7336845703](https://gumroad-to.sentry.io/issues/7336845703/), 38,425 events / 12,707 users since 3/15, still firing on 2026.07.13+355. (B1 item from the 2026-07-20 Sentry sweep.)

**Root cause:** download URLs embed a `url_redirect` token that can go stale between the API response and the user's tap (app backgrounded, returned later → 404), and several call sites bypassed the central download helper entirely.

## How

1. **Centralized downloads** — all five `File.downloadFileAsync` call sites now route through `downloadFileWithRetry` (`lib/file-utils.ts`). The shared URL builder moved to `lib/download-url.ts` (was duplicated in purchase + post screens).
2. **404 → refresh URL + retry once.** The helper takes an optional `refreshUrl: () => Promise<string>` callback. On a 404 it derives a fresh URL and retries exactly once:
   - **purchase/[token]** and **post/[id]**: refresh via `fetchPurchaseDetail` (extracted from `usePurchase`'s existing queryFn) → fresh `url_redirect_token` → rebuilt download URL.
   - **pdf-viewer**: same refresh when `urlRedirectId` + `productFileId` params are present; falls back to retry-same-URL when opened without purchase context.
   - **pdf-navigation-sheet**: no purchase context available (usually receives the viewer's already-cached local file) → retry-same-URL once.
   - **sales-export**: the export URL is derived from the access token, there is no fresher URL to fetch → retry-same-URL once.
3. **Stop capturing 404s that survived refresh+retry.** The helper throws a typed `FileUnavailableError` ("This file is unavailable right now…") and logs a Sentry breadcrumb instead; call sites skip `captureException` for that error and show their existing error UI (alert / "Unable to load this PDF" + Try Again). **All non-404 failures keep their existing capture behavior unchanged** (including the pre-existing single retry for connection-drop errors; non-404 HTTP statuses still fail fast with no retry).

## QA steps

- Open a purchase, background the app long enough for the url_redirect token to rotate, return, tap a file download → download succeeds after a transparent refresh+retry (no Sentry event).
- Same flow for a post attachment download and for opening a PDF from purchase content.
- Sales export: Download CSV still works; large-export and zero-byte paths unchanged.
- Simulate a permanently-missing file (double 404) → user sees "Download Failed / This file is unavailable right now" (or the PDF error state), Sentry gets a breadcrumb but no exception.
- Non-404 failure (e.g. airplane mode mid-download) → error alert and Sentry capture as before.

## Test Results

- `npx jest --forceExit`: **42 passed, 1 failed suite — the failing suite is `tests/lib/expo-fetch-stream-close.test.ts` with 2 pre-existing failures on main, unrelated to this change** (353 passed / 2 failed tests).
- New/updated coverage in `tests/lib/file-utils.test.ts` (11 tests): 404 → refresh called → fresh-URL retry succeeds; double 404 → `FileUnavailableError` + breadcrumb, no raw 404; 404 with no/failed `refreshUrl` → same-URL retry; non-404 HTTP status → no retry; transient errors → single retry preserved; non-404 failure after a 404 retry surfaces unchanged.
- `npx tsc --noEmit`: exit 0.
- `yarn lint`: 0 errors (1 pre-existing unused-var warning in `app/login.tsx`).
- `prettier --check` on all touched files: clean.

Video: no UI change (behavioral fix in the download path; error states are the existing ones). Flagging for a maintainer if a demo of the retry flow is wanted — it requires forcing a token rotation server-side.

## AI disclosure

This PR was authored by an AI agent (Hermes/Claude, operated by Gumclaw) as part of the 2026-07-20 Sentry sweep (item B1). All tests and checks were run locally as reported above; a human should review before merge.
