### PR TITLE
Prevent concurrent share requests from crashing (ExpoSharing.shareAsync rejected)

### DIFF
--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -13,6 +13,7 @@ import { cacheFileDestination, downloadFileWithRetry } from "@/lib/file-utils";
 import { updateMediaLocation } from "@/lib/media-location";
 import * as Sharing from "expo-sharing";
 import * as Sentry from "@sentry/react-native";
+import { shareFile } from "@/lib/share";
 import { useQueryClient } from "@tanstack/react-query";
 import { Stack, useLocalSearchParams } from "expo-router";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -173,7 +174,7 @@ export default function PdfViewerScreen() {
                     const isAvailable = await Sharing.isAvailableAsync();
                     if (!isAvailable) return;
                     const sharedUri = cachedUri ?? (await downloadPdfFile()).uri;
-                    await Sharing.shareAsync(sharedUri);
+                    await shareFile(sharedUri);
                   } finally {
                     setIsSharing(false);
                   }

--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -15,7 +15,7 @@ import { safeOpenURL } from "@/lib/open-url";
 import * as Sentry from "@sentry/react-native";
 import { File } from "expo-file-system";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import * as Sharing from "expo-sharing";
+import { shareFile } from "@/lib/share";
 import { Asset } from "expo-asset";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert, Pressable, ScrollView, useWindowDimensions, View } from "react-native";
@@ -161,9 +161,7 @@ export default function PostScreen() {
           },
         },
       );
-      const isAvailable = await Sharing.isAvailableAsync();
-      if (!isAvailable) throw new Error("Sharing is not available on this device");
-      await Sharing.shareAsync(downloadedFile.uri);
+      await shareFile(downloadedFile.uri);
     } catch (error) {
       if (!(error instanceof FileUnavailableError)) Sentry.captureException(error);
       Alert.alert("Download Failed", error instanceof Error ? error.message : "Failed to download file");

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -12,8 +12,8 @@ import { productFileDownloadUrl } from "@/lib/download-url";
 import { env } from "@/lib/env";
 import { cacheFileDestination, downloadFileWithRetry, FileUnavailableError } from "@/lib/file-utils";
 import { safeOpenURL } from "@/lib/open-url";
+import { shareFile } from "@/lib/share";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import * as Sharing from "expo-sharing";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as Sentry from "@sentry/react-native";
 import { Alert, View } from "react-native";
@@ -50,12 +50,6 @@ const webViewInternalSchemes = ["about:", "data:", "blob:", "javascript:"];
 const isWebViewInternalUrl = (url: string) => {
   const lower = url.toLowerCase();
   return webViewInternalSchemes.some((scheme) => lower.startsWith(scheme));
-};
-
-const shareFile = async (uri: string) => {
-  const isAvailable = await Sharing.isAvailableAsync();
-  if (!isAvailable) throw new Error("Sharing is not available on this device");
-  await Sharing.shareAsync(uri);
 };
 
 export default function DownloadScreen() {

--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -11,7 +11,7 @@ import { getExportAllSalesUrl } from "@/lib/sales-export";
 import * as Sentry from "@sentry/react-native";
 import { File, Paths } from "expo-file-system";
 import { Stack } from "expo-router";
-import * as Sharing from "expo-sharing";
+import { shareFile } from "@/lib/share";
 import { useCallback, useMemo, useState } from "react";
 import { Alert, View } from "react-native";
 
@@ -96,10 +96,8 @@ export default function SalesExportScreen() {
   const downloadSalesExport = useCallback(async () => {
     setIsDownloading(true);
     try {
-      const isAvailable = await Sharing.isAvailableAsync();
-      if (!isAvailable) throw new Error("Sharing is not available on this device");
       const downloaded = await downloadSalesExportFile(url);
-      await Sharing.shareAsync(downloaded.uri, {
+      await shareFile(downloaded.uri, {
         UTI: "public.comma-separated-values-text",
         mimeType: "text/csv",
         dialogTitle: "Export all sales",

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,20 @@
+import * as Sharing from "expo-sharing";
+
+const CONCURRENT_SHARE_MESSAGE = "Another share request is being processed";
+
+let shareInFlight = false;
+
+export const shareFile = async (uri: string, options?: Sharing.SharingOptions) => {
+  if (shareInFlight) return;
+  shareInFlight = true;
+  try {
+    const isAvailable = await Sharing.isAvailableAsync();
+    if (!isAvailable) throw new Error("Sharing is not available on this device");
+    await (options ? Sharing.shareAsync(uri, options) : Sharing.shareAsync(uri));
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(CONCURRENT_SHARE_MESSAGE)) return;
+    throw error;
+  } finally {
+    shareInFlight = false;
+  }
+};

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -1,0 +1,95 @@
+const mockIsAvailableAsync = jest.fn();
+const mockShareAsync = jest.fn();
+
+jest.mock("expo-sharing", () => ({
+  isAvailableAsync: (...args: unknown[]) => mockIsAvailableAsync(...args),
+  shareAsync: (...args: unknown[]) => mockShareAsync(...args),
+}));
+
+import { shareFile } from "@/lib/share";
+
+type Deferred = { promise: Promise<void>; resolve: () => void; reject: (error: Error) => void };
+
+const createDeferred = (): Deferred => {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("shareFile", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAvailableAsync.mockResolvedValue(true);
+    mockShareAsync.mockResolvedValue(undefined);
+  });
+
+  it("shares the file when sharing is available", async () => {
+    await shareFile("file:///cache/test.pdf");
+
+    expect(mockShareAsync).toHaveBeenCalledWith("file:///cache/test.pdf");
+  });
+
+  it("passes options through to shareAsync", async () => {
+    await shareFile("file:///cache/sales.csv", { mimeType: "text/csv" });
+
+    expect(mockShareAsync).toHaveBeenCalledWith("file:///cache/sales.csv", { mimeType: "text/csv" });
+  });
+
+  it("throws when sharing is not available", async () => {
+    mockIsAvailableAsync.mockResolvedValue(false);
+
+    await expect(shareFile("file:///cache/test.pdf")).rejects.toThrow("Sharing is not available on this device");
+    expect(mockShareAsync).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second share request while one is in flight", async () => {
+    const deferred = createDeferred();
+    mockShareAsync.mockReturnValue(deferred.promise);
+
+    const first = shareFile("file:///cache/first.pdf");
+    await Promise.resolve();
+    const second = shareFile("file:///cache/second.pdf");
+
+    await second;
+    expect(mockShareAsync).toHaveBeenCalledTimes(1);
+
+    deferred.resolve();
+    await first;
+  });
+
+  it("allows sharing again after the previous share settles", async () => {
+    await shareFile("file:///cache/first.pdf");
+    await shareFile("file:///cache/second.pdf");
+
+    expect(mockShareAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows sharing again after the previous share fails", async () => {
+    mockShareAsync.mockRejectedValueOnce(new Error("User did not share"));
+
+    await expect(shareFile("file:///cache/first.pdf")).rejects.toThrow("User did not share");
+    await shareFile("file:///cache/second.pdf");
+
+    expect(mockShareAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows the native concurrent-share rejection", async () => {
+    mockShareAsync.mockRejectedValueOnce(
+      new Error(
+        "Call to function 'ExpoSharing.shareAsync' has been rejected.\n→ Caused by: Another share request is being processed now.",
+      ),
+    );
+
+    await expect(shareFile("file:///cache/test.pdf")).resolves.toBeUndefined();
+  });
+
+  it("rethrows other share errors", async () => {
+    mockShareAsync.mockRejectedValueOnce(new Error("Something else broke"));
+
+    await expect(shareFile("file:///cache/test.pdf")).rejects.toThrow("Something else broke");
+  });
+});


### PR DESCRIPTION
## What

Fixes the remaining flavor of [Sentry 7336845703](https://gumroad-to.sentry.io/issues/7336845703/): `Error: Call to function 'ExpoSharing.shareAsync' has been rejected. → Caused by: Another share request is being processed now.` This Sentry group aggregates native-module rejections (38k+ events / 12.6k users since 3/15); #309 fixed the `downloadFileAsync` 404 flavor, and events like today's (Android, build 355) are the concurrent-share flavor, which this PR addresses.

**Root cause:** the native share module only allows one share request at a time. A second `Sharing.shareAsync` call while the share sheet is still open — a rapid double-tap on a share/download button, or a download completing and sharing while another share is up — makes the native layer reject with "Another share request is being processed now". Only the PDF viewer had a per-screen `isSharing` guard; the purchase content, post attachment, and sales export screens had none, and even a guard on one screen doesn't protect against a share initiated from another screen. The rejection was captured to Sentry and surfaced to the user as a "Download Failed" alert even though their share sheet was already open.

## How

- New `lib/share.ts` centralizes sharing for all four call sites (`pdf-viewer`, `purchase/[token]`, `post/[id]`, `sales-export`):
  1. **Module-level in-flight guard** — a share attempt while one is already in progress is a no-op (module scope makes it app-wide, not per-screen).
  2. **Availability check** folded in (previously duplicated at each call site with the identical error message, which the existing catch/alert paths still handle).
  3. **Last-resort safety net** — if the native concurrent-share rejection still slips through (e.g. the promise settled but the native module hasn't released yet), it's swallowed instead of captured/alerted: the OS share sheet is already visible, so there is nothing actionable to show the user. All other share errors still propagate to the existing capture/alert handling.

## QA steps

- Open a purchase file / post attachment / PDF / sales export and share it — share sheet opens as before, CSV export keeps its UTI/mimeType/dialog title options.
- Rapidly double-tap a share or download-and-share button — one share sheet opens, no error alert, no Sentry event.
- Sharing unavailable (unsupported device) — existing "Sharing is not available on this device" alert unchanged.

## Test Results

- `yarn jest tests/lib/share.test.ts tests/app/pdf-viewer.test.tsx tests/app/purchase-token.test.tsx tests/app/sales-export.test.tsx tests/app/post-id.test.tsx`: **4 suites, 28 tests, all passed.**
- New `tests/lib/share.test.ts` (8 tests): second call during in-flight share is a no-op (single `shareAsync` call); guard releases after success AND failure; options pass-through; unavailable → throws; the exact native concurrent-share rejection is swallowed; other rejections rethrow. The in-flight test fails if the guard is reverted.
- `npx tsc --noEmit`: 0 errors in repo code.
- `yarn lint`: 0 errors (1 pre-existing unused-var warning in `app/login.tsx`).
- `prettier --check` on all touched files: clean.

Video: no UI change — the fix removes an erroneous error alert on double-tap; every normal share flow renders exactly the screens it did before. Happy to record a device demo of the double-tap repro if a maintainer wants one.

---

## AI disclosure

Authored by an AI agent (Hermes, Claude Fable 5, operated by Gumclaw), triggered by the Sentry webhook for the event above. Instructions given: triage the Sentry event, identify the root cause, write a failing-first test, fix, and open a PR with local test evidence. All tests and checks were run locally as reported above.
