### PR TITLE
Fix SIGABRT crash: add NSCameraUsageDescription to iOS Info.plist

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -17,6 +17,10 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       UIBackgroundModes: ["audio", "remote-notification", "fetch"],
       ITSAppUsesNonExemptEncryption: false,
       UIDesignRequiresCompatibility: true,
+      NSCameraUsageDescription:
+        "Gumroad needs access to your camera when you choose to take a photo or video to upload.",
+      NSMicrophoneUsageDescription:
+        "Gumroad needs access to your microphone when you choose to record a video to upload.",
       NSPhotoLibraryAddUsageDescription:
         "Gumroad needs access to save files to your photo library when you choose to download content.",
     },

--- a/tests/app-config.test.ts
+++ b/tests/app-config.test.ts
@@ -1,0 +1,14 @@
+import createConfig from "../app.config";
+
+describe("app.config", () => {
+  const config = createConfig({ config: {} } as never);
+
+  it("declares camera and microphone usage descriptions so WebView media capture cannot crash the app", () => {
+    expect(config.ios?.infoPlist?.NSCameraUsageDescription).toEqual(expect.any(String));
+    expect(config.ios?.infoPlist?.NSMicrophoneUsageDescription).toEqual(expect.any(String));
+  });
+
+  it("keeps the photo library save usage description", () => {
+    expect(config.ios?.infoPlist?.NSPhotoLibraryAddUsageDescription).toEqual(expect.any(String));
+  });
+});


### PR DESCRIPTION
Issue: Sentry [GUMROAD-MOBILE issue 7610075117](https://gumroad-to.sentry.io/issues/7610075117/) — `SIGABRT: NSCameraUsageDescription` (23 events / 14 users since 2026-07-12)

## Problem

Tapping "Take Photo or Video" from a file-upload input inside a WebView (breadcrumbs show the Profile settings screen presenting the system photo picker) kills the app with a fatal `SIGABRT`:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an NSCameraUsageDescription key…

The iOS `infoPlist` in `app.config.ts` only declares `NSPhotoLibraryAddUsageDescription`. WKWebView surfaces the OS camera option on any `<input type="file">`, so any web-embedded screen (profile settings, payments onboarding, purchase content) can reach the camera path — and iOS terminates the process instantly when the key is missing. This is unhandleable in JS; the only fix is declaring the keys.

## Solution

Add `NSCameraUsageDescription` and `NSMicrophoneUsageDescription` to `ios.infoPlist` in `app.config.ts` (the tracked source of truth — `ios/Gumroad/Info.plist` is prebuild output). Microphone is included because the same picker offers video capture, which hits the identical crash on the mic permission.

Added `tests/app-config.test.ts` asserting both keys (plus the existing photo-library key) are present in the generated config, so a future config refactor can't silently drop them. Verified red-first: the new test fails on main without the fix.

---

# Before/After

Not a UI change — config-only. Before: selecting "Take Photo" in any in-app WebView file upload hard-crashes the app. After: iOS shows the standard camera permission prompt with the new usage string. No visible change for users who don't invoke the camera. On-device verification requires a camera-equipped physical device (simulator has no camera); flagged below as pending for a maintainer.

---

# Test Results

```
PASS tests/app-config.test.ts
Tests:       2 passed, 2 total
```

Red-first check (fix stashed): `Tests: 1 failed, 1 passed, 2 total`. `tsc --noEmit` exit 0, prettier + eslint clean.

---

# AI Disclosure

Written by Claude Fable 5 (Hermes agent) responding to the Sentry alert for issue 7610075117. Instructions: triage the crash, root-cause it, add a failing test, fix, and open a PR.
