### PR TITLE
Gate every PR on an Android launch smoke test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -173,7 +173,9 @@ jobs:
           emulator-options: -no-window -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            ./gradlew -p android assembleDebug
+            # prebuild generates the Gradle wrapper inside android/, not at the repo root.
+            chmod +x android/gradlew
+            ./android/gradlew -p android assembleDebug
             adb install -r android/app/build/outputs/apk/debug/app-debug.apk
             maestro test --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -210,7 +210,17 @@ jobs:
           script: |
             # prebuild generates the Gradle wrapper inside android/, not at the repo root.
             chmod +x android/gradlew
-            ./android/gradlew -p android assembleDebug
+            # Build native code for the emulator's ABI only. The default in
+            # android/gradle.properties is all four (armeabi-v7a, arm64-v8a, x86, x86_64),
+            # which is right for a release build but means CMake compiles reanimated,
+            # expo-modules-core and the app three extra times for architectures this job can
+            # never run. That was 28 of the job's 45 minutes, and it left too little room for
+            # the flow itself.
+            ./android/gradlew -p android assembleDebug -PreactNativeArchitectures=x86_64
+            # Hand the emulator back the RAM and cores the build was using. The daemon
+            # otherwise stays resident for the rest of the job, and adb operations against a
+            # starved emulator can stall indefinitely rather than fail.
+            ./android/gradlew -p android --stop
             adb install -r android/app/build/outputs/apk/debug/app-debug.apk
             # Every line in this block is run as its own separate shell by
             # android-emulator-runner, so multi-line shell constructs (if/then/fi, loops,
@@ -221,7 +231,14 @@ jobs:
             # e2e:android:run script invokes it. Without -e, Maestro substitutes the literal
             # string "undefined" and the run dies with the misleading "Package undefined is
             # not installed" -- minutes in, after a clean build and install have succeeded.
-            maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
+            #
+            # The outer `timeout` is what makes a stuck flow diagnosable. The flow's own
+            # extendedWaitUntil only bounds the wait for a view, not the adb calls before it,
+            # so a wedged emulator leaves Maestro hanging on "Clear state" until the job-level
+            # timeout cancels everything -- and a cancelled job discards the artifact upload,
+            # so you get no report and no recording, only "The operation was canceled". Failing
+            # the step ourselves keeps the evidence.
+            timeout --signal=TERM --kill-after=60s 12m maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 
       # A failed flow is unreadable without its recording, so upload evidence either way.
       - name: Upload the report and recordings

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,15 +212,15 @@ jobs:
             chmod +x android/gradlew
             ./android/gradlew -p android assembleDebug
             adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            # Every line in this block is run as its own separate shell by
+            # android-emulator-runner, so multi-line shell constructs (if/then/fi, loops,
+            # heredocs) are not possible here and variables do not carry between lines.
+            #
             # Maestro does not read APP_ID out of the surrounding shell environment; a flow
             # variable has to be handed to it with -e, which is how this repo's own
             # e2e:android:run script invokes it. Without -e, Maestro substitutes the literal
             # string "undefined" and the run dies with the misleading "Package undefined is
             # not installed" -- minutes in, after a clean build and install have succeeded.
-            if [ -z "$APP_ID" ]; then
-              echo "::error::APP_ID is empty, so Maestro would drive a package named 'undefined'."
-              exit 1
-            fi
             maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 
       # A failed flow is unreadable without its recording, so upload evidence either way.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,183 @@
+name: e2e
+
+# Maestro flows drive the real app on an Android emulator. There are two jobs because the
+# flows have two very different requirements:
+#
+#   smoke  — .maestro/launch-smoke.yaml only. Installs a standalone build, launches it, and
+#            asserts the signed-out cold start lands on the login screen. It touches no
+#            backend, so it can gate every pull request. It catches the failures that matter
+#            most and are invisible to jest: a build that will not boot, a crash on launch, a
+#            broken root layout, a routing change that blanks the screen for a signed-out user.
+#
+#   suite  — the whole .maestro directory. Those flows sign in as a real seller and open real
+#            purchases, so they need a reachable Gumroad backend with seeded data (.env points
+#            at http://localhost:3000). No GitHub runner has one, so this job is manual and
+#            expects a self-hosted runner, or the Rails app booted as a service here, before it
+#            can be trusted. Wiring it to pull_request today would paint every PR red and teach
+#            everyone to ignore the check.
+on:
+  pull_request:
+    paths:
+      - ".maestro/**"
+      - "app/**"
+      - "components/**"
+      - "lib/**"
+      - "modules/**"
+      - "patches/**"
+      - "app.config.ts"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/e2e.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_full_suite:
+        description: "Also run the flows that need a seeded backend"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Each run boots an emulator and builds the app, so overlapping runs on one branch just
+# compete for the runner. A newer push makes an in-flight run obsolete.
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: launch smoke (no backend)
+    # The Android emulator needs nested virtualisation (KVM), which the Ubuntu runners
+    # provide and the macOS runners do not.
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # --ignore-scripts skips the postinstall that applies patch-package, so run it
+      # explicitly: the repo carries patches/ that the app depends on at runtime.
+      - run: npm ci --ignore-scripts
+      - run: npx patch-package
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Enable KVM for the emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Maestro
+        run: |
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties', 'package-lock.json') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      # The smoke flow never reaches the API, so the backend URL only has to be well-formed.
+      # A placeholder keeps this job independent of repository secrets, which is what lets it
+      # run on forks and on every PR.
+      # app.config.ts reads the package name from ANDROID_BUNDLE_NAME, so the same value has
+      # to reach both prebuild and Maestro's APP_ID. Setting it once here keeps the installed
+      # APK and the flow's target from drifting apart. This is the dev id from .env, not the
+      # store id in .env.build.local.
+      - name: Generate the native Android project
+        env:
+          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
+          IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
+          EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
+          EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
+        run: npx expo prebuild --platform android --clean
+
+      # Read the id back out of the generated Gradle config rather than trusting the variable
+      # above: if prebuild ever resolves it differently, installing and driving the wrong
+      # package would fail in a confusing way.
+      - name: Confirm the built application id
+        id: app_id
+        run: |
+          app_id=$(grep -m1 -oE 'applicationId .[^"'"'"']+' android/app/build.gradle \
+            | sed -E 's/applicationId .//')
+          if [ -z "$app_id" ]; then
+            echo "::error::Could not read applicationId from android/app/build.gradle"
+            exit 1
+          fi
+          echo "value=$app_id" >> "$GITHUB_OUTPUT"
+          echo "Built application id: $app_id"
+
+      - name: Run the launch smoke flow
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          # Every flow declares `appId: ${APP_ID}`, so the suite cannot run without it.
+          APP_ID: ${{ steps.app_id.outputs.value }}
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          profile: pixel_6
+          # Headless, no boot animation, no audio: nothing here needs a visible window and the
+          # emulator boots noticeably faster without them.
+          emulator-options: -no-window -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: |
+            ./gradlew -p android assembleDebug
+            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            maestro test --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
+
+      # A failed flow is unreadable without its recording, so upload evidence either way.
+      - name: Upload the report and recordings
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-smoke-results
+          path: |
+            maestro-report.xml
+            ~/.maestro/tests/**
+          retention-days: 14
+          if-no-files-found: warn
+
+  suite:
+    name: full suite (needs a seeded backend)
+    needs: smoke
+    if: inputs.run_full_suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deliberately fails fast and loudly rather than running flows that cannot pass. The
+      # flows sign in as mobile_seller1_do_not_edit@gumroad.com and open real purchases, so
+      # without a seeded backend every one of them fails on the login step and the output
+      # tells you nothing about the app.
+      - name: Check a seeded backend was provided
+        env:
+          BACKEND_URL: ${{ secrets.E2E_GUMROAD_URL }}
+        run: |
+          if [ -z "$BACKEND_URL" ]; then
+            echo "::error::The full Maestro suite needs a seeded Gumroad backend, but the"
+            echo "::error::E2E_GUMROAD_URL secret is not set. See .github/workflows/e2e.yml"
+            echo "::error::for what this job still needs. The launch smoke flow runs without it."
+            exit 1
+          fi
+          echo "Using backend $BACKEND_URL"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,47 +1,13 @@
 name: e2e
 
-# Maestro flows drive the real app on an Android emulator. There are two jobs because the
-# flows have two very different requirements:
-#
-#   smoke  — .maestro/launch-smoke.yaml only. Installs a standalone build, launches it, and
-#            asserts the signed-out cold start lands on the login screen. It touches no
-#            backend, so it can gate every pull request. It catches the failures that matter
-#            most and are invisible to jest: a build that will not boot, a crash on launch, a
-#            broken root layout, a routing change that blanks the screen for a signed-out user.
-#
-#   suite  — the whole .maestro directory. Those flows sign in as a real seller and open real
-#            purchases, so they need a reachable Gumroad backend with seeded data (.env points
-#            at http://localhost:3000). No GitHub runner has one, so this job is manual and
-#            expects a self-hosted runner, or the Rails app booted as a service here, before it
-#            can be trusted. Wiring it to pull_request today would paint every PR red and teach
-#            everyone to ignore the check.
 on:
   pull_request:
-    paths:
-      - ".maestro/**"
-      - "app/**"
-      - "components/**"
-      - "lib/**"
-      - "modules/**"
-      - "patches/**"
-      - "app.config.ts"
-      - "package.json"
-      - "package-lock.json"
-      - ".github/workflows/e2e.yml"
   push:
     branches: [main]
-  workflow_dispatch:
-    inputs:
-      run_full_suite:
-        description: "Also run the flows that need a seeded backend"
-        type: boolean
-        default: false
 
 permissions:
   contents: read
 
-# Each run boots an emulator and builds the app, so overlapping runs on one branch just
-# compete for the runner. A newer push makes an in-flight run obsolete.
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -49,45 +15,21 @@ concurrency:
 jobs:
   smoke:
     name: launch smoke (no backend)
-    # The Android emulator needs nested virtualisation (KVM), which the Ubuntu runners
-    # provide and the macOS runners do not.
     runs-on: ubuntu-latest
-    # A release build costs noticeably more than the debug build this job used to make: it
-    # compiles the Hermes bundle and runs the release-only packaging tasks on top of the same
-    # native compile. Locally, x86_64-only, that was 2m for assembleDebug against 9m for
-    # assembleRelease. The old 45-minute ceiling was sized for the debug build and was already
-    # being hit, and hitting it is the worst outcome available: a cancelled job discards the
-    # artifact upload, so you lose the report and the recording and learn nothing but "The
-    # operation was canceled". The `timeout` wrapped around the flow itself is the guard that
-    # is supposed to fire, because it fails the step and keeps the evidence.
     timeout-minutes: 60
-
-    # These have to be job-level, not per-step. app.config.ts reads them from the environment,
-    # and it is evaluated twice: once by `expo prebuild`, and again during the Gradle build by
-    # expo-constants' createExpoConfig task. Locally the second read still works because Expo
-    # loads the gitignored .env, but a CI checkout has no .env, so the config came back with
-    # ios.bundleIdentifier undefined and the expo-widgets plugin aborted the Gradle build with
-    # "iOS bundle identifier is required". Setting them for the whole job means every read of
-    # app.config.ts sees the same values, so the built APK and the package Maestro drives
-    # cannot drift apart either. These are the dev ids from .env, not the store ids in
-    # .env.build.local.
     env:
       ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
       IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
-      # The smoke flow never reaches the API, so the backend URL only has to be well-formed.
-      # 10.0.2.2 is the emulator's alias for the host. Using a literal keeps this job
-      # independent of repository secrets, which is what lets it run on forks and every PR.
       EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
       EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
-      # lib/env.ts asserts these two are defined and throws at import time if either is
-      # missing, which kills the app before the first frame renders. Expo inlines every
-      # EXPO_PUBLIC_* value into the JS bundle at BUILD time, so they have to be present when
-      # the bundle is built, not merely when the app runs. Locally the gitignored .env supplies
-      # them, so a missing value is invisible until CI builds without it. These placeholders
-      # are only ever used to get past that assertion: the smoke flow stops at the login
-      # screen and never starts an OAuth exchange, so no real client id or token is involved.
       EXPO_PUBLIC_GUMROAD_CLIENT_ID: ci-smoke-placeholder-client-id
       EXPO_PUBLIC_MOBILE_TOKEN: ci-smoke-placeholder-mobile-token
+      ANDROID_KEYSTORE_PASSWORD: ci-smoke-throwaway
+      ANDROID_KEY_ALIAS: ci-smoke
+      ANDROID_KEY_PASSWORD: ci-smoke-throwaway
+      SENTRY_DISABLE_AUTO_UPLOAD: "true"
+      MAESTRO_VERSION: "2.7.0"
+      MAESTRO_CLI_NO_ANALYTICS: "true"
 
     steps:
       - uses: actions/checkout@v4
@@ -98,8 +40,6 @@ jobs:
           node-version: 20
           cache: npm
 
-      # --ignore-scripts skips the postinstall that applies patch-package, so run it
-      # explicitly: the repo carries patches/ that the app depends on at runtime.
       - run: npm ci --ignore-scripts
       - run: npx patch-package
 
@@ -120,6 +60,7 @@ jobs:
         run: |
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+          "$HOME/.maestro/bin/maestro" --version
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -127,19 +68,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('android/gradle/wrapper/gradle-wrapper.properties', 'package-lock.json') }}
+          key: gradle-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: gradle-${{ runner.os }}-
 
-      # The smoke flow never reaches the API, so the backend URL only has to be well-formed.
-      # A placeholder keeps this job independent of repository secrets, which is what lets it
-      # run on forks and on every PR.
-      # app.config.ts sets googleServicesFile: "./google-services.json" unconditionally, and
-      # that file is gitignored (it carries the real Firebase project's keys), so prebuild
-      # fails on a fresh checkout with "Cannot copy google-services.json". The smoke flow
-      # never signs in for push notifications or reports analytics, so a structurally valid
-      # placeholder with obviously-fake ids is enough to get through prebuild. Anything that
-      # actually exercises Firebase needs the real file supplied as a secret.
-      - name: Write a placeholder google-services.json
+      - name: Write placeholder Firebase config
         run: |
           cat > google-services.json <<JSON
           {
@@ -162,34 +94,22 @@ jobs:
             "configuration_version": "1"
           }
           JSON
-          node -e "JSON.parse(require('fs').readFileSync('google-services.json','utf8')); console.log('placeholder google-services.json is valid JSON')"
+          node -e "JSON.parse(require('fs').readFileSync('google-services.json', 'utf8'))"
 
-      - name: Generate the native Android project
+      - name: Generate Android project
         run: npx expo prebuild --platform android --clean
 
-      # The Gradle build re-evaluates app.config.ts, and a missing bundle id only surfaces
-      # there, several minutes into the emulator step. Fail here instead, with a message that
-      # names the cause.
-      - name: Confirm the config resolves the same way Gradle will read it
+      - name: Validate generated config
         run: |
           npx expo config --type prebuild --json > /tmp/expo-config.json
           node -e "
-            const c = require('/tmp/expo-config.json');
-            const missing = [
-              !c.android?.package && 'android.package (ANDROID_BUNDLE_NAME)',
-              !c.ios?.bundleIdentifier && 'ios.bundleIdentifier (IOS_BUNDLE_NAME)',
-            ].filter(Boolean);
-            if (missing.length) {
-              console.error('::error::app.config.ts resolved without ' + missing.join(', ') + '. The Gradle createExpoConfig task reads the same config, and expo-widgets aborts the build when the iOS bundle identifier is absent.');
-              process.exit(1);
+            const config = require('/tmp/expo-config.json');
+            if (!config.android?.package || !config.ios?.bundleIdentifier) {
+              throw new Error('app.config.ts must resolve Android and iOS bundle identifiers');
             }
-            console.log('Config resolves with android.package ' + c.android.package + ' and ios.bundleIdentifier ' + c.ios.bundleIdentifier);
           "
 
-      # Read the id back out of the generated Gradle config rather than trusting the variable
-      # above: if prebuild ever resolves it differently, installing and driving the wrong
-      # package would fail in a confusing way.
-      - name: Confirm the built application id
+      - name: Read application ID
         id: app_id
         run: |
           app_id=$(grep -m1 -oE 'applicationId .[^"'"'"']+' android/app/build.gradle \
@@ -199,115 +119,35 @@ jobs:
             exit 1
           fi
           echo "value=$app_id" >> "$GITHUB_OUTPUT"
-          echo "Built application id: $app_id"
 
-      # The smoke flow needs a RELEASE build, and a release build has to be signed. This
-      # generates a throwaway keystore rather than carrying one as a secret: nothing here is
-      # published, and the flow only cares that the APK installs and launches. Real store
-      # builds sign with the upload keystore from the release workflow's secrets.
-      #
-      # This has to run AFTER `expo prebuild --clean`, which deletes and regenerates the whole
-      # android/ directory -- a keystore written before it silently disappears.
-      - name: Generate a throwaway signing key for the release build
+      - name: Generate signing key
         run: |
           keytool -genkeypair -v \
             -keystore android/app/upload-keystore.jks \
-            -alias ci-smoke -keyalg RSA -keysize 2048 -validity 30 \
-            -storepass ci-smoke-throwaway -keypass ci-smoke-throwaway \
+            -alias "$ANDROID_KEY_ALIAS" -keyalg RSA -keysize 2048 -validity 30 \
+            -storepass "$ANDROID_KEYSTORE_PASSWORD" -keypass "$ANDROID_KEY_PASSWORD" \
             -dname "CN=gumroad-mobile CI smoke, O=Gumroad, C=US"
 
-      - name: Run the launch smoke flow
+      - name: Run launch smoke
         uses: reactivecircus/android-emulator-runner@v2
         env:
-          # Every flow declares `appId: ${APP_ID}`, so the suite cannot run without it.
           APP_ID: ${{ steps.app_id.outputs.value }}
-          # The Gradle build re-evaluates app.config.ts through expo-constants'
-          # createExpoConfig task, so these have to be present here too, not just for
-          # prebuild. Without IOS_BUNDLE_NAME that task fails the Android build with
-          # "iOS bundle identifier is required" — confusing, because nothing about this
-          # job touches iOS.
-          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
-          IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
-          EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
-          EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
-          # Required by lib/env.ts, and inlined into the bundle by the Gradle build that runs
-          # inside this step -- so they must be here, not only on the job. See the job-level
-          # env block for why these are placeholders.
-          EXPO_PUBLIC_GUMROAD_CLIENT_ID: ci-smoke-placeholder-client-id
-          EXPO_PUBLIC_MOBILE_TOKEN: ci-smoke-placeholder-mobile-token
-          # Read by the release signingConfig in android/app/build.gradle. Throwaway values
-          # matching the keystore generated in the previous step.
-          ANDROID_KEYSTORE_PASSWORD: ci-smoke-throwaway
-          ANDROID_KEY_ALIAS: ci-smoke
-          ANDROID_KEY_PASSWORD: ci-smoke-throwaway
-          # A release build uploads its JavaScript source maps to Sentry, and that upload is a
-          # hard failure of the Gradle build when it cannot authenticate. android/ is
-          # gitignored, so `expo prebuild` regenerates android/sentry.properties from the
-          # @sentry/react-native config plugin, which fills in the organization from SENTRY_ORG
-          # and SENTRY_PROJECT. Those are unset here, because this job deliberately depends on
-          # no repository secrets so it can run on forks. The regenerated file therefore has no
-          # organization and sentry-cli exits 1 with "An organization ID or slug is required",
-          # failing the build after eleven minutes. Locally this is invisible: the gitignored
-          # .env sets SENTRY_ALLOW_FAILURE, which downgrades the same error to a warning.
-          #
-          # Nothing about a throwaway smoke build belongs in Sentry, so skip the upload
-          # entirely rather than tolerate its failure. The JS bundle is still built and
-          # embedded in the APK, which is all the flow needs.
-          SENTRY_DISABLE_AUTO_UPLOAD: "true"
         with:
           api-level: 34
           target: google_apis
           arch: x86_64
           profile: pixel_6
-          # Headless, no boot animation, no audio: nothing here needs a visible window and the
-          # emulator boots noticeably faster without them.
           emulator-options: -no-window -no-snapshot-save -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: |
-            # prebuild generates the Gradle wrapper inside android/, not at the repo root.
             chmod +x android/gradlew
-            # RELEASE, not debug. This project depends on expo-dev-client, which makes
-            # DevLauncherActivity the launcher activity of every DEBUG build, and React
-            # Native's default `debuggableVariants = ["debug"]` means a debug APK embeds no JS
-            # bundle at all. So a debug APK cannot run the app standalone by design: it boots
-            # the "Development Build / DEVELOPMENT SERVERS / npx expo start" launcher and waits
-            # for a Metro server that no CI runner has. A release build embeds the Hermes
-            # bundle and launches MainActivity directly, which is what the flow asserts on.
-            #
-            # Build native code for the emulator's ABI only. The default in
-            # android/gradle.properties is all four (armeabi-v7a, arm64-v8a, x86, x86_64), so
-            # CMake was compiling reanimated, expo-modules-core and the app three extra times
-            # for architectures this job can never run -- 28 of the job's 45 minutes.
             ./android/gradlew -p android assembleRelease -PreactNativeArchitectures=x86_64
-            # Assert the JS bundle really is inside the APK. Without this, a variant or
-            # bundling regression reappears as the confusing "the app launched but the login
-            # screen never rendered" failure, 15 minutes into the job.
-            unzip -l android/app/build/outputs/apk/release/app-release.apk | grep -q assets/index.android.bundle || { echo "::error::app-release.apk carries no assets/index.android.bundle, so the app cannot run without a Metro server. Check react.debuggableVariants and that this is a release variant."; exit 1; }
-            # Hand the emulator back the RAM and cores the build was using. The daemon
-            # otherwise stays resident for the rest of the job, and adb operations against a
-            # starved emulator can stall indefinitely rather than fail.
+            unzip -l android/app/build/outputs/apk/release/app-release.apk | grep -q assets/index.android.bundle
             ./android/gradlew -p android --stop
             adb install -r android/app/build/outputs/apk/release/app-release.apk
-            # Every line in this block is run as its own separate shell by
-            # android-emulator-runner, so multi-line shell constructs (if/then/fi, loops,
-            # heredocs) are not possible here and variables do not carry between lines.
-            #
-            # Maestro does not read APP_ID out of the surrounding shell environment; a flow
-            # variable has to be handed to it with -e, which is how this repo's own
-            # e2e:android:run script invokes it. Without -e, Maestro substitutes the literal
-            # string "undefined" and the run dies with the misleading "Package undefined is
-            # not installed" -- minutes in, after a clean build and install have succeeded.
-            #
-            # The outer `timeout` is what makes a stuck flow diagnosable. The flow's own
-            # extendedWaitUntil only bounds the wait for a view, not the adb calls before it,
-            # so a wedged emulator leaves Maestro hanging on "Clear state" until the job-level
-            # timeout cancels everything -- and a cancelled job discards the artifact upload,
-            # so you get no report and no recording, only "The operation was canceled". Failing
-            # the step ourselves keeps the evidence.
             timeout --signal=TERM --kill-after=60s 12m maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 
-      # A failed flow is unreadable without its recording, so upload evidence either way.
-      - name: Upload the report and recordings
+      - name: Upload smoke artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
@@ -317,29 +157,3 @@ jobs:
             ~/.maestro/tests/**
           retention-days: 14
           if-no-files-found: warn
-
-  suite:
-    name: full suite (needs a seeded backend)
-    needs: smoke
-    if: inputs.run_full_suite
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # Deliberately fails fast and loudly rather than running flows that cannot pass. The
-      # flows sign in as mobile_seller1_do_not_edit@gumroad.com and open real purchases, so
-      # without a seeded backend every one of them fails on the login step and the output
-      # tells you nothing about the app.
-      - name: Check a seeded backend was provided
-        env:
-          BACKEND_URL: ${{ secrets.E2E_GUMROAD_URL }}
-        run: |
-          if [ -z "$BACKEND_URL" ]; then
-            echo "::error::The full Maestro suite needs a seeded Gumroad backend, but the"
-            echo "::error::E2E_GUMROAD_URL secret is not set. See .github/workflows/e2e.yml"
-            echo "::error::for what this job still needs. The launch smoke flow runs without it."
-            exit 1
-          fi
-          echo "Using backend $BACKEND_URL"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,6 +184,21 @@ jobs:
           echo "value=$app_id" >> "$GITHUB_OUTPUT"
           echo "Built application id: $app_id"
 
+      # The smoke flow needs a RELEASE build, and a release build has to be signed. This
+      # generates a throwaway keystore rather than carrying one as a secret: nothing here is
+      # published, and the flow only cares that the APK installs and launches. Real store
+      # builds sign with the upload keystore from the release workflow's secrets.
+      #
+      # This has to run AFTER `expo prebuild --clean`, which deletes and regenerates the whole
+      # android/ directory -- a keystore written before it silently disappears.
+      - name: Generate a throwaway signing key for the release build
+        run: |
+          keytool -genkeypair -v \
+            -keystore android/app/upload-keystore.jks \
+            -alias ci-smoke -keyalg RSA -keysize 2048 -validity 30 \
+            -storepass ci-smoke-throwaway -keypass ci-smoke-throwaway \
+            -dname "CN=gumroad-mobile CI smoke, O=Gumroad, C=US"
+
       - name: Run the launch smoke flow
         uses: reactivecircus/android-emulator-runner@v2
         env:
@@ -198,6 +213,11 @@ jobs:
           IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
           EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
           EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
+          # Read by the release signingConfig in android/app/build.gradle. Throwaway values
+          # matching the keystore generated in the previous step.
+          ANDROID_KEYSTORE_PASSWORD: ci-smoke-throwaway
+          ANDROID_KEY_ALIAS: ci-smoke
+          ANDROID_KEY_PASSWORD: ci-smoke-throwaway
         with:
           api-level: 34
           target: google_apis
@@ -210,18 +230,28 @@ jobs:
           script: |
             # prebuild generates the Gradle wrapper inside android/, not at the repo root.
             chmod +x android/gradlew
+            # RELEASE, not debug. This project depends on expo-dev-client, which makes
+            # DevLauncherActivity the launcher activity of every DEBUG build, and React
+            # Native's default `debuggableVariants = ["debug"]` means a debug APK embeds no JS
+            # bundle at all. So a debug APK cannot run the app standalone by design: it boots
+            # the "Development Build / DEVELOPMENT SERVERS / npx expo start" launcher and waits
+            # for a Metro server that no CI runner has. A release build embeds the Hermes
+            # bundle and launches MainActivity directly, which is what the flow asserts on.
+            #
             # Build native code for the emulator's ABI only. The default in
-            # android/gradle.properties is all four (armeabi-v7a, arm64-v8a, x86, x86_64),
-            # which is right for a release build but means CMake compiles reanimated,
-            # expo-modules-core and the app three extra times for architectures this job can
-            # never run. That was 28 of the job's 45 minutes, and it left too little room for
-            # the flow itself.
-            ./android/gradlew -p android assembleDebug -PreactNativeArchitectures=x86_64
+            # android/gradle.properties is all four (armeabi-v7a, arm64-v8a, x86, x86_64), so
+            # CMake was compiling reanimated, expo-modules-core and the app three extra times
+            # for architectures this job can never run -- 28 of the job's 45 minutes.
+            ./android/gradlew -p android assembleRelease -PreactNativeArchitectures=x86_64
+            # Assert the JS bundle really is inside the APK. Without this, a variant or
+            # bundling regression reappears as the confusing "the app launched but the login
+            # screen never rendered" failure, 15 minutes into the job.
+            unzip -l android/app/build/outputs/apk/release/app-release.apk | grep -q assets/index.android.bundle || { echo "::error::app-release.apk carries no assets/index.android.bundle, so the app cannot run without a Metro server. Check react.debuggableVariants and that this is a release variant."; exit 1; }
             # Hand the emulator back the RAM and cores the build was using. The daemon
             # otherwise stays resident for the rest of the job, and adb operations against a
             # starved emulator can stall indefinitely rather than fail.
             ./android/gradlew -p android --stop
-            adb install -r android/app/build/outputs/apk/debug/app-debug.apk
+            adb install -r android/app/build/outputs/apk/release/app-release.apk
             # Every line in this block is run as its own separate shell by
             # android-emulator-runner, so multi-line shell constructs (if/then/fi, loops,
             # heredocs) are not possible here and variables do not carry between lines.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,6 +98,39 @@ jobs:
       # The smoke flow never reaches the API, so the backend URL only has to be well-formed.
       # A placeholder keeps this job independent of repository secrets, which is what lets it
       # run on forks and on every PR.
+      # app.config.ts sets googleServicesFile: "./google-services.json" unconditionally, and
+      # that file is gitignored (it carries the real Firebase project's keys), so prebuild
+      # fails on a fresh checkout with "Cannot copy google-services.json". The smoke flow
+      # never signs in for push notifications or reports analytics, so a structurally valid
+      # placeholder with obviously-fake ids is enough to get through prebuild. Anything that
+      # actually exercises Firebase needs the real file supplied as a secret.
+      - name: Write a placeholder google-services.json
+        env:
+          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
+        run: |
+          cat > google-services.json <<JSON
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "gumroad-mobile-ci-placeholder",
+              "storage_bucket": "gumroad-mobile-ci-placeholder.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": { "package_name": "${ANDROID_BUNDLE_NAME}" }
+                },
+                "oauth_client": [],
+                "api_key": [{ "current_key": "AIzaSyCI0000000000000000000000000000000" }],
+                "services": { "appinvite_service": { "other_platform_oauth_client": [] } }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          JSON
+          node -e "JSON.parse(require('fs').readFileSync('google-services.json','utf8')); console.log('placeholder google-services.json is valid JSON')"
+
       # app.config.ts reads the package name from ANDROID_BUNDLE_NAME, so the same value has
       # to reach both prebuild and Maestro's APP_ID. Setting it once here keeps the installed
       # APK and the flow's target from drifting apart. This is the dev id from .env, not the

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -54,6 +54,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
+    # These have to be job-level, not per-step. app.config.ts reads them from the environment,
+    # and it is evaluated twice: once by `expo prebuild`, and again during the Gradle build by
+    # expo-constants' createExpoConfig task. Locally the second read still works because Expo
+    # loads the gitignored .env, but a CI checkout has no .env, so the config came back with
+    # ios.bundleIdentifier undefined and the expo-widgets plugin aborted the Gradle build with
+    # "iOS bundle identifier is required". Setting them for the whole job means every read of
+    # app.config.ts sees the same values, so the built APK and the package Maestro drives
+    # cannot drift apart either. These are the dev ids from .env, not the store ids in
+    # .env.build.local.
+    env:
+      ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
+      IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
+      # The smoke flow never reaches the API, so the backend URL only has to be well-formed.
+      # 10.0.2.2 is the emulator's alias for the host. Using a literal keeps this job
+      # independent of repository secrets, which is what lets it run on forks and every PR.
+      EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
+      EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
+
     steps:
       - uses: actions/checkout@v4
 
@@ -105,8 +123,6 @@ jobs:
       # placeholder with obviously-fake ids is enough to get through prebuild. Anything that
       # actually exercises Firebase needs the real file supplied as a secret.
       - name: Write a placeholder google-services.json
-        env:
-          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
         run: |
           cat > google-services.json <<JSON
           {
@@ -131,17 +147,27 @@ jobs:
           JSON
           node -e "JSON.parse(require('fs').readFileSync('google-services.json','utf8')); console.log('placeholder google-services.json is valid JSON')"
 
-      # app.config.ts reads the package name from ANDROID_BUNDLE_NAME, so the same value has
-      # to reach both prebuild and Maestro's APP_ID. Setting it once here keeps the installed
-      # APK and the flow's target from drifting apart. This is the dev id from .env, not the
-      # store id in .env.build.local.
       - name: Generate the native Android project
-        env:
-          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
-          IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
-          EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
-          EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
         run: npx expo prebuild --platform android --clean
+
+      # The Gradle build re-evaluates app.config.ts, and a missing bundle id only surfaces
+      # there, several minutes into the emulator step. Fail here instead, with a message that
+      # names the cause.
+      - name: Confirm the config resolves the same way Gradle will read it
+        run: |
+          npx expo config --type prebuild --json > /tmp/expo-config.json
+          node -e "
+            const c = require('/tmp/expo-config.json');
+            const missing = [
+              !c.android?.package && 'android.package (ANDROID_BUNDLE_NAME)',
+              !c.ios?.bundleIdentifier && 'ios.bundleIdentifier (IOS_BUNDLE_NAME)',
+            ].filter(Boolean);
+            if (missing.length) {
+              console.error('::error::app.config.ts resolved without ' + missing.join(', ') + '. The Gradle createExpoConfig task reads the same config, and expo-widgets aborts the build when the iOS bundle identifier is absent.');
+              process.exit(1);
+            }
+            console.log('Config resolves with android.package ' + c.android.package + ' and ios.bundleIdentifier ' + c.ios.bundleIdentifier);
+          "
 
       # Read the id back out of the generated Gradle config rather than trusting the variable
       # above: if prebuild ever resolves it differently, installing and driving the wrong
@@ -163,6 +189,15 @@ jobs:
         env:
           # Every flow declares `appId: ${APP_ID}`, so the suite cannot run without it.
           APP_ID: ${{ steps.app_id.outputs.value }}
+          # The Gradle build re-evaluates app.config.ts through expo-constants'
+          # createExpoConfig task, so these have to be present here too, not just for
+          # prebuild. Without IOS_BUNDLE_NAME that task fails the Android build with
+          # "iOS bundle identifier is required" — confusing, because nothing about this
+          # job touches iOS.
+          ANDROID_BUNDLE_NAME: com.antiwork.gumroadmobile
+          IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
+          EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
+          EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
         with:
           api-level: 34
           target: google_apis

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -52,7 +52,15 @@ jobs:
     # The Android emulator needs nested virtualisation (KVM), which the Ubuntu runners
     # provide and the macOS runners do not.
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # A release build costs noticeably more than the debug build this job used to make: it
+    # compiles the Hermes bundle and runs the release-only packaging tasks on top of the same
+    # native compile. Locally, x86_64-only, that was 2m for assembleDebug against 9m for
+    # assembleRelease. The old 45-minute ceiling was sized for the debug build and was already
+    # being hit, and hitting it is the worst outcome available: a cancelled job discards the
+    # artifact upload, so you lose the report and the recording and learn nothing but "The
+    # operation was canceled". The `timeout` wrapped around the flow itself is the guard that
+    # is supposed to fire, because it fails the step and keeps the evidence.
+    timeout-minutes: 60
 
     # These have to be job-level, not per-step. app.config.ts reads them from the environment,
     # and it is evaluated twice: once by `expo prebuild`, and again during the Gradle build by

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,6 +79,15 @@ jobs:
       # independent of repository secrets, which is what lets it run on forks and every PR.
       EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
       EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
+      # lib/env.ts asserts these two are defined and throws at import time if either is
+      # missing, which kills the app before the first frame renders. Expo inlines every
+      # EXPO_PUBLIC_* value into the JS bundle at BUILD time, so they have to be present when
+      # the bundle is built, not merely when the app runs. Locally the gitignored .env supplies
+      # them, so a missing value is invisible until CI builds without it. These placeholders
+      # are only ever used to get past that assertion: the smoke flow stops at the login
+      # screen and never starts an OAuth exchange, so no real client id or token is involved.
+      EXPO_PUBLIC_GUMROAD_CLIENT_ID: ci-smoke-placeholder-client-id
+      EXPO_PUBLIC_MOBILE_TOKEN: ci-smoke-placeholder-mobile-token
 
     steps:
       - uses: actions/checkout@v4
@@ -221,6 +230,11 @@ jobs:
           IOS_BUNDLE_NAME: com.antiwork.gumroadmobile
           EXPO_PUBLIC_GUMROAD_URL: http://10.0.2.2:3000
           EXPO_PUBLIC_GUMROAD_API_URL: http://10.0.2.2:3000
+          # Required by lib/env.ts, and inlined into the bundle by the Gradle build that runs
+          # inside this step -- so they must be here, not only on the job. See the job-level
+          # env block for why these are placeholders.
+          EXPO_PUBLIC_GUMROAD_CLIENT_ID: ci-smoke-placeholder-client-id
+          EXPO_PUBLIC_MOBILE_TOKEN: ci-smoke-placeholder-mobile-token
           # Read by the release signingConfig in android/app/build.gradle. Throwaway values
           # matching the keystore generated in the previous step.
           ANDROID_KEYSTORE_PASSWORD: ci-smoke-throwaway

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -226,6 +226,20 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ci-smoke-throwaway
           ANDROID_KEY_ALIAS: ci-smoke
           ANDROID_KEY_PASSWORD: ci-smoke-throwaway
+          # A release build uploads its JavaScript source maps to Sentry, and that upload is a
+          # hard failure of the Gradle build when it cannot authenticate. android/ is
+          # gitignored, so `expo prebuild` regenerates android/sentry.properties from the
+          # @sentry/react-native config plugin, which fills in the organization from SENTRY_ORG
+          # and SENTRY_PROJECT. Those are unset here, because this job deliberately depends on
+          # no repository secrets so it can run on forks. The regenerated file therefore has no
+          # organization and sentry-cli exits 1 with "An organization ID or slug is required",
+          # failing the build after eleven minutes. Locally this is invisible: the gitignored
+          # .env sets SENTRY_ALLOW_FAILURE, which downgrades the same error to a warning.
+          #
+          # Nothing about a throwaway smoke build belongs in Sentry, so skip the upload
+          # entirely rather than tolerate its failure. The JS bundle is still built and
+          # embedded in the APK, which is all the flow needs.
+          SENTRY_DISABLE_AUTO_UPLOAD: "true"
         with:
           api-level: 34
           target: google_apis

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -212,7 +212,16 @@ jobs:
             chmod +x android/gradlew
             ./android/gradlew -p android assembleDebug
             adb install -r android/app/build/outputs/apk/debug/app-debug.apk
-            maestro test --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
+            # Maestro does not read APP_ID out of the surrounding shell environment; a flow
+            # variable has to be handed to it with -e, which is how this repo's own
+            # e2e:android:run script invokes it. Without -e, Maestro substitutes the literal
+            # string "undefined" and the run dies with the misleading "Package undefined is
+            # not installed" -- minutes in, after a clean build and install have succeeded.
+            if [ -z "$APP_ID" ]; then
+              echo "::error::APP_ID is empty, so Maestro would drive a package named 'undefined'."
+              exit 1
+            fi
+            maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 
       # A failed flow is unreadable without its recording, so upload evidence either way.
       - name: Upload the report and recordings

--- a/.maestro/launch-smoke.yaml
+++ b/.maestro/launch-smoke.yaml
@@ -1,0 +1,27 @@
+appId: ${APP_ID}
+---
+# Cold-start smoke test for a STANDALONE build, deliberately backend-free.
+#
+# Every other flow in this directory signs in and then reads real data, so they need a
+# seeded Gumroad backend the emulator can reach. This one asserts only what the app can do
+# on its own: install, launch, survive the unauthenticated cold-start path in app/index.tsx,
+# and land on the login screen (which renders no network data). That makes it the one flow
+# that can gate a pull request today, and it still catches the failures that matter most --
+# a build that will not boot, a crash on launch, a broken root layout, or a routing change
+# that leaves a signed-out user staring at a blank screen.
+#
+# Do NOT add assertions here that need a signed-in session or seeded products. Those belong
+# in the flows that run behind the seeded-backend job.
+- killApp
+- clearState
+- clearKeychain
+- launchApp
+
+# app/index.tsx sends a signed-out user to /login. It caps its first-launch network probe so
+# a cold start cannot hang, so the redirect must land even with no backend reachable at all.
+- extendedWaitUntil:
+    visible: "Sign in with Gumroad"
+    timeout: 45000
+
+# The button being tappable proves the screen is interactive, not a frozen first frame.
+- assertVisible: "Sign in with Gumroad"

--- a/.maestro/launch-smoke.yaml
+++ b/.maestro/launch-smoke.yaml
@@ -1,27 +1,10 @@
 appId: ${APP_ID}
 ---
-# Cold-start smoke test for a STANDALONE build, deliberately backend-free.
-#
-# Every other flow in this directory signs in and then reads real data, so they need a
-# seeded Gumroad backend the emulator can reach. This one asserts only what the app can do
-# on its own: install, launch, survive the unauthenticated cold-start path in app/index.tsx,
-# and land on the login screen (which renders no network data). That makes it the one flow
-# that can gate a pull request today, and it still catches the failures that matter most --
-# a build that will not boot, a crash on launch, a broken root layout, or a routing change
-# that leaves a signed-out user staring at a blank screen.
-#
-# Do NOT add assertions here that need a signed-in session or seeded products. Those belong
-# in the flows that run behind the seeded-backend job.
 - killApp
 - clearState
 - clearKeychain
 - launchApp
 
-# app/index.tsx sends a signed-out user to /login. It caps its first-launch network probe so
-# a cold start cannot hang, so the redirect must land even with no backend reachable at all.
 - extendedWaitUntil:
     visible: "Sign in with Gumroad"
     timeout: 45000
-
-# The button being tappable proves the screen is interactive, not a frozen first frame.
-- assertVisible: "Sign in with Gumroad"


### PR DESCRIPTION
## What

Adds an Android launch smoke test that runs on every pull request and push to `main`.

The workflow builds a standalone x86_64 release APK, installs it on an API 34 emulator, and verifies that a signed-out cold start reaches the login screen without a backend. It uploads the Maestro JUnit report and recording on success or failure.

The existing signed-in Maestro flows still require a reachable seeded Gumroad backend. This PR does not expose a placeholder full-suite job that can report success without running them.

## Why

Jest cannot catch a native build that fails, an APK that lacks its JavaScript bundle, a launch crash, or a broken initial route. This gives those regressions a real Android runtime gate while keeping the check independent of repository secrets.

The smoke test runs for every pull request so changes to entrypoints, Metro config, Expo plugins, assets, and other build inputs cannot bypass it.

## Before/After

CI-only change. [Successful emulator run and recording](https://github.com/antiwork/gumroad-mobile/actions/runs/30316028896/artifacts/8672447801).

## Test Results

- `actionlint .github/workflows/e2e.yml`
- Prettier check for the workflow and smoke flow
- TypeScript check
- ESLint: zero errors, one existing warning in `app/login.tsx`
- [Jest: 48 suites, 401 tests, zero failures](https://github.com/antiwork/gumroad-mobile/actions/runs/30316028811)
- [Maestro 2.7.0: 1/1 flow passed](https://github.com/antiwork/gumroad-mobile/actions/runs/30316028896)
- Codex autoreview: clean, no actionable findings

---

**AI disclosure:** The original workflow was generated with Claude Opus 5. Review fixes were implemented with OpenAI Codex and reviewed with `gpt-5.6-sol`. Prompts: “wire maestro into CI” and “fix review findings, run autoreview, and push without force.”
