### PR TITLE
Retry sales export download once when the file arrives empty (Error: Failed to download file)

### DIFF
--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -36,18 +36,30 @@ const SALES_CSV_FILE_NAME = "sales.csv";
 const HTML_TAG_OPEN_BYTE = "<".charCodeAt(0);
 const LARGE_EXPORT_MESSAGE = "Large exports arrive by email.";
 
+const readFirstByte = (file: File) => {
+  const handle = file.open();
+  try {
+    return handle.readBytes(1)[0];
+  } finally {
+    handle.close();
+  }
+};
+
 const downloadSalesExportFile = async (url: string) => {
   const file = new File(Paths.cache, SALES_CSV_FILE_NAME);
   // The export URL is derived from the access token, so there is no fresher URL to fetch on a
   // 404 — the helper retries the same URL once.
   await downloadFileWithRetry(url, file);
+  let firstByte = readFirstByte(file);
 
-  const handle = file.open();
-  let firstByte: number | undefined;
-  try {
-    firstByte = handle.readBytes(1)[0];
-  } finally {
-    handle.close();
+  if (firstByte === undefined) {
+    // A zero-byte file means the transfer was cut off even though the download reported
+    // success; a second attempt usually completes, so retry once before giving up.
+    try {
+      file.delete();
+    } catch {}
+    await downloadFileWithRetry(url, file);
+    firstByte = readFirstByte(file);
   }
 
   const failureMessage =

--- a/tests/app/sales-export.test.tsx
+++ b/tests/app/sales-export.test.tsx
@@ -143,9 +143,27 @@ describe("SalesExportScreen", () => {
     expect(mockShareAsync).not.toHaveBeenCalled();
   });
 
-  it("treats a zero-byte download as a failure and deletes the file", async () => {
-    jest.spyOn(NativeAlert, "alert");
+  it("retries once when the download produces an empty file and shares the successful retry", async () => {
     mockReadBytes.mockReturnValueOnce(new Uint8Array([]));
+
+    render(<SalesExportScreen />);
+
+    fireEvent.press(screen.getByText("Download CSV"));
+
+    await waitFor(() => {
+      expect(mockShareAsync).toHaveBeenCalledWith("file:///cache/sales.csv", {
+        UTI: "public.comma-separated-values-text",
+        mimeType: "text/csv",
+        dialogTitle: "Export all sales",
+      });
+    });
+    expect(mockDownloadFileAsync).toHaveBeenCalledTimes(2);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it("treats a download that stays empty after the retry as a failure and deletes the file", async () => {
+    jest.spyOn(NativeAlert, "alert");
+    mockReadBytes.mockReturnValueOnce(new Uint8Array([])).mockReturnValueOnce(new Uint8Array([]));
 
     render(<SalesExportScreen />);
 
@@ -154,6 +172,7 @@ describe("SalesExportScreen", () => {
     await waitFor(() => {
       expect(NativeAlert.alert).toHaveBeenCalledWith("Download failed", "Failed to download file");
     });
+    expect(mockDownloadFileAsync).toHaveBeenCalledTimes(2);
     expect(mockCaptureException).toHaveBeenCalled();
     expect(mockDelete).toHaveBeenCalled();
     expect(mockShareAsync).not.toHaveBeenCalled();


### PR DESCRIPTION
## What

Retries the all-sales CSV export download once when the downloaded file arrives empty, instead of immediately failing with "Failed to download file".

## Why

Sentry issue [7579928209](https://gumroad-to.sentry.io/issues/7579928209/) — `Error: Failed to download file` in `downloadSalesExportFile` (`app/sales-export.tsx`), 5 events / 3 users since 6/28, still firing on 2026.07.13+355.

`File.downloadFileAsync` can resolve successfully but leave a zero-byte file behind when the transfer is cut off mid-flight on a flaky mobile connection. The screen already routes through `downloadFileWithRetry` (#309), but that helper only retries when the download *rejects* — a "successful" empty download slipped past it, so the user got a dead-end error alert and each occurrence was reported to Sentry.

Now the empty-file case gets one retry (delete the empty file, re-download, re-check the first byte) before failing. If it stays empty after the retry, the existing failure path is unchanged: alert + Sentry capture, so we still see genuinely broken exports.

## Test plan

- `npx jest tests/app/sales-export.test.tsx` — 8 passed:
  - new: "retries once when the download produces an empty file and shares the successful retry" (verified RED against the pre-fix code, GREEN with the fix)
  - new: "treats a download that stays empty after the retry as a failure and deletes the file" (asserts exactly 2 download attempts, Sentry capture, temp-file cleanup)
  - all existing large-export / share / failure cases unchanged
- `prettier` + `eslint` clean on changed files (remaining warnings are pre-existing mock boilerplate)

## Before/After

Not a rendered-UI change — behavior only. Before: transient empty download → immediate "Download failed" alert. After: silent retry; alert only if the retry also produces an empty file.

---

**AI disclosure:** Authored by Claude Fable 5 (Hermes agent) from an automated Sentry webhook trigger. Instructions: triage Sentry issue 7579928209, identify root cause from the stacktrace, write a failing test, fix, verify locally, open a PR.
