### PR TITLE
Decide audio pause-vs-play from native player state, not the web row's stale claim

### DIFF
--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -64,7 +64,7 @@ export default function DownloadScreen() {
   const webViewRef = useRef<BaseWebView>(null);
   const url = `${env.EXPO_PUBLIC_GUMROAD_URL}/d/${token}?display=mobile_app&access_token=${accessToken}&mobile_token=${env.EXPO_PUBLIC_MOBILE_TOKEN}`;
 
-  const { pauseAudio, playAudio } = useAudioPlayerSync(webViewRef);
+  const { pauseAudio, playAudio, activeResourceId, isPlaying } = useAudioPlayerSync(webViewRef);
   const { bottom } = useSafeAreaInsets();
 
   // Download URLs embed the url_redirect token, which can go stale by the time the user taps a
@@ -157,7 +157,10 @@ export default function DownloadScreen() {
         return;
       }
       if (message.payload.type === "audio" && !message.payload.isDownload) {
-        if (message.payload.isPlaying === "true") {
+        // The web row's isPlaying claim can go stale (it only receives player-info messages for
+        // the current track, so a row left behind by auto-advance or track end still claims to
+        // be playing). Trust the native player's state instead of the row's.
+        if (message.payload.resourceId === activeResourceId && isPlaying) {
           await pauseAudio();
         } else {
           const allAudioFiles = purchase?.file_data?.filter((fileData) => fileData.filegroup === "audio") ?? [];

--- a/tests/app/purchase-token.test.tsx
+++ b/tests/app/purchase-token.test.tsx
@@ -30,15 +30,29 @@ jest.mock("expo-sharing", () => ({
 }));
 
 jest.mock("@/components/library/use-purchases", () => ({
-  usePurchase: () => undefined,
+  usePurchase: () => mockUsePurchase(),
+  fetchPurchaseDetail: jest.fn(),
 }));
 
 jest.mock("@/components/library/use-recent-products", () => ({
   useAddRecentPurchase: () => jest.fn(),
 }));
 
+const mockPauseAudio = jest.fn();
+const mockPlayAudio = jest.fn();
+const mockUsePurchase = jest.fn();
+let mockPlayerState: { activeResourceId: string | null; isPlaying: boolean } = {
+  activeResourceId: null,
+  isPlaying: false,
+};
+
 jest.mock("@/components/use-audio-player-sync", () => ({
-  useAudioPlayerSync: () => ({ pauseAudio: jest.fn(), playAudio: jest.fn() }),
+  useAudioPlayerSync: () => ({
+    pauseAudio: mockPauseAudio,
+    playAudio: mockPlayAudio,
+    activeResourceId: mockPlayerState.activeResourceId,
+    isPlaying: mockPlayerState.isPlaying,
+  }),
 }));
 
 jest.mock("@/components/mini-audio-player", () => ({
@@ -76,6 +90,8 @@ describe("DownloadScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseAuth.mockReturnValue({ isLoading: false, accessToken: "test-access-token" });
+    mockUsePurchase.mockReturnValue(undefined);
+    mockPlayerState = { activeResourceId: null, isPlaying: false };
   });
 
   it("keeps Gumroad navigation and WebView-internal schemes in the WebView", () => {
@@ -116,5 +132,61 @@ describe("DownloadScreen", () => {
     render(<DownloadScreen />);
 
     expect(screen.getByTestId("purchase-webview").props.allowsFullscreenVideo).toBe(true);
+  });
+
+  const purchaseWithAudio = {
+    purchase_id: "purchase-1",
+    url_redirect_external_id: "redirect-1",
+    file_data: [
+      { id: "ep1", filegroup: "audio", name: "Episode 1", content_length: 223 },
+      { id: "ep2", filegroup: "audio", name: "Episode 2", content_length: 223 },
+    ],
+  };
+
+  const sendAudioTap = async (resourceId: string, claimedIsPlaying: string) => {
+    const onMessage = screen.getByTestId("purchase-webview").props.onMessage as (event: {
+      nativeEvent: { data: string };
+    }) => Promise<void>;
+    await onMessage({
+      nativeEvent: {
+        data: JSON.stringify({
+          type: "click",
+          payload: { type: "audio", resourceId, isPlaying: claimedIsPlaying, isDownload: false },
+        }),
+      },
+    });
+  };
+
+  it("pauses when the tapped audio row is the actively playing track", async () => {
+    mockUsePurchase.mockReturnValue(purchaseWithAudio);
+    mockPlayerState = { activeResourceId: "ep1", isPlaying: true };
+    render(<DownloadScreen />);
+
+    await sendAudioTap("ep1", "true");
+
+    expect(mockPauseAudio).toHaveBeenCalled();
+    expect(mockPlayAudio).not.toHaveBeenCalled();
+  });
+
+  it("plays the tapped audio row when its stale isPlaying claim does not match the native player", async () => {
+    mockUsePurchase.mockReturnValue(purchaseWithAudio);
+    mockPlayerState = { activeResourceId: "ep2", isPlaying: true };
+    render(<DownloadScreen />);
+
+    await sendAudioTap("ep1", "true");
+
+    expect(mockPauseAudio).not.toHaveBeenCalled();
+    expect(mockPlayAudio).toHaveBeenCalledWith(expect.objectContaining({ resourceId: "ep1" }));
+  });
+
+  it("plays the tapped audio row when nothing is playing even if the row claims to be playing", async () => {
+    mockUsePurchase.mockReturnValue(purchaseWithAudio);
+    mockPlayerState = { activeResourceId: "ep1", isPlaying: false };
+    render(<DownloadScreen />);
+
+    await sendAudioTap("ep1", "true");
+
+    expect(mockPauseAudio).not.toHaveBeenCalled();
+    expect(mockPlayAudio).toHaveBeenCalledWith(expect.objectContaining({ resourceId: "ep1" }));
   });
 });


### PR DESCRIPTION
Issue: antiwork/gumroad-mobile#324 (also the remaining Android half of antiwork/gumroad-mobile#297)

## What

Makes the purchase content screen decide pause-vs-play from the native player's actual state (`activeResourceId` + `isPlaying` from `useAudioPlayerSync`) instead of the tapped web row's self-reported `isPlaying` claim.

## Why

Each audio row in the embedded web page tracks its own `isPlaying`, updated only by `mobileAppAudioPlayerInfo` messages matching its fileId. The app only posts info for the current track, so a row left behind by lock-screen queue auto-advance or track end never hears `isPlaying: false` and stays stuck claiming playback. The old handler paused whenever the tapped row claimed to be playing — so taps on stuck rows paused the *actually* playing track instead of playing the tapped episode. On-device this presents as dead taps / "nothing plays".

Found during Android on-device QA for the 2026.07.20 release (antiwork/gumroad-private#1185): @nyomanjyotisa on a Samsung Galaxy A13 (versionCode 356) hit it in two checklist scenarios — episode taps after auto-advance, and replaying a finished episode. His recording shows Episode 2's row with a pause icon while the mini player plays Episode 1.

`app/post/[id].tsx` already guards its native rows this way (`activeResourceId === fileId && isPlaying`); this brings the purchase screen in line.

## Before / After

- Before: tapping an episode whose row is stuck in the "playing" state pauses current playback; the tapped episode never plays.
- After: a tap only pauses when the tapped file IS the actively playing track; anything else routes to `playAudio` (which already handles same-playlist skips and finished-track restarts from #305).

Verification: @nyomanjyotisa exercised both podcast scenarios (active-row pause, and finished/stale-row replay after auto-advance) on the iOS simulator and the Android emulator — in both, the stale web row reported `isPlaying: true` while another native track was active, and tapping it restarted the requested episode instead of pausing current playback. Not re-tested on the physical Samsung Galaxy A13 where the bug was originally found.

## Test results

- `npx jest tests/app/purchase-token.test.tsx` — 7 passed (3 new: pause when tapped row is the active playing track; play when the claim is stale because another track is active; play when the claim is stale because nothing is playing). Verified red-first by stashing the source fix: the 2 stale-claim tests fail on the old handler.
- `tsc --noEmit`, `prettier --check` — clean

🤖 Generated with Hermes Agent

AI disclosure: authored by an AI agent (Gumclaw); human QA evidence from @nyomanjyotisa.

