### PR TITLE
Add Today range with hourly buckets and projected end-of-day total to analytics

### DIFF
--- a/app/(tabs)/analytics.tsx
+++ b/app/(tabs)/analytics.tsx
@@ -55,6 +55,7 @@ export default function Analytics() {
 
       <View className="gap-3 p-4">
         <View className="flex-row justify-center gap-2">
+          <TabButton<AnalyticsTimeRange> label="1D" value="1d" selected={timeRange === "1d"} onSelect={setTimeRange} />
           <TabButton<AnalyticsTimeRange> label="1W" value="1w" selected={timeRange === "1w"} onSelect={setTimeRange} />
           <TabButton<AnalyticsTimeRange> label="1M" value="1m" selected={timeRange === "1m"} onSelect={setTimeRange} />
           <TabButton<AnalyticsTimeRange> label="1Y" value="1y" selected={timeRange === "1y"} onSelect={setTimeRange} />

--- a/components/analytics/analytics-bar-chart.tsx
+++ b/components/analytics/analytics-bar-chart.tsx
@@ -114,3 +114,42 @@ export const SelectionOverlay = ({
     />
   );
 };
+
+// Faint accent bar rendered behind today's actual revenue bar, rising from the
+// baseline to the projected end-of-day total — mirrors the web sales chart's
+// projection treatment. Rendered before the BarChart so the real bar paints on top.
+export const ProjectionOverlay = ({
+  projectedValue,
+  maxValue,
+  barWidth,
+  spacing,
+  index,
+  color,
+}: {
+  projectedValue: number;
+  maxValue: number;
+  barWidth: number;
+  spacing: number;
+  index: number;
+  color: string;
+}) => {
+  if (maxValue <= 0 || projectedValue <= 0) return null;
+  const height = Math.min(CHART_HEIGHT, (projectedValue / maxValue) * CHART_HEIGHT);
+  return (
+    <View
+      testID="projection-overlay"
+      pointerEvents="none"
+      style={{
+        position: "absolute",
+        top: 4 + CHART_HEIGHT - height,
+        height,
+        left: index * (barWidth + spacing),
+        width: barWidth,
+        backgroundColor: color,
+        opacity: 0.2,
+        borderTopLeftRadius: 4,
+        borderTopRightRadius: 4,
+      }}
+    />
+  );
+};

--- a/components/analytics/projected-end-of-day-total.ts
+++ b/components/analytics/projected-end-of-day-total.ts
@@ -1,0 +1,58 @@
+export const MINIMUM_ELAPSED_DAY_FRACTION = 1 / 24;
+
+// Reads the instant's wall-clock date/time in the given zone re-encoded as UTC, so
+// comparing it against the real epoch time yields the zone's UTC offset at that instant.
+const wallClockAsUTC = (timeZone: string, date: Date): number => {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((part) => part.type === type)?.value);
+  return Date.UTC(get("year"), get("month") - 1, get("day"), get("hour"), get("minute"), get("second"));
+};
+
+// Epoch ms of local midnight in the zone for the day containing `date`, shifted by
+// `dayOffset` days; the correction loop handles daylight-saving offset changes.
+const localMidnightInstant = (timeZone: string, date: Date, dayOffset: number): number => {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const get = (type: Intl.DateTimeFormatPartTypes) => Number(parts.find((part) => part.type === type)?.value);
+  const targetWallClock = Date.UTC(get("year"), get("month") - 1, get("day") + dayOffset, 0, 0, 0);
+  let instant = targetWallClock - (wallClockAsUTC(timeZone, date) - date.getTime());
+  for (let i = 0; i < 2; i += 1) {
+    instant -= wallClockAsUTC(timeZone, new Date(instant)) - targetWallClock;
+  }
+  return instant;
+};
+
+// Fraction of the seller's current calendar day that has elapsed (0..1), or null if
+// the time zone can't be resolved. Uses the seller's zone so "today" matches the day
+// boundaries the analytics backend aggregates by.
+export const fractionOfDayElapsed = (timeZone: string, now: Date = new Date()): number | null => {
+  try {
+    const dayStart = localMidnightInstant(timeZone, now, 0);
+    const dayEnd = localMidnightInstant(timeZone, now, 1);
+    if (!Number.isFinite(dayStart) || !Number.isFinite(dayEnd) || dayEnd <= dayStart) return null;
+    return Math.min(Math.max((now.getTime() - dayStart) / (dayEnd - dayStart), 0), 1);
+  } catch {
+    return null;
+  }
+};
+
+// Extrapolates today's sales total (cents) to end of day using the run rate so far;
+// null when a projection wouldn't be meaningful (no sales, day barely started or over).
+export const projectedEndOfDayTotal = (totalSoFarCents: number, elapsedFraction: number | null): number | null => {
+  if (elapsedFraction === null || elapsedFraction < MINIMUM_ELAPSED_DAY_FRACTION || elapsedFraction >= 1) return null;
+  if (totalSoFarCents <= 0) return null;
+  return Math.round(totalSoFarCents / elapsedFraction);
+};

--- a/components/analytics/projected-end-of-day-total.ts
+++ b/components/analytics/projected-end-of-day-total.ts
@@ -1,4 +1,13 @@
-export const MINIMUM_ELAPSED_DAY_FRACTION = 1 / 24;
+export const MINIMUM_ELAPSED_MS = 60 * 60 * 1000;
+
+// Progress through the seller's current calendar day: how far along the day is (0..1)
+// and how much wall-clock time has actually passed since local midnight. Both are
+// needed because on daylight-saving transition days the local day is 23 or 25 hours,
+// so a fraction alone can't express "at least one real hour has elapsed".
+export interface DayProgress {
+  fraction: number;
+  elapsedMs: number;
+}
 
 // Reads the instant's wall-clock date/time in the given zone re-encoded as UTC, so
 // comparing it against the real epoch time yields the zone's UTC offset at that instant.
@@ -35,24 +44,53 @@ const localMidnightInstant = (timeZone: string, date: Date, dayOffset: number): 
   return instant;
 };
 
-// Fraction of the seller's current calendar day that has elapsed (0..1), or null if
-// the time zone can't be resolved. Uses the seller's zone so "today" matches the day
-// boundaries the analytics backend aggregates by.
-export const fractionOfDayElapsed = (timeZone: string, now: Date = new Date()): number | null => {
+// Progress through the seller's current calendar day, or null if the time zone can't
+// be resolved. Uses the seller's zone so "today" matches the day boundaries the
+// analytics backend aggregates by.
+export const dayProgress = (timeZone: string, now: Date = new Date()): DayProgress | null => {
   try {
     const dayStart = localMidnightInstant(timeZone, now, 0);
     const dayEnd = localMidnightInstant(timeZone, now, 1);
     if (!Number.isFinite(dayStart) || !Number.isFinite(dayEnd) || dayEnd <= dayStart) return null;
-    return Math.min(Math.max((now.getTime() - dayStart) / (dayEnd - dayStart), 0), 1);
+    const elapsedMs = Math.min(Math.max(now.getTime() - dayStart, 0), dayEnd - dayStart);
+    return { fraction: elapsedMs / (dayEnd - dayStart), elapsedMs };
+  } catch {
+    return null;
+  }
+};
+
+const ordinalSuffix = (day: number): string => {
+  if (day % 100 >= 11 && day % 100 <= 13) return "th";
+  return { 1: "st", 2: "nd", 3: "rd" }[day % 10] ?? "th";
+};
+
+// The analytics endpoint labels day buckets like "Monday, July 20th" in the seller's
+// time zone. Reproduce that label for the current day so callers can verify a bucket
+// really is today before treating its total as today's revenue.
+export const todaysBucketLabel = (timeZone: string, now: Date = new Date()): string | null => {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    }).formatToParts(now);
+    const get = (type: Intl.DateTimeFormatPartTypes) => parts.find((part) => part.type === type)?.value;
+    const weekday = get("weekday");
+    const month = get("month");
+    const day = Number(get("day"));
+    if (!weekday || !month || !Number.isFinite(day)) return null;
+    return `${weekday}, ${month} ${day}${ordinalSuffix(day)}`;
   } catch {
     return null;
   }
 };
 
 // Extrapolates today's sales total (cents) to end of day using the run rate so far;
-// null when a projection wouldn't be meaningful (no sales, day barely started or over).
-export const projectedEndOfDayTotal = (totalSoFarCents: number, elapsedFraction: number | null): number | null => {
-  if (elapsedFraction === null || elapsedFraction < MINIMUM_ELAPSED_DAY_FRACTION || elapsedFraction >= 1) return null;
+// null when a projection wouldn't be meaningful (no sales, less than an hour of real
+// time elapsed, or the day is over).
+export const projectedEndOfDayTotal = (totalSoFarCents: number, progress: DayProgress | null): number | null => {
+  if (progress === null || progress.elapsedMs < MINIMUM_ELAPSED_MS || progress.fraction >= 1) return null;
   if (totalSoFarCents <= 0) return null;
-  return Math.round(totalSoFarCents / elapsedFraction);
+  return Math.round(totalSoFarCents / progress.fraction);
 };

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -6,16 +6,18 @@ import {
   CHART_HEIGHT,
   formatCurrency,
   formatNumber,
+  ProjectionOverlay,
   SelectionOverlay,
   useChartColors,
   useChartDimensions,
 } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { ChartGestureHandler } from "./chart-gesture-handler";
+import { fractionOfDayElapsed, projectedEndOfDayTotal } from "./projected-end-of-day-total";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
-  const { processedData, isLoading } = useAnalyticsByDate(timeRange);
+  const { processedData, isLoading, sellerTimeZone } = useAnalyticsByDate(timeRange);
   const colors = useChartColors();
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const { dates, totals, sales, views } = processedData;
@@ -30,6 +32,16 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const totalRevenue = totals.reduce((sum, val) => sum + val, 0);
   const totalSales = sales.reduce((sum, val) => sum + val, 0);
   const totalViews = views.reduce((sum, val) => sum + val, 0);
+
+  // Every range except "1y" ends on the seller's current day, so the last day bucket
+  // (or the whole hourly range for "1d") is today. Project today's revenue to an
+  // end-of-day total from the run rate so far, matching the web analytics chart.
+  const todaysRevenue = timeRange === "1d" ? totalRevenue : (totals[totals.length - 1] ?? 0);
+  const projectedRevenue =
+    timeRange !== "1y" && sellerTimeZone
+      ? projectedEndOfDayTotal(todaysRevenue, fractionOfDayElapsed(sellerTimeZone))
+      : null;
+  const projection = projectedRevenue !== null && projectedRevenue > todaysRevenue ? projectedRevenue : null;
 
   const selectedRevenue = activeIndex !== null ? totals[activeIndex] : 0;
   const selectedSales = activeIndex !== null ? sales[activeIndex] : 0;
@@ -64,6 +76,16 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const showSalesChart = hasData && totalSales > 0;
   const showViewsChart = hasData && totalViews > 0;
 
+  // The projection bar sits behind today's bar (the last bucket of a day-grouped
+  // range) and shares the chart's value scale, so the chart max must account for the
+  // projection possibly exceeding every actual bar. The hourly "Today" view skips the
+  // bar (a whole-day projection has no single hourly bar to sit behind) and shows the
+  // projected total as text only.
+  const projectionIndex = totals.length - 1;
+  const maxRevenueBar = totals.reduce((max, val) => Math.max(max, val), 0);
+  const revenueChartMax = Math.max(maxRevenueBar, projection ?? 0);
+  const showProjectionBar = projection !== null && timeRange !== "1d" && showRevenueChart;
+
   return (
     <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
       <View className="p-4 pt-0" onLayout={handleLayout}>
@@ -75,9 +97,23 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
         >
           <View className="mb-1 flex-row items-baseline justify-between">
             <Text className="text-2xl font-bold text-foreground">{formatCurrency(totalRevenue)}</Text>
-            {activeIndex !== null && <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>}
+            {activeIndex !== null ? (
+              <Text className="text-lg text-accent">{formatCurrency(selectedRevenue)}</Text>
+            ) : projection !== null ? (
+              <Text className="text-sm text-muted">{formatCurrency(projection)} projected today</Text>
+            ) : null}
           </View>
           <View className="mt-4">
+            {showProjectionBar && (
+              <ProjectionOverlay
+                projectedValue={projection}
+                maxValue={revenueChartMax}
+                barWidth={barWidth}
+                spacing={spacing}
+                index={projectionIndex}
+                color={colors.accent}
+              />
+            )}
             {activeIndex !== null && (
               <SelectionOverlay activeIndex={activeIndex} barWidth={barWidth} spacing={spacing} />
             )}
@@ -90,6 +126,7 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
               <BarChart
                 data={revenueData}
                 height={CHART_HEIGHT}
+                maxValue={showProjectionBar ? revenueChartMax : undefined}
                 barWidth={barWidth}
                 spacing={spacing}
                 initialSpacing={0}

--- a/components/analytics/sales-tab.tsx
+++ b/components/analytics/sales-tab.tsx
@@ -13,7 +13,7 @@ import {
 } from "./analytics-bar-chart";
 import { ChartContainer } from "./chart-container";
 import { ChartGestureHandler } from "./chart-gesture-handler";
-import { fractionOfDayElapsed, projectedEndOfDayTotal } from "./projected-end-of-day-total";
+import { dayProgress, projectedEndOfDayTotal, todaysBucketLabel } from "./projected-end-of-day-total";
 import { AnalyticsTimeRange, useAnalyticsByDate } from "./use-analytics-by-date";
 
 export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
@@ -33,15 +33,20 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const totalSales = sales.reduce((sum, val) => sum + val, 0);
   const totalViews = views.reduce((sum, val) => sum + val, 0);
 
-  // Every range except "1y" ends on the seller's current day, so the last day bucket
-  // (or the whole hourly range for "1d") is today. Project today's revenue to an
-  // end-of-day total from the run rate so far, matching the web analytics chart.
-  const todaysRevenue = timeRange === "1d" ? totalRevenue : (totals[totals.length - 1] ?? 0);
-  const projectedRevenue =
-    timeRange !== "1y" && sellerTimeZone
-      ? projectedEndOfDayTotal(todaysRevenue, fractionOfDayElapsed(sellerTimeZone))
-      : null;
-  const projection = projectedRevenue !== null && projectedRevenue > todaysRevenue ? projectedRevenue : null;
+  // Every range except "1y" can end on the seller's current day. For "1d" the whole
+  // hourly range is today; for day-grouped ranges, locate today's bucket by matching
+  // the backend's day label (e.g. "Monday, July 20th") instead of assuming it is the
+  // last bucket, so an omitted, incomplete, or reordered response never projects
+  // another day's revenue. Project today's revenue to an end-of-day total from the
+  // run rate so far, matching the web analytics chart.
+  const progress = timeRange !== "1y" && sellerTimeZone ? dayProgress(sellerTimeZone) : null;
+  const todayLabel = sellerTimeZone ? todaysBucketLabel(sellerTimeZone) : null;
+  const todaysBucketIndex = timeRange === "1d" || todayLabel === null ? -1 : dates.indexOf(todayLabel);
+  const todaysRevenue =
+    timeRange === "1d" ? totalRevenue : todaysBucketIndex >= 0 ? (totals[todaysBucketIndex] ?? 0) : null;
+  const projectedRevenue = todaysRevenue !== null ? projectedEndOfDayTotal(todaysRevenue, progress) : null;
+  const projection =
+    projectedRevenue !== null && todaysRevenue !== null && projectedRevenue > todaysRevenue ? projectedRevenue : null;
 
   const selectedRevenue = activeIndex !== null ? totals[activeIndex] : 0;
   const selectedSales = activeIndex !== null ? sales[activeIndex] : 0;
@@ -76,15 +81,15 @@ export const SalesTab = ({ timeRange }: { timeRange: AnalyticsTimeRange }) => {
   const showSalesChart = hasData && totalSales > 0;
   const showViewsChart = hasData && totalViews > 0;
 
-  // The projection bar sits behind today's bar (the last bucket of a day-grouped
-  // range) and shares the chart's value scale, so the chart max must account for the
-  // projection possibly exceeding every actual bar. The hourly "Today" view skips the
-  // bar (a whole-day projection has no single hourly bar to sit behind) and shows the
-  // projected total as text only.
-  const projectionIndex = totals.length - 1;
+  // The projection bar sits behind today's bar (the bucket matching today's label in
+  // a day-grouped range) and shares the chart's value scale, so the chart max must
+  // account for the projection possibly exceeding every actual bar. The hourly "Today"
+  // view skips the bar (a whole-day projection has no single hourly bar to sit behind)
+  // and shows the projected total as text only.
+  const projectionIndex = todaysBucketIndex;
   const maxRevenueBar = totals.reduce((max, val) => Math.max(max, val), 0);
   const revenueChartMax = Math.max(maxRevenueBar, projection ?? 0);
-  const showProjectionBar = projection !== null && timeRange !== "1d" && showRevenueChart;
+  const showProjectionBar = projection !== null && timeRange !== "1d" && projectionIndex >= 0 && showRevenueChart;
 
   return (
     <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>

--- a/components/analytics/use-analytics-by-date.ts
+++ b/components/analytics/use-analytics-by-date.ts
@@ -1,10 +1,11 @@
 import { useAPIRequest } from "@/lib/request";
 
-export type AnalyticsTimeRange = "1w" | "1m" | "1y";
+export type AnalyticsTimeRange = "1d" | "1w" | "1m" | "1y";
 
 export interface AnalyticsByDateResponse {
   success: boolean;
   dates: string[];
+  seller_time_zone?: string;
   by_date: {
     totals: Record<string, number[]>;
     sales: Record<string, number[]>;
@@ -19,7 +20,10 @@ export interface ProcessedDateData {
   views: number[];
 }
 
-export const getGroupBy = (range: AnalyticsTimeRange): string => (range === "1w" || range === "1m" ? "day" : "month");
+export const getGroupBy = (range: AnalyticsTimeRange): string => {
+  if (range === "1d") return "hour";
+  return range === "1w" || range === "1m" ? "day" : "month";
+};
 
 export const sumByDateIndex = (dataByProduct: Record<string, number[]>, dateCount: number): number[] => {
   const productArrays = Object.values(dataByProduct);
@@ -57,5 +61,6 @@ export const useAnalyticsByDate = (timeRange: AnalyticsTimeRange) => {
   return {
     ...query,
     processedData,
+    sellerTimeZone: query.data?.seller_time_zone ?? null,
   };
 };

--- a/components/analytics/use-analytics-by-referral.ts
+++ b/components/analytics/use-analytics-by-referral.ts
@@ -38,7 +38,9 @@ export const formatReferrerName = (name: string): string => {
   return name;
 };
 
-const getGroupBy = (range: AnalyticsTimeRange): string => (range === "1w" || range === "1m" ? "day" : "month");
+// The mobile by_referral endpoint only serves day/month buckets, so the "Today"
+// range charts referrers as a single day bucket rather than hourly.
+const getGroupBy = (range: AnalyticsTimeRange): string => (range === "1y" ? "month" : "day");
 
 export const aggregateByReferrer = (
   metricData: Record<string, Record<string, number[]>>,

--- a/tests/components/analytics/projected-end-of-day-total.test.ts
+++ b/tests/components/analytics/projected-end-of-day-total.test.ts
@@ -1,0 +1,49 @@
+import {
+  fractionOfDayElapsed,
+  MINIMUM_ELAPSED_DAY_FRACTION,
+  projectedEndOfDayTotal,
+} from "@/components/analytics/projected-end-of-day-total";
+
+describe("fractionOfDayElapsed", () => {
+  it("returns the elapsed fraction of the day in the given time zone", () => {
+    expect(fractionOfDayElapsed("UTC", new Date("2026-07-16T18:00:00Z"))).toBeCloseTo(0.75);
+    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-07-16T18:00:00Z"))).toBeCloseTo(11 / 24);
+  });
+
+  it("handles midnight as zero elapsed", () => {
+    expect(fractionOfDayElapsed("UTC", new Date("2026-07-16T00:00:00Z"))).toBe(0);
+  });
+
+  it("uses the real day length on a spring-forward DST day (23 hours)", () => {
+    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-03-08T19:00:00Z"))).toBeCloseTo(11 / 23);
+  });
+
+  it("uses the real day length on a fall-back DST day (25 hours)", () => {
+    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-11-01T20:00:00Z"))).toBeCloseTo(13 / 25);
+  });
+
+  it("returns null for an unknown time zone", () => {
+    expect(fractionOfDayElapsed("Not/AZone", new Date())).toBeNull();
+  });
+});
+
+describe("projectedEndOfDayTotal", () => {
+  it("extrapolates the current total using the run rate so far", () => {
+    expect(projectedEndOfDayTotal(720000, 0.75)).toBe(960000);
+    expect(projectedEndOfDayTotal(100000, 0.5)).toBe(200000);
+  });
+
+  it("returns null when too little of the day has elapsed", () => {
+    expect(projectedEndOfDayTotal(720000, MINIMUM_ELAPSED_DAY_FRACTION - 0.001)).toBeNull();
+    expect(projectedEndOfDayTotal(720000, MINIMUM_ELAPSED_DAY_FRACTION)).not.toBeNull();
+  });
+
+  it("returns null when the day is over or the fraction is unknown", () => {
+    expect(projectedEndOfDayTotal(720000, 1)).toBeNull();
+    expect(projectedEndOfDayTotal(720000, null)).toBeNull();
+  });
+
+  it("returns null when there are no sales yet", () => {
+    expect(projectedEndOfDayTotal(0, 0.5)).toBeNull();
+  });
+});

--- a/tests/components/analytics/projected-end-of-day-total.test.ts
+++ b/tests/components/analytics/projected-end-of-day-total.test.ts
@@ -1,49 +1,77 @@
 import {
-  fractionOfDayElapsed,
-  MINIMUM_ELAPSED_DAY_FRACTION,
+  dayProgress,
+  MINIMUM_ELAPSED_MS,
   projectedEndOfDayTotal,
+  todaysBucketLabel,
 } from "@/components/analytics/projected-end-of-day-total";
 
-describe("fractionOfDayElapsed", () => {
-  it("returns the elapsed fraction of the day in the given time zone", () => {
-    expect(fractionOfDayElapsed("UTC", new Date("2026-07-16T18:00:00Z"))).toBeCloseTo(0.75);
-    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-07-16T18:00:00Z"))).toBeCloseTo(11 / 24);
+describe("dayProgress", () => {
+  it("returns the elapsed fraction and elapsed time of the day in the given time zone", () => {
+    expect(dayProgress("UTC", new Date("2026-07-16T18:00:00Z"))?.fraction).toBeCloseTo(0.75);
+    expect(dayProgress("UTC", new Date("2026-07-16T18:00:00Z"))?.elapsedMs).toBe(18 * 60 * 60 * 1000);
+    expect(dayProgress("America/Los_Angeles", new Date("2026-07-16T18:00:00Z"))?.fraction).toBeCloseTo(11 / 24);
   });
 
   it("handles midnight as zero elapsed", () => {
-    expect(fractionOfDayElapsed("UTC", new Date("2026-07-16T00:00:00Z"))).toBe(0);
+    expect(dayProgress("UTC", new Date("2026-07-16T00:00:00Z"))?.fraction).toBe(0);
+    expect(dayProgress("UTC", new Date("2026-07-16T00:00:00Z"))?.elapsedMs).toBe(0);
   });
 
   it("uses the real day length on a spring-forward DST day (23 hours)", () => {
-    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-03-08T19:00:00Z"))).toBeCloseTo(11 / 23);
+    const progress = dayProgress("America/Los_Angeles", new Date("2026-03-08T19:00:00Z"));
+    expect(progress?.fraction).toBeCloseTo(11 / 23);
+    expect(progress?.elapsedMs).toBe(11 * 60 * 60 * 1000);
   });
 
   it("uses the real day length on a fall-back DST day (25 hours)", () => {
-    expect(fractionOfDayElapsed("America/Los_Angeles", new Date("2026-11-01T20:00:00Z"))).toBeCloseTo(13 / 25);
+    const progress = dayProgress("America/Los_Angeles", new Date("2026-11-01T20:00:00Z"));
+    expect(progress?.fraction).toBeCloseTo(13 / 25);
+    expect(progress?.elapsedMs).toBe(13 * 60 * 60 * 1000);
   });
 
   it("returns null for an unknown time zone", () => {
-    expect(fractionOfDayElapsed("Not/AZone", new Date())).toBeNull();
+    expect(dayProgress("Not/AZone", new Date())).toBeNull();
+  });
+});
+
+describe("todaysBucketLabel", () => {
+  it("matches the backend's day bucket label format", () => {
+    expect(todaysBucketLabel("UTC", new Date("2026-07-20T12:00:00Z"))).toBe("Monday, July 20th");
+    expect(todaysBucketLabel("UTC", new Date("2026-07-01T12:00:00Z"))).toBe("Wednesday, July 1st");
+    expect(todaysBucketLabel("UTC", new Date("2026-07-03T12:00:00Z"))).toBe("Friday, July 3rd");
+    expect(todaysBucketLabel("UTC", new Date("2026-07-11T12:00:00Z"))).toBe("Saturday, July 11th");
+    expect(todaysBucketLabel("UTC", new Date("2026-07-22T12:00:00Z"))).toBe("Wednesday, July 22nd");
+  });
+
+  it("uses the seller's time zone for the current day", () => {
+    // 01:00 UTC on the 21st is still the evening of the 20th in Los Angeles.
+    expect(todaysBucketLabel("America/Los_Angeles", new Date("2026-07-21T01:00:00Z"))).toBe("Monday, July 20th");
+  });
+
+  it("returns null for an unknown time zone", () => {
+    expect(todaysBucketLabel("Not/AZone", new Date())).toBeNull();
   });
 });
 
 describe("projectedEndOfDayTotal", () => {
+  const progress = (fraction: number, elapsedMs = fraction * 24 * 60 * 60 * 1000) => ({ fraction, elapsedMs });
+
   it("extrapolates the current total using the run rate so far", () => {
-    expect(projectedEndOfDayTotal(720000, 0.75)).toBe(960000);
-    expect(projectedEndOfDayTotal(100000, 0.5)).toBe(200000);
+    expect(projectedEndOfDayTotal(720000, progress(0.75))).toBe(960000);
+    expect(projectedEndOfDayTotal(100000, progress(0.5))).toBe(200000);
   });
 
-  it("returns null when too little of the day has elapsed", () => {
-    expect(projectedEndOfDayTotal(720000, MINIMUM_ELAPSED_DAY_FRACTION - 0.001)).toBeNull();
-    expect(projectedEndOfDayTotal(720000, MINIMUM_ELAPSED_DAY_FRACTION)).not.toBeNull();
+  it("returns null until a real hour has elapsed, regardless of day length", () => {
+    expect(projectedEndOfDayTotal(720000, progress(0.1, MINIMUM_ELAPSED_MS - 1))).toBeNull();
+    expect(projectedEndOfDayTotal(720000, progress(0.1, MINIMUM_ELAPSED_MS))).not.toBeNull();
   });
 
-  it("returns null when the day is over or the fraction is unknown", () => {
-    expect(projectedEndOfDayTotal(720000, 1)).toBeNull();
+  it("returns null when the day is over or the progress is unknown", () => {
+    expect(projectedEndOfDayTotal(720000, progress(1))).toBeNull();
     expect(projectedEndOfDayTotal(720000, null)).toBeNull();
   });
 
   it("returns null when there are no sales yet", () => {
-    expect(projectedEndOfDayTotal(0, 0.5)).toBeNull();
+    expect(projectedEndOfDayTotal(0, progress(0.5))).toBeNull();
   });
 });

--- a/tests/components/analytics/sales-tab.test.tsx
+++ b/tests/components/analytics/sales-tab.test.tsx
@@ -26,7 +26,7 @@ jest.mock("@/components/analytics/chart-gesture-handler", () => ({
 }));
 
 import { SalesTab } from "@/components/analytics/sales-tab";
-import { fractionOfDayElapsed } from "@/components/analytics/projected-end-of-day-total";
+import { dayProgress } from "@/components/analytics/projected-end-of-day-total";
 
 const analyticsResult = (overrides: Record<string, unknown> = {}) => ({
   isLoading: false,
@@ -54,8 +54,21 @@ describe("SalesTab projection", () => {
     render(<SalesTab timeRange="1w" />);
 
     expect(screen.getByTestId("projection-overlay")).toBeTruthy();
-    const projected = Math.round(5000 / (fractionOfDayElapsed("UTC", new Date()) ?? 1));
+    const projected = Math.round(5000 / (dayProgress("UTC", new Date())?.fraction ?? 1));
     expect(screen.getByText(`$${projected / 100} projected today`)).toBeTruthy();
+    jest.useRealTimers();
+  });
+
+  it("renders no projection when no bucket matches today's date", () => {
+    // The response ends the day before "now" (e.g. a stale or incomplete range), so
+    // the last bucket's revenue must not be projected as today's.
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-21T18:00:00Z"));
+    mockUseAnalyticsByDate.mockReturnValue(analyticsResult());
+
+    render(<SalesTab timeRange="1w" />);
+
+    expect(screen.queryByTestId("projection-overlay")).toBeNull();
+    expect(screen.queryByText(/projected today/u)).toBeNull();
     jest.useRealTimers();
   });
 

--- a/tests/components/analytics/sales-tab.test.tsx
+++ b/tests/components/analytics/sales-tab.test.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable import/first -- jest.mock must precede imports */
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+const mockUseAnalyticsByDate = jest.fn();
+jest.mock("@/components/analytics/use-analytics-by-date", () => ({
+  ...jest.requireActual("@/components/analytics/use-analytics-by-date"),
+  useAnalyticsByDate: (...args: unknown[]) => mockUseAnalyticsByDate(...args),
+}));
+
+jest.mock("uniwind", () => ({
+  useCSSVariable: (names: string[]) => names.map((name) => `var(${name})`),
+}));
+
+jest.mock("@/components/icon", () => ({
+  LineIcon: () => null,
+  SolidIcon: () => null,
+}));
+
+jest.mock("react-native-gifted-charts", () => ({
+  BarChart: () => null,
+}));
+
+jest.mock("@/components/analytics/chart-gesture-handler", () => ({
+  ChartGestureHandler: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { SalesTab } from "@/components/analytics/sales-tab";
+import { fractionOfDayElapsed } from "@/components/analytics/projected-end-of-day-total";
+
+const analyticsResult = (overrides: Record<string, unknown> = {}) => ({
+  isLoading: false,
+  sellerTimeZone: "UTC",
+  processedData: {
+    dates: ["Sunday, July 19th", "Monday, July 20th"],
+    totals: [10000, 5000],
+    sales: [3, 2],
+    views: [40, 25],
+  },
+  ...overrides,
+});
+
+describe("SalesTab projection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the projection bar and projected total for a day-grouped range ending today", () => {
+    // Freeze "now" at 18:00 UTC so 75% of the day has elapsed and $50 by-now projects
+    // above today's booked total.
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-20T18:00:00Z"));
+    mockUseAnalyticsByDate.mockReturnValue(analyticsResult());
+
+    render(<SalesTab timeRange="1w" />);
+
+    expect(screen.getByTestId("projection-overlay")).toBeTruthy();
+    const projected = Math.round(5000 / (fractionOfDayElapsed("UTC", new Date()) ?? 1));
+    expect(screen.getByText(`$${projected / 100} projected today`)).toBeTruthy();
+    jest.useRealTimers();
+  });
+
+  it("shows the projected total without a bar on the hourly Today view", () => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-07-20T18:00:00Z"));
+    mockUseAnalyticsByDate.mockReturnValue(
+      analyticsResult({
+        processedData: {
+          dates: ["Monday, July 20th, 12 AM", "Monday, July 20th, 1 AM"],
+          totals: [3000, 2000],
+          sales: [1, 1],
+          views: [10, 5],
+        },
+      }),
+    );
+
+    render(<SalesTab timeRange="1d" />);
+
+    expect(screen.queryByTestId("projection-overlay")).toBeNull();
+    expect(screen.getByText(/projected today/u)).toBeTruthy();
+    jest.useRealTimers();
+  });
+
+  it("renders no projection on the yearly view", () => {
+    mockUseAnalyticsByDate.mockReturnValue(analyticsResult());
+
+    render(<SalesTab timeRange="1y" />);
+
+    expect(screen.queryByTestId("projection-overlay")).toBeNull();
+    expect(screen.queryByText(/projected today/u)).toBeNull();
+  });
+
+  it("renders no projection when the seller time zone is unavailable", () => {
+    mockUseAnalyticsByDate.mockReturnValue(analyticsResult({ sellerTimeZone: null }));
+
+    render(<SalesTab timeRange="1w" />);
+
+    expect(screen.queryByTestId("projection-overlay")).toBeNull();
+    expect(screen.queryByText(/projected today/u)).toBeNull();
+  });
+});

--- a/tests/components/analytics/use-analytics-by-date.test.ts
+++ b/tests/components/analytics/use-analytics-by-date.test.ts
@@ -6,6 +6,10 @@ import {
 } from "@/components/analytics/use-analytics-by-date";
 
 describe("getGroupBy", () => {
+  it('returns "hour" for "1d"', () => {
+    expect(getGroupBy("1d")).toBe("hour");
+  });
+
   it('returns "day" for "1w"', () => {
     expect(getGroupBy("1w")).toBe("day");
   });


### PR DESCRIPTION
Issue: antiwork/gumroad#6053 (parity request from the projection-fix PR)

## What

Brings the recent web analytics features to the app's Analytics tab:

- **Today (1D) range with hourly buckets**: a new "1D" preset next to 1W/1M/1Y. It requests `group_by=hour` from `/api/mobile/analytics/by_date`, charting one bar per wall-clock hour of the seller's current day — the mobile counterpart of the web dashboard's hourly view (antiwork/gumroad#5927) and the "Today" preset (antiwork/gumroad#5964). The Referrers tab keeps day buckets for 1D (the mobile `by_referral` endpoint is day/month only).
- **Projected end-of-day revenue** (antiwork/gumroad#5930, in the accent-bar treatment that shipped in antiwork/gumroad#6053): on any range ending today, the Revenue card shows "$X projected today" and renders a 20%-opacity accent bar behind today's revenue bar, rising to the projected total. The projection math (`projected-end-of-day-total.ts`) is a direct port of the web helper — seller-time-zone day fraction with DST-correct day lengths, minimum 1-hour elapsed guard, null when the projection wouldn't be meaningful. The hourly 1D view shows the projected total as text only (a whole-day projection has no single hourly bar to sit behind).
- The chart's value scale accounts for the projection when it exceeds every actual bar (`maxValue` passed to the BarChart only while the overlay renders, so existing views are untouched).

Depends on antiwork/gumroad#6063, which adds `group_by=hour` and `seller_time_zone` to the mobile `by_date` endpoint. Until that deploys, the 1D view falls back gracefully (hour param ignored server-side returns day buckets on old servers; missing `seller_time_zone` disables the projection entirely).

## Why

Sales projection and the hourly/last-7-days views shipped on the web analytics dashboard over the last few days; the app's Analytics tab should have parity.

## Before/After

- [x] Before/after screenshots (iOS) — captured via the Release-build sim recipe with fixture data matching the #6063 response shape; see [the screenshots comment](https://github.com/antiwork/gumroad-mobile/pull/320#issuecomment-5030067621)
- [x] Backend dependency antiwork/gumroad#6063 merged (2c25394) and confirmed live in production (prod `x-revision` 7dae06fcb210 contains the merge commit). Old-server graceful fallback is no longer exercised in prod. Real-data spot-check of the 1D view against a live creator account is listed under QA steps below.

## QA steps

- [ ] Analytics tab → 1D: hourly bars for today; "$X projected today" text in the Revenue card header when >1h of the day has elapsed and there are sales
- [ ] 1W/1M: faint accent bar behind today's (last) revenue bar rising to the projected total
- [ ] 1Y: no projection
- [ ] Seller with no sales today: no projection text or bar

## Test Results

```
PASS tests/components/analytics/projected-end-of-day-total.test.ts
PASS tests/components/analytics/analytics-bar-chart.test.ts
PASS tests/components/analytics/use-analytics-by-date.test.ts
PASS tests/components/analytics/use-analytics-by-referral.test.ts
PASS tests/components/analytics/sales-tab.test.tsx
Test Suites: 5 passed, 5 total
Tests:       52 passed, 52 total
```

New coverage: projection math (DST spring-forward/fall-back day lengths, elapsed-fraction guards, unknown-zone null), `getGroupBy("1d") === "hour"`, and SalesTab rendering — projection bar + text on day ranges ending today, text-only on 1D, nothing on 1Y or when `seller_time_zone` is absent.

`tsc --noEmit` exit 0, `eslint` clean (one pre-existing warning in `app/login.tsx`), `prettier --check` clean on touched files.

---

## AI disclosure

🤖 Generated with **Claude Fable 5** (Anthropic), running as gumclaw. Instruction given: bring the analytics projection + hourly/Today features from the web dashboard to the mobile app for parity (request on antiwork/gumroad#6053); the recent web PRs (#5924/#5927/#5930/#5964/#6053) were used as the spec.


