### PR TITLE
Fix WatchdogTermination: cap PDF thumbnail render size and defer generation until the sheet opens

### DIFF
--- a/components/pdf-navigation-sheet.tsx
+++ b/components/pdf-navigation-sheet.tsx
@@ -92,6 +92,7 @@ export const PdfNavigationSheet = ({
 }) => {
   const hasToc = tableOfContents.length > 0;
   const [activeTab, setActiveTab] = useState<"contents" | "pages">("pages");
+  const [hasOpened, setHasOpened] = useState(open);
   const [cachedUri, setCachedUri] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState(false);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -104,6 +105,10 @@ export const PdfNavigationSheet = ({
   useEffect(() => {
     if (hasToc) setActiveTab("contents");
   }, [hasToc]);
+
+  useEffect(() => {
+    if (open) setHasOpened(true);
+  }, [open]);
 
   const downloadPdf = useCallback(() => {
     let cancelled = false;
@@ -135,10 +140,15 @@ export const PdfNavigationSheet = ({
     };
   }, [isLocalFile, uri]);
 
-  useEffect(downloadPdf, [downloadPdf]);
+  // Generating thumbnails for every page of a large PDF is memory-heavy, so nothing runs
+  // until the seller actually opens this sheet (it is always mounted alongside the viewer).
+  useEffect(() => {
+    if (!hasOpened) return;
+    return downloadPdf();
+  }, [hasOpened, downloadPdf]);
 
   useEffect(() => {
-    if (!cachedUri) return;
+    if (!hasOpened || !cachedUri) return;
     let cancelled = false;
     const results = new Map<number, string>();
     const failed = new Set<number>();
@@ -171,7 +181,7 @@ export const PdfNavigationSheet = ({
     return () => {
       cancelled = true;
     };
-  }, [cachedUri, totalPages]);
+  }, [hasOpened, cachedUri, totalPages]);
 
   const handlePagePress = useCallback(
     (page: number) => {

--- a/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
+++ b/modules/pdf-thumbnail/android/src/main/java/expo/modules/pdfthumbnail/PdfThumbnailModule.kt
@@ -38,8 +38,10 @@ class PdfThumbnailModule : Module() {
 
           val pdfPage = renderer.openPage(page)
           try {
-            val width = pdfPage.width
-            val height = pdfPage.height
+            val maxThumbnailDimension = 480f
+            val scale = minOf(1f, maxThumbnailDimension / maxOf(pdfPage.width, pdfPage.height))
+            val width = (pdfPage.width * scale).toInt().coerceAtLeast(1)
+            val height = (pdfPage.height * scale).toInt().coerceAtLeast(1)
             val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             try {
               bitmap.eraseColor(Color.WHITE)

--- a/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
+++ b/modules/pdf-thumbnail/ios/PdfThumbnailModule.swift
@@ -17,12 +17,20 @@ public class PdfThumbnailModule: Module {
       }
 
       let pageRect = pdfPage.bounds(for: .mediaBox)
-      let renderer = UIGraphicsImageRenderer(size: pageRect.size)
+      // Thumbnails render at roughly a third of the screen width, so drawing each page at
+      // full size and screen scale wastes tens of megabytes per page and can get the app
+      // killed by the OS for memory overuse on large documents.
+      let maxThumbnailDimension: CGFloat = 480
+      let scale = min(1, maxThumbnailDimension / max(pageRect.width, pageRect.height))
+      let renderSize = CGSize(width: pageRect.width * scale, height: pageRect.height * scale)
+      let format = UIGraphicsImageRendererFormat()
+      format.scale = 1
+      let renderer = UIGraphicsImageRenderer(size: renderSize, format: format)
       let image = renderer.image { ctx in
         UIColor.white.setFill()
-        ctx.fill(pageRect)
-        ctx.cgContext.translateBy(x: 0, y: pageRect.height)
-        ctx.cgContext.scaleBy(x: 1, y: -1)
+        ctx.fill(CGRect(origin: .zero, size: renderSize))
+        ctx.cgContext.translateBy(x: 0, y: renderSize.height)
+        ctx.cgContext.scaleBy(x: scale, y: -scale)
         pdfPage.draw(with: .mediaBox, to: ctx.cgContext)
       }
 

--- a/tests/components/pdf-navigation-sheet.test.tsx
+++ b/tests/components/pdf-navigation-sheet.test.tsx
@@ -10,10 +10,10 @@ jest.mock("@/modules/pdf-thumbnail", () => ({
   generateThumbnail: jest.fn().mockResolvedValue({ uri: "file:///thumb.jpg", width: 300, height: 420 }),
 }));
 
-const renderSheet = (uri: string) =>
+const renderSheet = (uri: string, open = true) =>
   render(
     <PdfNavigationSheet
-      open
+      open={open}
       onOpenChange={jest.fn()}
       uri={uri}
       tableOfContents={[]}
@@ -54,5 +54,37 @@ describe("PdfNavigationSheet", () => {
 
     await waitFor(() => expect(generateThumbnail).toHaveBeenCalledWith("file:///cache/test.pdf", 0, 60));
     expect(File.downloadFileAsync).not.toHaveBeenCalled();
+  });
+
+  it("does no download or thumbnail work while the sheet has never been opened", async () => {
+    const { File } = require("expo-file-system");
+    const { generateThumbnail } = require("@/modules/pdf-thumbnail");
+
+    renderSheet("https://example.com/test.pdf", false);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(File.downloadFileAsync).not.toHaveBeenCalled();
+    expect(generateThumbnail).not.toHaveBeenCalled();
+  });
+
+  it("starts downloading and generating thumbnails once the sheet opens", async () => {
+    const { File } = require("expo-file-system");
+    const { generateThumbnail } = require("@/modules/pdf-thumbnail");
+
+    const { rerender } = renderSheet("https://example.com/test.pdf", false);
+    rerender(
+      <PdfNavigationSheet
+        open
+        onOpenChange={jest.fn()}
+        uri="https://example.com/test.pdf"
+        tableOfContents={[]}
+        totalPages={1}
+        currentPage={1}
+        onPageSelect={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(File.downloadFileAsync).toHaveBeenCalled());
+    await waitFor(() => expect(generateThumbnail).toHaveBeenCalledWith("file:///cache/downloaded.pdf", 0, 60));
   });
 });


### PR DESCRIPTION
## What

Reduces peak memory usage in the PDF viewer's page-navigation sheet:

- **Native thumbnail modules (iOS + Android) now render at a capped size.** Pages were rendered at full mediaBox dimensions — on iOS additionally at the device's screen scale — so a single large-format page could allocate tens of megabytes of bitmap. Thumbnails display at roughly a third of the screen width, so both modules now scale rendering to at most 480px on the longest side (iOS also pins `UIGraphicsImageRendererFormat.scale = 1`).
- **Thumbnail generation is deferred until the sheet is first opened.** `PdfNavigationSheet` is always mounted alongside the viewer and previously kicked off a download plus a thumbnail render for *every page* of the document on mount, even when the seller never tapped the pages button.

## Why

Sentry issue [GUMROAD-MOBILE-2S](https://gumroad-to.sentry.io/issues/7379668252/) — `WatchdogTermination: The OS watchdog terminated your app, possibly because it overused RAM.` — is the app's highest-impact crash: **1,356 events / 823 users** since April, still recurring daily across every recent release. Event breadcrumbs consistently end in purchase-content flows downloading PDF attachments (`files.gumroad.com/attachments/...` followed by `mobile/media_locations`), pointing at the PDF viewer as the dominant memory hotspot. A 300-page PDF previously triggered 300 full-resolution page renders the moment the viewer opened; after this change nothing renders until the sheet opens, and each render is bounded.

## Test plan

- `npx jest tests/components/pdf-navigation-sheet.test.tsx tests/app/pdf-viewer.test.tsx` — 12 passed. New tests assert no download/thumbnail work happens while the sheet has never been opened and that work starts on first open. Red-first verified: stashing the component change fails the new deferral test.
- `npx tsc --noEmit` exit 0; prettier + eslint clean on changed files.
- Native module changes (Swift/Kotlin) can't be exercised in CI — on-device verification (open a large PDF, open the pages sheet, confirm thumbnails render) is pending for a maintainer.
- Post-merge: watch GUMROAD-MOBILE-2S event rate on the next store release.

## Before/After

No intended visual change — thumbnails render in ~120px cells, well below the new 480px cap. Video pending for a maintainer with a device (native-module change; simulator capture of memory behavior isn't meaningful).

---

## AI disclosure

Authored by Claude Fable 5 (Hermes agent) from an automated Sentry alert webhook. Instructions: triage the WatchdogTermination issue, identify the memory hotspot from event breadcrumbs, write a failing test, fix, and open a PR.
