### PR TITLE
Complete Maestro release QA flows

### DIFF
--- a/.maestro/agent-tab.yaml
+++ b/.maestro/agent-tab.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Agent
+# The tab renders the chat composer when the assistant is enabled, or the unavailable
+# message when the account doesn't have access — either proves the screen loads cleanly
+- extendedWaitUntil:
+    visible: "Ask about your store.*|Store assistant.*"
+    timeout: 15000

--- a/.maestro/audio-playback.yaml
+++ b/.maestro/audio-playback.yaml
@@ -1,0 +1,43 @@
+appId: ${APP_ID}
+# Covers the "podcast on a commute" release-checklist item: start audio from a purchase,
+# pause/resume from the mini player, skip controls in the full player, and confirm playback
+# survives backgrounding. Requires the audio seed data from db/seeds/030_development/mobile_app_test_data.rb.
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+# Open the purchased product that has the seeded audio file
+- tapOn: Mobile Test Product 1
+# The purchase page is a WebView; the play control comes from the web content
+- extendedWaitUntil:
+    visible: Play
+    timeout: 20000
+- tapOn: Play
+# Native playback started: the mini player renders with a Pause control
+- extendedWaitUntil:
+    visible: Pause
+    timeout: 15000
+# Pause from the mini player, then resume
+- tapOn: Pause
+- assertVisible: Play
+- tapOn: Play
+- assertVisible: Pause
+# Open the full player and exercise skip controls
+- tapOn: Mobile Test Audio
+- assertVisible: Skip back 15 seconds
+- tapOn: Skip forward 30 seconds
+- tapOn: Skip back 15 seconds
+- assertVisible: Pause
+# Background the app, then come back: playback must still be running (background audio)
+- pressKey: home
+- launchApp:
+    stopApp: false
+- extendedWaitUntil:
+    visible: Pause
+    timeout: 10000
+# Minimize the full player; the mini player should still show the active track
+- tapOn: Minimize player
+- assertVisible: Mobile Test Audio
+- assertVisible: Pause

--- a/.maestro/audio-playback.yaml
+++ b/.maestro/audio-playback.yaml
@@ -9,7 +9,7 @@ appId: ${APP_ID}
       EMAIL: mobile_buyer_do_not_edit@gumroad.com
       PASSWORD: password
 # Open the purchased product that has the seeded audio file
-- tapOn: Mobile Test Product 1
+- tapOn: ".*Mobile Test Product 1.*"
 # The purchase page is a WebView; the play control comes from the web content
 - extendedWaitUntil:
     visible: Play

--- a/.maestro/audio-restart-resume.yaml
+++ b/.maestro/audio-restart-resume.yaml
@@ -1,0 +1,82 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: ".*Mobile Test Product 1.*"
+- extendedWaitUntil:
+    visible: ".*Mobile Test Audio.*"
+    timeout: 45000
+- tapOn:
+    text: ".*Mobile Test Audio.*"
+    above: Mobile Test Video
+- extendedWaitUntil:
+    visible:
+      id: open-audio-player
+    timeout: 15000
+- tapOn:
+    id: open-audio-player
+- extendedWaitUntil:
+    visible: "Toggle loop, (On|Off)"
+    timeout: 10000
+- runFlow:
+    when:
+      visible: "Toggle loop, On"
+    commands:
+      - tapOn: "Toggle loop, On"
+- assertVisible: "Toggle loop, Off"
+- tapOn:
+    text: Skip back 15 seconds
+    repeat: 4
+    delay: 100
+- tapOn: Skip forward 30 seconds
+- tapOn:
+    id: full-audio-play-pause
+- assertVisible: "0:(2[5-9]|3[0-9])"
+- tapOn:
+    point: "1%,1%"
+    repeat: 2
+    delay: 3000
+- runFlow:
+    file: utils/relaunch.yaml
+- tapOn: Library
+- tapOn: ".*Mobile Test Product 1.*"
+- extendedWaitUntil:
+    visible: ".*Mobile Test Audio.*"
+    timeout: 45000
+- tapOn:
+    text: ".*Mobile Test Audio.*"
+    above: Mobile Test Video
+- extendedWaitUntil:
+    visible:
+      id: open-audio-player
+    timeout: 15000
+- tapOn:
+    id: open-audio-player
+- assertVisible: "0:(2[5-9]|3[0-9])"
+- tapOn:
+    text: Skip forward 30 seconds
+    repeat: 2
+    delay: 200
+- extendedWaitUntil:
+    visible:
+      id: full-audio-play-pause
+      text: Play
+    timeout: 15000
+- assertVisible: "0:46"
+- tapOn: Minimize player
+- tapOn:
+    text: ".*Mobile Test Audio.*"
+    above: Mobile Test Video
+- extendedWaitUntil:
+    visible:
+      id: mini-audio-play-pause
+      text: Pause
+    timeout: 15000
+- tapOn:
+    id: mini-audio-play-pause
+- tapOn:
+    id: open-audio-player
+- assertVisible: "Playback position, 0:(0[0-9]|1[0-5]) of 0:46"

--- a/.maestro/creator-analytics.yaml
+++ b/.maestro/creator-analytics.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Analytics
+- extendedWaitUntil:
+    visible: Referrers
+    timeout: 15000
+- assertVisible: 1W
+- assertVisible: Export all sales
+- tapOn: Referrers
+- assertVisible: 1W

--- a/.maestro/creator-dashboard.yaml
+++ b/.maestro/creator-dashboard.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Dashboard
+# Revenue header plus the time range selector confirm the sales dashboard rendered with data
+- extendedWaitUntil:
+    visible: "from .* sale.*"
+    timeout: 15000
+- assertVisible: Today
+- assertVisible: Month
+- assertVisible: Year

--- a/.maestro/flaky-network-recovery.yaml
+++ b/.maestro/flaky-network-recovery.yaml
@@ -1,0 +1,55 @@
+appId: ${APP_ID}
+tags:
+  - android-only
+onFlowStart:
+  - runFlow:
+      when:
+        platform: Android
+      commands:
+        - setAirplaneMode: disabled
+onFlowComplete:
+  - runFlow:
+      when:
+        platform: Android
+      commands:
+        - setAirplaneMode: disabled
+---
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - assertTrue:
+          condition: ${false}
+          label: flaky-network-recovery is Android-only; run it with npm run e2e:android
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - runFlow:
+          file: utils/sign-in.yaml
+          env:
+            EMAIL: mobile_buyer_do_not_edit@gumroad.com
+            PASSWORD: password
+      - tapOn:
+          text: ".*Mobile Test Product 1.*"
+          waitToSettleTimeoutMs: 0
+      - setAirplaneMode: enabled
+      - tapOn:
+          point: "1%,1%"
+          repeat: 2
+          delay: 4000
+      - setAirplaneMode: disabled
+      # Android WebViews do not support pull-to-refresh. Reopen the purchase
+      # after connectivity returns so this makes a new document request.
+      - runFlow:
+          file: utils/back.yaml
+      - extendedWaitUntil:
+          visible: ".*Mobile Test Product 1.*"
+          timeout: 15000
+      - tapOn: ".*Mobile Test Product 1.*"
+      - extendedWaitUntil:
+          visible: ".*Mobile Test Audio.*"
+          timeout: 45000
+      - assertVisible: Mobile Test Video
+      - assertVisible: Mobile Test PDF
+      - assertNotVisible: "net::ERR_UNKNOWN_URL_SCHEME|Something went wrong"

--- a/.maestro/library-purchased-content.yaml
+++ b/.maestro/library-purchased-content.yaml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000
+- assertVisible: Mobile Test Product 2
+- tapOn: Mobile Test Product 1
+# The purchase content screen uses the product name as its header title
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000
+- back
+- assertVisible: Mobile Test Product 2

--- a/.maestro/library-purchased-content.yaml
+++ b/.maestro/library-purchased-content.yaml
@@ -7,13 +7,13 @@ appId: ${APP_ID}
       PASSWORD: password
 - tapOn: Library
 - extendedWaitUntil:
-    visible: Mobile Test Product 1
+    visible: ".*Mobile Test Product 1.*"
     timeout: 15000
 - assertVisible: Mobile Test Product 2
-- tapOn: Mobile Test Product 1
+- tapOn: ".*Mobile Test Product 1.*"
 # The purchase content screen uses the product name as its header title
 - extendedWaitUntil:
-    visible: Mobile Test Product 1
+    visible: ".*Mobile Test Product 1.*"
     timeout: 15000
 - back
 - assertVisible: Mobile Test Product 2

--- a/.maestro/login-screen.yaml
+++ b/.maestro/login-screen.yaml
@@ -1,39 +1,7 @@
 appId: ${APP_ID}
 ---
 - runFlow:
-    file: utils/launch.yaml
-- tapOn: Sign in with Gumroad
-# Tap through the iOS "Sign in with gumroad.dev?" prompt
-- runFlow:
-    when:
-      visible: Continue
-    commands:
-      - tapOn: Continue
-# The browser state isn't cleared when the app cache is cleared, so we may still be logged in from a previous session
-- runFlow:
-    when:
-      visible: Logout
-    commands:
-      - tapOn: Logout
-- scrollUntilVisible:
-    element: Login
-- tapOn: Email
-- inputText: mobile_buyer_do_not_edit@gumroad.com
-- pressKey: enter # Form validation auto-focuses the password field
-- inputText: password
-- pressKey: enter
-# Tap through the iOS password manager prompt
-- runFlow:
-    when:
-      visible: Not Now
-    commands:
-      - tapOn: Not Now
-# 2FA prompt will trigger if it hasn't already been completed
-- runFlow:
-    when:
-      visible: Authentication Token
-    commands:
-      - tapOn: Login
-- assertVisible: Authorize
-- tapOn: Authorize
-- assertVisible: Library
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password

--- a/.maestro/logout.yaml
+++ b/.maestro/logout.yaml
@@ -1,0 +1,16 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- tapOn: Settings
+- extendedWaitUntil:
+    visible: Logout
+    timeout: 10000
+- tapOn: Logout
+- extendedWaitUntil:
+    visible: Sign in with Gumroad
+    timeout: 15000

--- a/.maestro/pdf-viewer.yaml
+++ b/.maestro/pdf-viewer.yaml
@@ -1,0 +1,38 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: ".*Mobile Test Product 1.*"
+- extendedWaitUntil:
+    visible: Mobile Test PDF
+    timeout: 30000
+- tapOn: Read
+- extendedWaitUntil:
+    visible: "Page [1-3] of 3"
+    timeout: 30000
+- swipe:
+    start: "15%,50%"
+    end: "85%,50%"
+    duration: 300
+- swipe:
+    start: "15%,50%"
+    end: "85%,50%"
+    duration: 300
+- swipe:
+    start: "15%,50%"
+    end: "85%,50%"
+    duration: 300
+- extendedWaitUntil:
+    visible: Page 1 of 3
+    timeout: 10000
+- swipe:
+    start: "85%,50%"
+    end: "15%,50%"
+    duration: 500
+- extendedWaitUntil:
+    visible: Page 2 of 3
+    timeout: 10000
+- assertNotVisible: Unable to load this PDF

--- a/.maestro/purchased-content-background-recovery.yaml
+++ b/.maestro/purchased-content-background-recovery.yaml
@@ -1,0 +1,23 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn:
+    text: ".*Mobile Test Product 1.*"
+    waitToSettleTimeoutMs: 0
+- pressKey: home
+- tapOn:
+    point: "1%,1%"
+    repeat: 2
+    delay: 31000
+- launchApp:
+    stopApp: false
+- extendedWaitUntil:
+    visible: ".*Mobile Test Audio.*"
+    timeout: 45000
+- assertVisible: Mobile Test Video
+- assertVisible: Mobile Test PDF
+- assertNotVisible: "Unable to resolve data for blob|Something went wrong"

--- a/.maestro/settings-payouts.yaml
+++ b/.maestro/settings-payouts.yaml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: Library
+- tapOn: Settings
+- extendedWaitUntil:
+    visible: Payout settings
+    timeout: 10000
+- tapOn: Payout settings
+# The payouts screen embeds the web payout settings in a WebView; the screen title
+# renders natively so it confirms navigation even if the WebView is still loading
+- extendedWaitUntil:
+    visible: Payouts
+    timeout: 15000
+- back

--- a/.maestro/settings-payouts.yaml
+++ b/.maestro/settings-payouts.yaml
@@ -5,15 +5,38 @@ appId: ${APP_ID}
     env:
       EMAIL: mobile_seller1_do_not_edit@gumroad.com
       PASSWORD: password
-- tapOn: Library
-- tapOn: Settings
+- tapOn: ".*Library.*"
+- tapOn:
+    id: settings-button
 - extendedWaitUntil:
-    visible: Payout settings
+    visible: ".*Edit profile.*"
     timeout: 10000
-- tapOn: Payout settings
-# The payouts screen embeds the web payout settings in a WebView; the screen title
-# renders natively so it confirms navigation even if the WebView is still loading
+- tapOn: ".*Edit profile.*"
 - extendedWaitUntil:
-    visible: Payouts
+    visible: Profile settings
+    timeout: 20000
+- assertVisible: Mobile Seller 1
+- assertNotVisible: Something went wrong
+- runFlow:
+    file: utils/back.yaml
+- tapOn:
+    id: settings-button
+- tapOn: ".*Payout settings.*"
+- extendedWaitUntil:
+    visible: "Payout schedule|Where are you located.*"
+    timeout: 20000
+- assertNotVisible: Something went wrong
+- runFlow:
+    file: utils/back.yaml
+- tapOn: ".*Analytics.*"
+- extendedWaitUntil:
+    visible: ".*Export all sales.*"
     timeout: 15000
-- back
+- tapOn: ".*Export all sales.*"
+- tapOn: Export
+- extendedWaitUntil:
+    visible: Download CSV
+    timeout: 20000
+- assertNotVisible: "net::ERR_UNKNOWN_URL_SCHEME|Something went wrong"
+- runFlow:
+    file: utils/back.yaml

--- a/.maestro/tab-navigation.yaml
+++ b/.maestro/tab-navigation.yaml
@@ -1,0 +1,25 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+# All tabs are visible for every account (PR #295); a buyer with no products sees empty states
+- tapOn: Dashboard
+- extendedWaitUntil:
+    visible: "You're just getting started."
+    timeout: 15000
+- tapOn: Analytics
+- extendedWaitUntil:
+    visible: "You're just getting started."
+    timeout: 15000
+# The Agent tab renders the chat composer or the unavailable message depending on account access
+- tapOn: Agent
+- extendedWaitUntil:
+    visible: "Ask about your store.*|Store assistant.*"
+    timeout: 15000
+- tapOn: Library
+- extendedWaitUntil:
+    visible: Mobile Test Product 1
+    timeout: 15000

--- a/.maestro/tab-navigation.yaml
+++ b/.maestro/tab-navigation.yaml
@@ -21,5 +21,5 @@ appId: ${APP_ID}
     timeout: 15000
 - tapOn: Library
 - extendedWaitUntil:
-    visible: Mobile Test Product 1
+    visible: ".*Mobile Test Product 1.*"
     timeout: 15000

--- a/.maestro/utils/back.yaml
+++ b/.maestro/utils/back.yaml
@@ -1,0 +1,13 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: BackButton
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn: Navigate up

--- a/.maestro/utils/launch.yaml
+++ b/.maestro/utils/launch.yaml
@@ -1,7 +1,11 @@
 appId: ${APP_ID}
 ---
 - killApp
-- clearState
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - clearState
 - clearKeychain
 # Open the development client directly, skipping the prompt to choose the URL
 - runFlow:
@@ -16,7 +20,39 @@ appId: ${APP_ID}
     commands:
       - openLink:
           link: "gumroadmobile://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082"
-# Skip past the development menu prompt
+# Disable password saving for the disposable localhost test account.
+- runFlow:
+    when:
+      visible: Never for This Website
+    commands:
+      - tapOn: Never for This Website
+# Dismiss any older password prompt left over from an interrupted iOS OAuth session.
+- runFlow:
+    when:
+      visible: Not Now
+    commands:
+      - tapOn: Not Now
+# A failed OAuth browser session can outlive the app process on iOS.
+- runFlow:
+    when:
+      visible: Cancel
+    commands:
+      - tapOn: Cancel
+# Tap through the iOS confirmation shown the first time a development-client link opens.
+- runFlow:
+    when:
+      visible: Open
+    commands:
+      - tapOn: Open
+# Retain Android development-client state to avoid replaying its first-run
+# onboarding sheet. The sign-in helper logs out any existing app session.
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - waitForAnimationToEnd:
+          timeout: 10000
+# Skip past the development-menu prompt when it appears.
 - runFlow:
     when:
       visible: "Continue"
@@ -26,6 +62,49 @@ appId: ${APP_ID}
     when:
       visible: "Toggle performance monitor"
     commands:
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "86%,96%"
+            - tapOn:
+                id: xmark
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - pressKey: back
+- runFlow:
+    when:
+      visible: "Don.t allow"
+    commands:
+      - tapOn: "Don.t allow"
+- extendedWaitUntil:
+    visible: "Sign in with Gumroad|.*Library.*|Logout|Navigate up"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: Navigate up
+    commands:
+      - tapOn: Navigate up
+- runFlow:
+    when:
+      visible: Navigate up
+    commands:
+      - tapOn: Navigate up
+- extendedWaitUntil:
+    visible: "Sign in with Gumroad|.*Library.*|Logout"
+    timeout: 30000
+- runFlow:
+    when:
+      platform: Android
+      visible: Tools
+    commands:
       - tapOn:
-          point: 50%,10%
-- assertVisible: "Sign in with Gumroad"
+          point: "94%,9%"
+      - extendedWaitUntil:
+          visible: Tools button
+          timeout: 10000
+      - tapOn: Tools button
+      - pressKey: back

--- a/.maestro/utils/login-with-password.yaml
+++ b/.maestro/utils/login-with-password.yaml
@@ -1,0 +1,60 @@
+appId: ${APP_ID}
+---
+- scrollUntilVisible:
+    element: Login
+- tapOn: Email
+- inputText: ${EMAIL}
+- pressKey: enter # The form moves focus to the password field.
+# The password field rerenders after each character in Safari on iOS 26,
+# so refocus it before entering each character of the seeded test password.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: Show password
+      - tapOn: Password
+      - inputText: p
+      - tapOn:
+          text: Never for This Website
+          optional: true
+      - tapOn: Password
+      - inputText: a
+      - tapOn: Password
+      - inputText: s
+      - tapOn: Password
+      - inputText: s
+      - tapOn: Password
+      - inputText: w
+      - tapOn: Password
+      - inputText: o
+      - tapOn: Password
+      - inputText: r
+      - tapOn: Password
+      - inputText: d
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - inputText: ${PASSWORD}
+- hideKeyboard
+# The password prompt may appear as soon as the form auto-submits.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: Not Now
+          optional: true
+- runFlow:
+    when:
+      visible: Login
+    commands:
+      - tapOn: Login
+# Or it may appear after an explicit submit.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          text: Not Now
+          optional: true

--- a/.maestro/utils/relaunch.yaml
+++ b/.maestro/utils/relaunch.yaml
@@ -1,0 +1,47 @@
+appId: ${APP_ID}
+---
+- stopApp
+# A development build returns to Expo's launcher after the process is killed. Reopen the
+# same Metro URL without clearing app or keychain state, which matches a production relaunch.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - openLink:
+          link: "gumroadmobile://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8082"
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - openLink:
+          link: "gumroadmobile://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082"
+- runFlow:
+    when:
+      visible: Open
+    commands:
+      - tapOn: Open
+- runFlow:
+    when:
+      visible: Continue
+    commands:
+      - tapOn: Continue
+- runFlow:
+    when:
+      visible: Toggle performance monitor
+    commands:
+      - runFlow:
+          when:
+            platform: iOS
+          commands:
+            - tapOn:
+                point: "86%,96%"
+            - tapOn:
+                id: xmark
+      - runFlow:
+          when:
+            platform: Android
+          commands:
+            - pressKey: back
+- extendedWaitUntil:
+    visible: Library
+    timeout: 30000

--- a/.maestro/utils/sign-in.yaml
+++ b/.maestro/utils/sign-in.yaml
@@ -1,0 +1,42 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: launch.yaml
+- tapOn: Sign in with Gumroad
+# Tap through the iOS "Sign in with gumroad.dev?" prompt
+- runFlow:
+    when:
+      visible: Continue
+    commands:
+      - tapOn: Continue
+# The browser state isn't cleared when the app cache is cleared, so we may still be logged in from a previous session
+- runFlow:
+    when:
+      visible: Logout
+    commands:
+      - tapOn: Logout
+- scrollUntilVisible:
+    element: Login
+- tapOn: Email
+- inputText: ${EMAIL}
+- pressKey: enter # Form validation auto-focuses the password field
+- inputText: ${PASSWORD}
+- pressKey: enter
+# Tap through the iOS password manager prompt
+- runFlow:
+    when:
+      visible: Not Now
+    commands:
+      - tapOn: Not Now
+# 2FA prompt will trigger if it hasn't already been completed
+- runFlow:
+    when:
+      visible: Authentication Token
+    commands:
+      - tapOn: Login
+- assertVisible: Authorize
+- tapOn: Authorize
+# All four tab labels are always visible after login, regardless of which tab the app lands on
+- extendedWaitUntil:
+    visible: Library
+    timeout: 15000

--- a/.maestro/utils/sign-in.yaml
+++ b/.maestro/utils/sign-in.yaml
@@ -2,10 +2,37 @@ appId: ${APP_ID}
 ---
 - runFlow:
     file: launch.yaml
-- tapOn: Sign in with Gumroad
+- runFlow:
+    when:
+      visible: Logout
+    commands:
+      - tapOn: Logout
+      - extendedWaitUntil:
+          visible: Sign in with Gumroad
+          timeout: 15000
+- runFlow:
+    when:
+      visible: ".*Library.*"
+    commands:
+      - tapOn: ".*Library.*"
+      - tapOn:
+          id: settings-button
+      - extendedWaitUntil:
+          visible: Logout
+          timeout: 10000
+      - tapOn: Logout
+      - extendedWaitUntil:
+          visible: Sign in with Gumroad
+          timeout: 15000
+- runFlow:
+    when:
+      visible: Sign in with Gumroad
+    commands:
+      - tapOn: Sign in with Gumroad
 # Tap through the iOS "Sign in with gumroad.dev?" prompt
 - runFlow:
     when:
+      platform: iOS
       visible: Continue
     commands:
       - tapOn: Continue
@@ -15,28 +42,43 @@ appId: ${APP_ID}
       visible: Logout
     commands:
       - tapOn: Logout
-- scrollUntilVisible:
-    element: Login
-- tapOn: Email
-- inputText: ${EMAIL}
-- pressKey: enter # Form validation auto-focuses the password field
-- inputText: ${PASSWORD}
-- pressKey: enter
-# Tap through the iOS password manager prompt
+- extendedWaitUntil:
+    visible: "Use a different account|Sign up|Authorize|.*Library.*"
+    timeout: 30000
 - runFlow:
     when:
-      visible: Not Now
+      visible: ${EMAIL}
     commands:
-      - tapOn: Not Now
+      - tapOn: Continue
+- runFlow:
+    when:
+      visible: Use a different account
+    commands:
+      - tapOn: Use a different account
+- runFlow:
+    when:
+      visible: Sign up
+    file: login-with-password.yaml
 # 2FA prompt will trigger if it hasn't already been completed
 - runFlow:
     when:
       visible: Authentication Token
     commands:
       - tapOn: Login
-- assertVisible: Authorize
-- tapOn: Authorize
+- runFlow:
+    when:
+      visible: "Don.t allow"
+    commands:
+      - tapOn: "Don.t allow"
+- extendedWaitUntil:
+    visible: "Authorize|.*Library.*"
+    timeout: 30000
+- runFlow:
+    when:
+      visible: Authorize
+    commands:
+      - tapOn: Authorize
 # All four tab labels are always visible after login, regardless of which tab the app lands on
 - extendedWaitUntil:
-    visible: Library
-    timeout: 15000
+    visible: ".*Library.*"
+    timeout: 30000

--- a/.maestro/video-playback.yaml
+++ b/.maestro/video-playback.yaml
@@ -1,0 +1,38 @@
+appId: ${APP_ID}
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- tapOn: ".*Mobile Test Product 1.*"
+- extendedWaitUntil:
+    visible: Mobile Test Video
+    timeout: 30000
+- tapOn: "Watch|Watch again"
+- extendedWaitUntil:
+    visible:
+      id: video-player
+    timeout: 20000
+- extendedWaitUntil:
+    visible: Video playback started
+    timeout: 20000
+- assertNotVisible: This video failed to load
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: video-player
+      - tapOn: "Enter fullscreen"
+      - extendedWaitUntil:
+          visible:
+            id: "${APP_ID}:id/player_view"
+          timeout: 10000
+      - runFlow:
+          when:
+            visible: "Got it"
+          commands:
+            - tapOn: "Got it"
+      - assertVisible:
+          id: "${APP_ID}:id/player_view"

--- a/README.md
+++ b/README.md
@@ -114,3 +114,24 @@ E2E tests use [Maestro](https://maestro.dev). To run the tests:
 ### Unit tests
 
 Unit tests use [Jest](https://jestjs.io). To run the tests, use `npm run test`.
+
+## Release QA
+
+Jest gates every PR, but it mocks the native layer (`expo-av`, PDF viewer, WebViews), so release candidates get a Maestro pass over the flows in `.maestro/` — they cover the standing release checklist: audio playback (play, pause/resume, skip, background audio), tab navigation with buyer empty states, library purchased content, creator dashboard, creator analytics, Agent tab, payouts WebView, login, and logout.
+
+### Baseline (every release candidate, no spend)
+
+Run the full `.maestro/` suite on an iOS simulator and an Android emulator against a local Gumroad backend with seed data loaded (see [E2E tests](#e2e-tests) above). Maestro records a video of each run — keep the recordings as the release's evidence trail.
+
+### Big releases: on-demand real devices, pay per use
+
+No standing device-cloud subscription. For big releases and releases carrying promised bug fixes:
+
+- **Android real hardware**: [AWS Device Farm](https://aws.amazon.com/device-farm/) pay-as-you-go ($0.17/device-minute) — a full flow pass costs a few dollars. Upload the release build plus the `.maestro/` flows and run on a Samsung device.
+- **iOS real device or a manual recorded session**: BrowserStack App Live, single month ($39), cancel after.
+
+**Is it a big release?** Yes if any of: a native-layer change (playback, PDF viewer, navigation shell, WebView bridge), a store-listing or build-config change, or the release carries a bug fix that was promised to a user. Routine dependency bumps and web-only changes ship on the emulator baseline alone.
+
+### Still manual
+
+Lock screen controls, biometrics prompts, and anything needing a physical sensor stay manual on a device in hand.

--- a/README.md
+++ b/README.md
@@ -104,12 +104,21 @@ E2E tests use [Maestro](https://maestro.dev). To run the tests:
 
 3. Ensure you have Gumroad running locally with the latest seed data (`rails db:seed`).
 
-4. Run a test file:
+4. For Android, route the local API and object storage ports through the emulator:
+
+   ```bash
+   adb reverse tcp:3000 tcp:3000
+   adb reverse tcp:9000 tcp:9000
+   ```
+
+5. Run a test file:
 
    ```bash
    npm run e2e:ios .maestro/<test>.yaml
    npm run e2e:android .maestro/<test>.yaml
    ```
+
+   The iOS suite excludes flows tagged `android-only`, such as `flaky-network-recovery.yaml`. Directly targeting one with the iOS command fails with an Android-only error.
 
 ### Unit tests
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -87,7 +87,7 @@ const useSettingsSheet = () => useContext(SettingsSheetContext);
 const SettingsButton = () => {
   const { setSettingsOpen } = useSettingsSheet();
   return (
-    <TouchableOpacity onPress={() => setSettingsOpen(true)}>
+    <TouchableOpacity accessibilityLabel="Settings" onPress={() => setSettingsOpen(true)}>
       <SolidIcon name="cog" size={24} className="text-white" />
     </TouchableOpacity>
   );

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -87,7 +87,7 @@ const useSettingsSheet = () => useContext(SettingsSheetContext);
 const SettingsButton = () => {
   const { setSettingsOpen } = useSettingsSheet();
   return (
-    <TouchableOpacity accessibilityLabel="Settings" onPress={() => setSettingsOpen(true)}>
+    <TouchableOpacity testID="settings-button" accessibilityLabel="Settings" onPress={() => setSettingsOpen(true)}>
       <SolidIcon name="cog" size={24} className="text-white" />
     </TouchableOpacity>
   );

--- a/app/pdf-viewer.tsx
+++ b/app/pdf-viewer.tsx
@@ -167,6 +167,8 @@ export default function PdfViewerScreen() {
             <View className="flex-row items-center gap-1">
               <TouchableOpacity
                 testID="share-pdf-button"
+                accessibilityRole="button"
+                accessibilityLabel="Share PDF"
                 disabled={isSharing}
                 onPress={async () => {
                   setIsSharing(true);
@@ -187,10 +189,20 @@ export default function PdfViewerScreen() {
                   className={cn("text-accent", Platform.OS === "ios" && "-rotate-90")}
                 />
               </TouchableOpacity>
-              <TouchableOpacity onPress={() => setShowTocModal(true)} className="p-2">
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel="Page navigation"
+                onPress={() => setShowTocModal(true)}
+                className="p-2"
+              >
                 <SolidIcon name="book-content" size={24} className="text-accent" />
               </TouchableOpacity>
-              <TouchableOpacity onPress={() => setShowViewModeModal(true)} className="p-2">
+              <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel="View mode"
+                onPress={() => setShowViewModeModal(true)}
+                className="p-2"
+              >
                 {viewMode === "continuous" ? (
                   <LineIcon name="move-vertical" size={24} className="text-accent" />
                 ) : (

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -229,8 +229,8 @@ export default function DownloadScreen() {
         source={{ uri: url }}
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled
+        incognito
         pullToRefreshEnabled
-        sharedCookiesEnabled
         thirdPartyCookiesEnabled
         mediaPlaybackRequiresUserAction={false}
         // Android blocks the HTML5 fullscreen API in WebViews unless this is enabled, so videos playing inline (like embedded players in rich content) would have a fullscreen button that does nothing. iOS ignores this prop.

--- a/app/sales-export.tsx
+++ b/app/sales-export.tsx
@@ -130,8 +130,8 @@ export default function SalesExportScreen() {
         source={{ uri: url }}
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled
+        incognito
         pullToRefreshEnabled
-        sharedCookiesEnabled
         thirdPartyCookiesEnabled
         originWhitelist={["*"]}
         onShouldStartLoadWithRequest={handleShouldStartLoadWithRequest}

--- a/app/settings/payments.tsx
+++ b/app/settings/payments.tsx
@@ -149,8 +149,8 @@ export default function PayoutSettingsScreen() {
         source={{ uri: url }}
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled={__DEV__}
+        incognito
         pullToRefreshEnabled
-        sharedCookiesEnabled
         thirdPartyCookiesEnabled
         setSupportMultipleWindows
         javaScriptCanOpenWindowsAutomatically

--- a/app/settings/profile.tsx
+++ b/app/settings/profile.tsx
@@ -149,8 +149,8 @@ export default function ProfileSettingsScreen() {
         source={{ uri: url }}
         className="flex-1 bg-transparent"
         webviewDebuggingEnabled={__DEV__}
+        incognito
         pullToRefreshEnabled
-        sharedCookiesEnabled
         thirdPartyCookiesEnabled
         setSupportMultipleWindows
         javaScriptCanOpenWindowsAutomatically

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -46,6 +46,8 @@ export default function VideoPlayerScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [playbackError, setPlaybackError] = useState<string | null>(null);
   const [currentPosition, setCurrentPosition] = useState(initialPosition ? Number(initialPosition) : 0);
+  const [playbackStarted, setPlaybackStarted] = useState(false);
+  const playbackStartedRef = useRef(false);
   const currentPositionRef = useRefToLatest(currentPosition);
 
   useEffect(() => {
@@ -75,6 +77,7 @@ export default function VideoPlayerScreen() {
   const player = useVideoPlayer(videoUrl, (player) => {
     player.loop = false;
     player.staysActiveInBackground = false;
+    player.timeUpdateEventInterval = 0.25;
     if (initialPosition) {
       player.currentTime = Number(initialPosition);
     }
@@ -123,6 +126,17 @@ export default function VideoPlayerScreen() {
     );
     return () => subscription.remove();
   }, [player]);
+
+  useEffect(() => {
+    const startingPosition = initialPosition ? Number(initialPosition) : 0;
+    const subscription = player.addListener("timeUpdate", ({ currentTime }) => {
+      if (!playbackStartedRef.current && currentTime > startingPosition + 0.1) {
+        playbackStartedRef.current = true;
+        setPlaybackStarted(true);
+      }
+    });
+    return () => subscription.remove();
+  }, [initialPosition, player]);
 
   useEffect(
     () => () => {
@@ -202,6 +216,8 @@ export default function VideoPlayerScreen() {
         }}
       />
       <VideoView
+        testID="video-player"
+        accessibilityLabel={playbackStarted ? "Video playback started" : "Video playback waiting"}
         style={styles.video}
         player={player}
         allowsPictureInPicture

--- a/components/full-audio-player.tsx
+++ b/components/full-audio-player.tsx
@@ -190,10 +190,20 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
     <Modal visible={visible} animationType="slide" presentationStyle="fullScreen">
       <View className="flex-1 bg-background" style={{ paddingTop: top, paddingBottom: bottom }}>
         <View className="flex-row items-center justify-between px-4 py-2">
-          <TouchableOpacity onPress={onClose} className="size-10 items-center justify-center">
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Minimize player"
+            className="size-10 items-center justify-center"
+          >
             <LineIcon name="chevron-down" size={28} className="text-foreground" />
           </TouchableOpacity>
-          <TouchableOpacity onPress={handleClose} className="size-10 items-center justify-center">
+          <TouchableOpacity
+            onPress={handleClose}
+            accessibilityRole="button"
+            accessibilityLabel="Close player"
+            className="size-10 items-center justify-center"
+          >
             <LineIcon name="x" size={28} className="text-foreground" />
           </TouchableOpacity>
         </View>
@@ -256,6 +266,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handlePreviousTrack}
               disabled={!hasPrevious}
+              accessibilityRole="button"
+              accessibilityLabel="Previous track"
               className="size-10 items-center justify-center"
               style={{ opacity: hasPrevious ? 1 : 0.3 }}
             >
@@ -264,6 +276,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
 
             <TouchableOpacity
               onPress={handleSkipBack}
+              accessibilityRole="button"
+              accessibilityLabel="Skip back 15 seconds"
               className="size-14 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-sm font-bold text-foreground">-15</Text>
@@ -272,6 +286,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handlePlayPause}
               disabled={isBuffering}
+              accessibilityRole="button"
+              accessibilityLabel={isPlaying ? "Pause" : "Play"}
               className="size-16 items-center justify-center rounded-full bg-primary"
             >
               <SolidIcon name={isPlaying ? "pause" : "play"} size={48} className="text-primary-foreground" />
@@ -279,6 +295,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
 
             <TouchableOpacity
               onPress={handleSkipForward}
+              accessibilityRole="button"
+              accessibilityLabel="Skip forward 30 seconds"
               className="size-14 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-sm font-bold text-foreground">+30</Text>
@@ -287,6 +305,8 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             <TouchableOpacity
               onPress={handleNextTrack}
               disabled={!hasNext}
+              accessibilityRole="button"
+              accessibilityLabel="Next track"
               className="size-10 items-center justify-center"
               style={{ opacity: hasNext ? 1 : 0.3 }}
             >
@@ -295,11 +315,18 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
           </View>
 
           <View className="flex-row items-center justify-center gap-6">
-            <TouchableOpacity onPress={handleCycleSpeed} className="h-10 min-w-16 items-center justify-center px-3">
+            <TouchableOpacity
+              onPress={handleCycleSpeed}
+              accessibilityRole="button"
+              accessibilityLabel="Playback speed"
+              className="h-10 min-w-16 items-center justify-center px-3"
+            >
               <Text className="font-bold text-foreground">{playbackSpeed}x</Text>
             </TouchableOpacity>
             <TouchableOpacity
               onPress={handleToggleLoop}
+              accessibilityRole="button"
+              accessibilityLabel="Toggle loop"
               className="h-10 min-w-16 flex-row items-center justify-center gap-2 px-3"
             >
               <LineIcon name="repeat-alt-2" size={22} className={loopEnabled ? "text-accent" : "text-foreground"} />

--- a/components/full-audio-player.tsx
+++ b/components/full-audio-player.tsx
@@ -240,6 +240,11 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
         <View className="px-8 pb-8">
           <GestureDetector gesture={seekBarGesture}>
             <View
+              accessibilityLabel="Playback position"
+              accessibilityRole="progressbar"
+              accessibilityValue={{
+                text: `${formatTime(seekProgress != null ? (seekProgress / 100) * duration : position)} of ${formatTime(duration)}`,
+              }}
               className="mb-2 justify-center py-2"
               onLayout={(e) => {
                 barWidthRef.current = e.nativeEvent.layout.width;
@@ -284,6 +289,7 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
             </TouchableOpacity>
 
             <TouchableOpacity
+              testID="full-audio-play-pause"
               onPress={handlePlayPause}
               disabled={isBuffering}
               accessibilityRole="button"
@@ -327,6 +333,7 @@ export const FullAudioPlayer = ({ visible, onClose }: { visible: boolean; onClos
               onPress={handleToggleLoop}
               accessibilityRole="button"
               accessibilityLabel="Toggle loop"
+              accessibilityValue={{ text: loopEnabled ? "On" : "Off" }}
               className="h-10 min-w-16 flex-row items-center justify-center gap-2 px-3"
             >
               <LineIcon name="repeat-alt-2" size={22} className={loopEnabled ? "text-accent" : "text-foreground"} />

--- a/components/mini-audio-player.tsx
+++ b/components/mini-audio-player.tsx
@@ -66,6 +66,8 @@ const MiniAudioPlayerBase = () => {
             <TouchableOpacity
               onPress={handlePlayPause}
               disabled={isBuffering}
+              accessibilityRole="button"
+              accessibilityLabel={isPlaying ? "Pause" : "Play"}
               className="size-7 items-center justify-center rounded-full bg-primary"
             >
               <SolidIcon name={isPlaying ? "pause" : "play"} size={24} className="text-primary-foreground" />
@@ -73,6 +75,8 @@ const MiniAudioPlayerBase = () => {
 
             <TouchableOpacity
               onPress={handleSkipForward}
+              accessibilityRole="button"
+              accessibilityLabel="Skip forward 30 seconds"
               className="size-7 items-center justify-center rounded-full border-2 border-foreground"
             >
               <Text className="text-xs font-bold">+30</Text>

--- a/components/mini-audio-player.tsx
+++ b/components/mini-audio-player.tsx
@@ -45,7 +45,7 @@ const MiniAudioPlayerBase = () => {
 
   return (
     <>
-      <Pressable onPress={() => setFullPlayerVisible(true)}>
+      <Pressable testID="open-audio-player" onPress={() => setFullPlayerVisible(true)}>
         <View className="h-1 border-t border-border bg-background">
           <View className="h-1 bg-primary" style={{ width: `${progress}%` }} />
         </View>
@@ -64,6 +64,7 @@ const MiniAudioPlayerBase = () => {
 
           <View className="flex-row items-center gap-2">
             <TouchableOpacity
+              testID="mini-audio-play-pause"
               onPress={handlePlayPause}
               disabled={isBuffering}
               accessibilityRole="button"

--- a/components/page-indicator.tsx
+++ b/components/page-indicator.tsx
@@ -54,6 +54,8 @@ export const PageIndicator = ({
       }}
     >
       <TouchableOpacity
+        accessibilityRole="button"
+        accessibilityLabel={`Page ${currentPage} of ${totalPages}`}
         activeOpacity={0.7}
         onPress={() => {
           if (isEditing) {

--- a/components/pdf-navigation-sheet.tsx
+++ b/components/pdf-navigation-sheet.tsx
@@ -44,7 +44,12 @@ const PageThumbnail = memo(
     failed: boolean;
     onPress: (page: number) => void;
   }) => (
-    <TouchableOpacity onPress={() => onPress(page)} style={{ width: thumbnailWidth }}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={`Page ${page}`}
+      onPress={() => onPress(page)}
+      style={{ width: thumbnailWidth }}
+    >
       <View
         className={cn("overflow-hidden rounded-lg border-2", isCurrent ? "border-accent" : "border-border")}
         style={{ width: thumbnailWidth, height: thumbnailHeight }}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "e2e:ios": "dotenv-flow -- npm run e2e:ios:run",
-    "e2e:ios:run": "maestro test -p ios -e APP_ID=$IOS_BUNDLE_NAME",
+    "e2e:ios:run": "maestro test -p ios --exclude-tags=android-only -e APP_ID=$IOS_BUNDLE_NAME",
     "e2e:android": "dotenv-flow -- npm run e2e:android:run",
     "e2e:android:run": "maestro test -p android -e APP_ID=$ANDROID_BUNDLE_NAME",
     "eas": "dotenv-flow eas --",

--- a/tests/app/payments.test.tsx
+++ b/tests/app/payments.test.tsx
@@ -57,6 +57,8 @@ describe("PayoutSettingsScreen", () => {
     expect(source.uri).toBe(expectedUrl);
 
     const props = screen.getByTestId("payments-webview").props;
+    expect(props.incognito).toBe(true);
+    expect(props.sharedCookiesEnabled).toBeUndefined();
     expect(props.setSupportMultipleWindows).toBe(true);
     expect(props.javaScriptCanOpenWindowsAutomatically).toBe(true);
   });

--- a/tests/app/profile.test.tsx
+++ b/tests/app/profile.test.tsx
@@ -57,6 +57,8 @@ describe("ProfileSettingsScreen", () => {
     expect(source.uri).toBe(expectedUrl);
 
     const props = screen.getByTestId("profile-webview").props;
+    expect(props.incognito).toBe(true);
+    expect(props.sharedCookiesEnabled).toBeUndefined();
     expect(props.setSupportMultipleWindows).toBe(true);
     expect(props.javaScriptCanOpenWindowsAutomatically).toBe(true);
   });

--- a/tests/app/purchase-token.test.tsx
+++ b/tests/app/purchase-token.test.tsx
@@ -115,6 +115,8 @@ describe("DownloadScreen", () => {
   it("allows fullscreen video for content playing inline in the WebView", () => {
     render(<DownloadScreen />);
 
+    expect(screen.getByTestId("purchase-webview").props.incognito).toBe(true);
+    expect(screen.getByTestId("purchase-webview").props.sharedCookiesEnabled).toBeUndefined();
     expect(screen.getByTestId("purchase-webview").props.allowsFullscreenVideo).toBe(true);
   });
 });

--- a/tests/app/sales-export.test.tsx
+++ b/tests/app/sales-export.test.tsx
@@ -78,6 +78,8 @@ describe("SalesExportScreen", () => {
     expect(screen.getByTestId("sales-export-webview").props.source).toEqual({
       uri: "https://example.com/purchases/export?access_token=test-access-token&mobile_token=test-mobile-token",
     });
+    expect(screen.getByTestId("sales-export-webview").props.incognito).toBe(true);
+    expect(screen.getByTestId("sales-export-webview").props.sharedCookiesEnabled).toBeUndefined();
   });
 
   it("keeps Gumroad navigation in the WebView and opens external links outside it", () => {

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -2,7 +2,9 @@ import { AppState } from "react-native";
 import { renderWithQueryClient } from "../render-with-query-client";
 
 type StatusChangePayload = { status: string; error?: { message: string } };
+type TimeUpdatePayload = { currentTime: number };
 let statusChangeListener: ((payload: StatusChangePayload) => void) | null = null;
+let timeUpdateListener: ((payload: TimeUpdatePayload) => void) | null = null;
 const mockSubscriptionRemove = jest.fn();
 
 const mockPlayer = {
@@ -10,10 +12,15 @@ const mockPlayer = {
   staysActiveInBackground: true,
   playing: true,
   currentTime: 0,
+  timeUpdateEventInterval: 0,
   play: jest.fn(),
   pause: jest.fn(),
-  addListener: jest.fn((eventName: string, listener: (payload: StatusChangePayload) => void) => {
-    if (eventName === "statusChange") statusChangeListener = listener;
+  addListener: jest.fn((eventName: string, listener: (payload: never) => void) => {
+    if (eventName === "statusChange") {
+      statusChangeListener = listener as (payload: StatusChangePayload) => void;
+    } else if (eventName === "timeUpdate") {
+      timeUpdateListener = listener as (payload: TimeUpdatePayload) => void;
+    }
     return { remove: mockSubscriptionRemove };
   }),
 };
@@ -58,8 +65,10 @@ describe("VideoPlayerScreen", () => {
     mockPlayer.staysActiveInBackground = true;
     mockPlayer.loop = false;
     mockPlayer.currentTime = 0;
+    mockPlayer.timeUpdateEventInterval = 0;
     appStateCallback = null;
     statusChangeListener = null;
+    timeUpdateListener = null;
 
     jest.spyOn(AppState, "addEventListener").mockImplementation((_type, callback) => {
       appStateCallback = callback as (state: string) => void;
@@ -74,6 +83,18 @@ describe("VideoPlayerScreen", () => {
   it("sets staysActiveInBackground to false on player setup", () => {
     renderScreen();
     expect(mockPlayer.staysActiveInBackground).toBe(false);
+  });
+
+  it("exposes when playback advances", () => {
+    const { getByLabelText } = renderScreen();
+
+    expect(getByLabelText("Video playback waiting")).toBeTruthy();
+
+    act(() => {
+      timeUpdateListener!({ currentTime: 0.25 });
+    });
+
+    expect(getByLabelText("Video playback started")).toBeTruthy();
   });
 
   it("pauses the player when app goes to background", () => {


### PR DESCRIPTION
Ref antiwork/gumroad-private#1265

Depends on antiwork/gumroad#6242

## What

Completes the Maestro release QA coverage with restart/resume audio, video playback, PDF viewing, purchased-content background recovery, flaky-network recovery, and seller settings flows. It also adds stable accessibility state for native controls and isolates token-authenticated WebViews so switching accounts cannot reuse the prior Rails session.

## Why

The release checklist depended on manual checks for native media, WebViews, backgrounding, and weak-network behavior. These flows make those checks repeatable against local seed data, while the small runtime changes expose the state Maestro needs to verify and fix the account-session leak found during local testing.

---

This PR was implemented with AI assistance using gpt‑5.6 xhigh.