### PR TITLE
Bump version to 2026.07.20

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -4,13 +4,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "Gumroad",
   slug: "gumroad",
-  version: "2026.07.13",
+  version: "2026.07.20",
   orientation: "portrait",
   icon: "./assets/images/icon.png",
   scheme: "gumroadmobile",
   userInterfaceStyle: "automatic",
   ios: {
-    buildNumber: "2",
+    buildNumber: "1",
     supportsTablet: true,
     bundleIdentifier: process.env.IOS_BUNDLE_NAME,
     infoPlist: {


### PR DESCRIPTION
## Summary

Version bump for the July 20 release — carries everything merged since 2026.07.02+1. Full manifest + human QA checklist: antiwork/gumroad-private#1185.

Highlights: download-404 refresh+retry (#309, 38K events/12.7K users), Android video fullscreen (#303), Android podcast playback (#305), 5xx retry + Sentry hygiene (#306), stale-blob recovery (#300/#301), invalid_grant session handling (#299).

## AI disclosure

🤖 Generated with claude-fable-5 (Hermes agent) per release issue gumroad-private#1185.

## QA steps

On-device human QA checklist lives in gumroad-private#1185 (11 items) and gates the store rollout.

## Test Results

Config-only change (version string + iOS build number reset). Main suite state unchanged: all suites green except the 2 pre-existing expo-fetch-stream-close failures.
