### PR TITLE
Add Maestro release-QA flows, starting with native audio playback

### DIFF
--- a/.maestro/agent-tab.yaml
+++ b/.maestro/agent-tab.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Agent
+# The tab renders the chat composer when the assistant is enabled, or the unavailable
+# message when the account doesn't have access — either proves the screen loads cleanly
+- extendedWaitUntil:
+    visible: "Ask about your store.*|Store assistant.*"
+    timeout: 15000

--- a/.maestro/audio-playback.yaml
+++ b/.maestro/audio-playback.yaml
@@ -1,0 +1,43 @@
+appId: ${APP_ID}
+# Covers the "podcast on a commute" release-checklist item: start audio from a purchase,
+# pause/resume from the mini player, skip controls in the full player, and confirm playback
+# survives backgrounding. Requires the audio seed data from db/seeds/030_development/mobile_app_test_data.rb.
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+# Open the purchased product that has the seeded audio file
+- tapOn: Mobile Test Product 1
+# The purchase page is a WebView; the play control comes from the web content
+- extendedWaitUntil:
+    visible: Play
+    timeout: 20000
+- tapOn: Play
+# Native playback started: the mini player renders with a Pause control
+- extendedWaitUntil:
+    visible: Pause
+    timeout: 15000
+# Pause from the mini player, then resume
+- tapOn: Pause
+- assertVisible: Play
+- tapOn: Play
+- assertVisible: Pause
+# Open the full player and exercise skip controls
+- tapOn: Mobile Test Audio
+- assertVisible: Skip back 15 seconds
+- tapOn: Skip forward 30 seconds
+- tapOn: Skip back 15 seconds
+- assertVisible: Pause
+# Background the app, then come back: playback must still be running (background audio)
+- pressKey: home
+- launchApp:
+    stopApp: false
+- extendedWaitUntil:
+    visible: Pause
+    timeout: 10000
+# Minimize the full player; the mini player should still show the active track
+- tapOn: Minimize player
+- assertVisible: Mobile Test Audio
+- assertVisible: Pause

--- a/.maestro/creator-analytics.yaml
+++ b/.maestro/creator-analytics.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Analytics
+- extendedWaitUntil:
+    visible: Referrers
+    timeout: 15000
+- assertVisible: 1W
+- assertVisible: Export all sales
+- tapOn: Referrers
+- assertVisible: 1W

--- a/.maestro/creator-dashboard.yaml
+++ b/.maestro/creator-dashboard.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Dashboard
+# Revenue header plus the time range selector confirm the sales dashboard rendered with data
+- extendedWaitUntil:
+    visible: "from .* sale.*"
+    timeout: 15000
+- assertVisible: Today
+- assertVisible: Month
+- assertVisible: Year

--- a/.maestro/library-purchased-content.yaml
+++ b/.maestro/library-purchased-content.yaml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000
+- assertVisible: Mobile Test Product 2
+- tapOn: Mobile Test Product 1
+# The purchase content screen uses the product name as its header title
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000
+- back
+- assertVisible: Mobile Test Product 2

--- a/.maestro/login-screen.yaml
+++ b/.maestro/login-screen.yaml
@@ -1,39 +1,7 @@
 appId: ${APP_ID}
 ---
 - runFlow:
-    file: utils/launch.yaml
-- tapOn: Sign in with Gumroad
-# Tap through the iOS "Sign in with gumroad.dev?" prompt
-- runFlow:
-    when:
-      visible: Continue
-    commands:
-      - tapOn: Continue
-# The browser state isn't cleared when the app cache is cleared, so we may still be logged in from a previous session
-- runFlow:
-    when:
-      visible: Logout
-    commands:
-      - tapOn: Logout
-- scrollUntilVisible:
-    element: Login
-- tapOn: Email
-- inputText: mobile_buyer_do_not_edit@gumroad.com
-- pressKey: enter # Form validation auto-focuses the password field
-- inputText: password
-- pressKey: enter
-# Tap through the iOS password manager prompt
-- runFlow:
-    when:
-      visible: Not Now
-    commands:
-      - tapOn: Not Now
-# 2FA prompt will trigger if it hasn't already been completed
-- runFlow:
-    when:
-      visible: Authentication Token
-    commands:
-      - tapOn: Login
-- assertVisible: Authorize
-- tapOn: Authorize
-- assertVisible: Library
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password

--- a/.maestro/logout.yaml
+++ b/.maestro/logout.yaml
@@ -1,0 +1,16 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- tapOn: Settings
+- extendedWaitUntil:
+    visible: Logout
+    timeout: 10000
+- tapOn: Logout
+- extendedWaitUntil:
+    visible: Sign in with Gumroad
+    timeout: 15000

--- a/.maestro/settings-payouts.yaml
+++ b/.maestro/settings-payouts.yaml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- tapOn: Settings
+- extendedWaitUntil:
+    visible: Payout settings
+    timeout: 10000
+- tapOn: Payout settings
+# The payouts screen embeds the web payout settings in a WebView; the screen title
+# renders natively so it confirms navigation even if the WebView is still loading
+- extendedWaitUntil:
+    visible: Payouts
+    timeout: 15000
+- back

--- a/.maestro/tab-navigation.yaml
+++ b/.maestro/tab-navigation.yaml
@@ -1,0 +1,25 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+# All tabs are visible for every account (PR #295); a buyer with no products sees empty states
+- tapOn: Dashboard
+- extendedWaitUntil:
+    visible: "You're just getting started."
+    timeout: 15000
+- tapOn: Analytics
+- extendedWaitUntil:
+    visible: "You're just getting started."
+    timeout: 15000
+# The Agent tab renders the chat composer or the unavailable message depending on account access
+- tapOn: Agent
+- extendedWaitUntil:
+    visible: "Ask about your store.*|Store assistant.*"
+    timeout: 15000
+- tapOn: Library
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000

--- a/.maestro/utils/sign-in.yaml
+++ b/.maestro/utils/sign-in.yaml
@@ -1,0 +1,42 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: launch.yaml
+- tapOn: Sign in with Gumroad
+# Tap through the iOS "Sign in with gumroad.dev?" prompt
+- runFlow:
+    when:
+      visible: Continue
+    commands:
+      - tapOn: Continue
+# The browser state isn't cleared when the app cache is cleared, so we may still be logged in from a previous session
+- runFlow:
+    when:
+      visible: Logout
+    commands:
+      - tapOn: Logout
+- scrollUntilVisible:
+    element: Login
+- tapOn: Email
+- inputText: ${EMAIL}
+- pressKey: enter # Form validation auto-focuses the password field
+- inputText: ${PASSWORD}
+- pressKey: enter
+# Tap through the iOS password manager prompt
+- runFlow:
+    when:
+      visible: Not Now
+    commands:
+      - tapOn: Not Now
+# 2FA prompt will trigger if it hasn't already been completed
+- runFlow:
+    when:
+      visible: Authentication Token
+    commands:
+      - tapOn: Login
+- assertVisible: Authorize
+- tapOn: Authorize
+# All four tab labels are always visible after login, regardless of which tab the app lands on
+- extendedWaitUntil:
+    visible: Library
+    timeout: 15000

--- a/README.md
+++ b/README.md
@@ -114,3 +114,24 @@ E2E tests use [Maestro](https://maestro.dev). To run the tests:
 ### Unit tests
 
 Unit tests use [Jest](https://jestjs.io). To run the tests, use `npm run test`.
+
+## Release QA
+
+Jest gates every PR, but it mocks the native layer (`expo-av`, PDF viewer, WebViews), so release candidates get a Maestro pass over the flows in `.maestro/` — they cover the standing release checklist: audio playback (play, pause/resume, skip, background audio), tab navigation with buyer empty states, library purchased content, creator dashboard, creator analytics, Agent tab, payouts WebView, login, and logout.
+
+### Baseline (every release candidate, no spend)
+
+Run the full `.maestro/` suite on an iOS simulator and an Android emulator against a local Gumroad backend with seed data loaded (see [E2E tests](#e2e-tests) above). Maestro records a video of each run — keep the recordings as the release's evidence trail.
+
+### Big releases: on-demand real devices, pay per use
+
+No standing device-cloud subscription. For big releases and releases carrying promised bug fixes:
+
+- **Android real hardware**: [AWS Device Farm](https://aws.amazon.com/device-farm/) pay-as-you-go ($0.17/device-minute) — a full flow pass costs a few dollars. Upload the release build plus the `.maestro/` flows and run on a Samsung device.
+- **iOS real device or a manual recorded session**: BrowserStack App Live, single month ($39), cancel after.
+
+**Is it a big release?** Yes if any of: a native-layer change (playback, PDF viewer, navigation shell, WebView bridge), a store-listing or build-config change, or the release carries a bug fix that was promised to a user. Routine dependency bumps and web-only changes ship on the emulator baseline alone.
+
+### Still manual
+
+Lock screen controls, biometrics prompts, and anything needing a physical sensor stay manual on a device in hand.

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -87,7 +87,7 @@ const useSettingsSheet = () => useContext(SettingsSheetContext);
 const SettingsButton = () => {
   const { setSettingsOpen } = useSettingsSheet();
   return (
-    <TouchableOpacity onPress={() => setSettingsOpen(true)}>
+    <TouchableOpacity accessibilityLabel="Settings" onPress={() => setSettingsOpen(true)}>
       <SolidIcon name="cog" size={24} className="text-white" />
     </TouchableOpacity>
   );

--- a/components/full-audio-player.tsx
+++ b/components/full-audio-player.tsx
@@ -190,10 +190,20 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
     <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
       <View className="flex-1 bg-background" style={{ paddingTop: top, paddingBottom: bottom }}>
         <View className="flex-row items-center justify-between px-4 py-2">
-          <TouchableOpacity onPress={onClose} className="size-10 items-center justify-center">
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Minimize player"
+            className="size-10 items-center justify-center"
+          >
             <LineIcon name="chevron-down" size={28} className="text-foreground" />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleClose} className="size-10 items-center justify-center">
+          <TouchableOpacity
+            onPress={handleClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close player"
+            className="size-10 items-center justify-center"
+          >
             <LineIcon name="x" size={28} className="text-foreground" />
           </TouchableOpacity>
         </View>
@@ -256,6 +266,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handlePreviousTrack}
               disabled={!hasPrevious}
+              accessibilityRole="button"
+              accessibilityLabel="Previous track"
               className="size-10 items-center justify-center"
               style={{ opacity: hasPrevious ? 1 : 0.3 }}
             >
@@ -264,6 +276,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
 
             <TouchableOpacity
               onPress={handleSkipBack}
+              accessibilityRole="button"
+              accessibilityLabel="Skip back 15 seconds"
               className="size-14 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-sm font-bold text-foreground">-15</Text>
@@ -272,6 +286,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handlePlayPause}
               disabled={isBuffering}
+              accessibilityRole="button"
+              accessibilityLabel={isPlaying ? "Pause" : "Play"}
               className="size-16 items-center justify-center rounded-full bg-primary"
             >
               <SolidIcon name={isPlaying ? "pause" : "play"} size={48} className="text-primary-foreground" />
@@ -279,6 +295,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
 
             <TouchableOpacity
               onPress={handleSkipForward}
+              accessibilityRole="button"
+              accessibilityLabel="Skip forward 30 seconds"
               className="size-14 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-sm font-bold text-foreground">+30</Text>
@@ -287,6 +305,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handleNextTrack}
               disabled={!hasNext}
+              accessibilityRole="button"
+              accessibilityLabel="Next track"
               className="size-10 items-center justify-center"
               style={{ opacity: hasNext ? 1 : 0.3 }}
             >
@@ -295,11 +315,18 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
           </View>
 
           <View className="flex-row items-center justify-center gap-6">
-            <TouchableOpacity onPress={handleCycleSpeed} className="h-10 min-w-16 items-center justify-center px-3">
+            <TouchableOpacity
+              onPress={handleCycleSpeed}
+              accessibilityRole="button"
+              accessibilityLabel="Playback speed"
+              className="h-10 min-w-16 items-center justify-center px-3"
+            >
               <Text className="font-bold text-foreground">{playbackSpeed}x</Text>
             </TouchableOpacity>
             <TouchableOpacity
               onPress={handleToggleLoop}
+              accessibilityRole="button"
+              accessibilityLabel="Toggle loop"
               className="h-10 min-w-16 flex-row items-center justify-center gap-2 px-3"
             >
               <LineIcon name="repeat-alt-2" size={22} className={loopEnabled ? "text-accent" : "text-foreground"} />

--- a/components/mini-audio-player.tsx
+++ b/components/mini-audio-player.tsx
@@ -66,6 +66,8 @@ const MiniAudioPlayerBase = () => {
             <TouchableOpacity
               onPress={handlePlayPause}
               disabled={isBuffering}
+              accessibilityRole="button"
+              accessibilityLabel={isPlaying ? "Pause" : "Play"}
               className="size-7 items-center justify-center rounded-full bg-primary"
             >
               <SolidIcon name={isPlaying ? "pause" : "play"} size={24} className="text-primary-foreground" />
@@ -73,6 +75,8 @@ const MiniAudioPlayerBase = () => {
 
             <TouchableOpacity
               onPress={handleSkipForward}
+              accessibilityRole="button"
+              accessibilityLabel="Skip forward 30 seconds"
               className="size-7 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-xs font-bold">+30</Text>


### PR DESCRIPTION
## What

Starts the Maestro release-flow suite from gumroad-private#1265, beginning with the flow Sahil prioritized: native audio playback (the "long podcast on a commute" case). Adds `.maestro/audio-playback.yaml` covering play-from-purchase, pause/resume from the mini player, skip controls in the full player, background-audio survival, and full-player minimize, plus seven more release-checklist flows: tab navigation with buyer empty states, library purchased content, creator dashboard, creator analytics, Agent tab, payouts WebView, and logout. Extracts the login steps into a reusable `.maestro/utils/sign-in.yaml` parameterized by `EMAIL`/`PASSWORD` so every flow shares it, and adds `accessibilityRole`/`accessibilityLabel` to the icon-only audio player controls and the settings gear so Maestro (and screen readers) can target them.

## Why

The Jest suite mocks `expo-av`/`react-native-track-player`, so native playback — the hardest and longest item on the manual release checklist — has zero automated coverage. This is the first of the ~10 release-checklist flows planned on gumroad-private#1265; audio playback goes first per Sahil's comment there.

## Progress

- [x] `utils/sign-in.yaml` shared login flow (credential-parameterized)
- [x] `audio-playback.yaml` — play, pause/resume, skip, background audio, minimize
- [x] Accessibility labels on player controls (prerequisite for stable Maestro selectors)
- [x] Tab navigation, library purchased content, creator dashboard, creator analytics, Agent tab, payouts WebView, and logout flows
- [ ] PDF viewer and video playback flows (blocked on the same seed-data companion PR — the seeded products need a PDF and a video file)
- [x] Seed an audio product file in `db/seeds/030_development/mobile_app_test_data.rb` (antiwork/gumroad#6217, merged and live in prod)
- [x] Document the release QA process (Maestro baseline + pay-per-use real-device recipe + "big release?" decision) in README.md
- [ ] Wire Maestro runs into release-candidate CI with recorded video artifacts

## Before/After

Not applicable yet — draft. A recorded Maestro run video (the flow produces one natively) will be attached before this is marked ready.

## Test Results

`yarn tsc --noEmit` and `yarn prettier` pass on the touched files. The Maestro flow itself requires the seeded audio file (companion gumroad seed PR) plus a local dev build — recorded run pending; will be posted before un-drafting.

---

AI disclosure: Written by Claude Fable 5 (gumclaw), triggered by Sahil's comment on gumroad-private#1265 asking to start with the native playback flow.


