### PR TITLE
Pad video player above the Android system navigation bar

### DIFF
--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -10,6 +10,7 @@ import { Stack, useLocalSearchParams } from "expo-router";
 import { useVideoPlayer, VideoView, type VideoPlayerStatus } from "expo-video";
 import { useEffect, useRef, useState } from "react";
 import { AppState, type AppStateStatus, StyleSheet, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const fetchStreamingPlaylistUrl = async (streamingUrl: string, accessToken: string): Promise<string> =>
   (await requestAPI<{ playlist_url: string }>(streamingUrl, { accessToken })).playlist_url;
@@ -42,6 +43,7 @@ export default function VideoPlayerScreen() {
   }>();
 
   const queryClient = useQueryClient();
+  const { bottom } = useSafeAreaInsets();
   const [videoUrl, setVideoUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [playbackError, setPlaybackError] = useState<string | null>(null);
@@ -193,7 +195,7 @@ export default function VideoPlayerScreen() {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingBottom: bottom }]} testID="video-player-container">
       <Stack.Screen
         options={{
           title: title ?? "Video",

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -1,4 +1,4 @@
-import { AppState } from "react-native";
+import { AppState, StyleSheet } from "react-native";
 import { renderWithQueryClient } from "../render-with-query-client";
 
 type StatusChangePayload = { status: string; error?: { message: string } };
@@ -40,6 +40,10 @@ jest.mock("@/lib/auth-context", () => ({
 
 jest.mock("@/lib/media-location", () => ({
   updateMediaLocation: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 48, left: 0, right: 0 }),
 }));
 
 import VideoPlayerScreen from "@/app/video-player";
@@ -237,5 +241,15 @@ describe("VideoPlayerScreen", () => {
       statusChangeListener!({ status: "readyToPlay" });
     });
     expect(queryByText("This video failed to load")).toBeNull();
+  });
+
+  it("pads the video container above the system navigation bar", async () => {
+    const { getByTestId } = renderScreen();
+
+    await act(async () => {});
+
+    const container = getByTestId("video-player-container");
+    const style = StyleSheet.flatten(container.props.style);
+    expect(style.paddingBottom).toBe(48);
   });
 });


### PR DESCRIPTION
Issue: antiwork/gumroad-mobile#322

## What

Applies the bottom safe-area inset as padding on the video player screen's container so the expo-video native controls (seek bar + fullscreen toggle) render above the Android system navigation bar instead of underneath it.

## Why

`android/gradle.properties` enables edge-to-edge, so screens draw under the system bars. `app/video-player.tsx` was the only media screen with no safe-area handling (post, purchase, and full-audio-player all use `useSafeAreaInsets`). On devices with 3-button navigation (e.g. Samsung Galaxy A13), the player's bottom-anchored fullscreen button landed directly under the nav bar and was untappable — fullscreen was effectively unavailable. Found during on-device QA for the 2026.07.20 release (antiwork/gumroad-private#1185); same edge-to-edge bug class as #318/#319.

## Before / After

- Before: fullscreen button rendered beneath the 3-button nav bar; taps hit the nav bar (tester screen recording on the QA thread — Samsung A13, versionCode 356).
- After: player controls end above the nav bar and the fullscreen button is tappable. On gesture-nav and iOS devices the inset is small/zero, so the layout is unchanged.

On-device verification: pending — @nyomanjyotisa has the affected Samsung A13 and will re-test from the next internal build. No emulator video available for the 3-button-nav case; flagging honestly rather than substituting a gesture-nav recording that wouldn't demonstrate the bug.

## Test results

- `npx jest tests/app/video-player.test.tsx` — 14 passed (new regression test asserts the container pads by the bottom inset; verified red-first by stashing the source fix)
- `tsc --noEmit`, `prettier --check` — clean

🤖 Generated with Hermes Agent

AI disclosure: authored by an AI agent (Gumclaw); human QA evidence from @nyomanjyotisa.
