### PR TITLE
Hide emulator error dialogs during the Android launch smoke

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,6 +144,10 @@ jobs:
             ./android/gradlew -p android assembleRelease -PreactNativeArchitectures=x86_64
             unzip -l android/app/build/outputs/apk/release/app-release.apk | grep -q assets/index.android.bundle
             ./android/gradlew -p android --stop
+            # The emulator's Pixel Launcher intermittently ANRs while the release build
+            # installs, and its "isn't responding" dialog then covers our app, so the
+            # launch assertion inspects the dialog instead of the login screen.
+            adb shell settings put global hide_error_dialogs 1
             adb install -r android/app/build/outputs/apk/release/app-release.apk
             timeout --signal=TERM --kill-after=60s 12m maestro test -p android -e APP_ID="$APP_ID" --format junit --output maestro-report.xml .maestro/launch-smoke.yaml
 


### PR DESCRIPTION
Unbreaks `main`.

## What broke

The `e2e` launch smoke on `main` fails with:

```
[Failed] launch-smoke (51s) (Assertion is false: "Sign in with Gumroad" is visible)
```

The workflow name suggests an app regression, but the app is fine. The failure is an emulator infrastructure problem.

## Evidence

The `maestro-smoke-results` artifact records the view hierarchy at the moment the assertion ran. The topmost window is not our app:

```
"Pixel Launcher isn't responding"   android:id/alertTitle
  "Close app"  android:id/aerr_close
  "Wait"       android:id/aerr_wait
```

`aerr_close` / `aerr_wait` are the Android ANR dialog. The Pixel Launcher ANRed while the release APK was installing, and its dialog sat on top of the app, so Maestro queried the dialog's hierarchy and correctly concluded that `Sign in with Gumroad` was not visible.

The app itself started normally in the same logcat:

```
I/ReactNativeJS: Running "main"
I/ActivityTaskManager: Displayed com.antiwork.gumroadmobile/.MainActivity for user 0: +2s427ms
D/SplashScreenView: remove starting view
```

No `FATAL EXCEPTION`, no crash, no JS error. The only app-scoped errors are the expected `Firebase-Installations` / `FirebaseMessaging` failures caused by the intentional placeholder `google-services.json` this workflow writes, which are unrelated to the login screen.

## It is not the merge that preceded it

`main` went red right after "Fix: Preserve WebView sessions" (#331), which made it a natural suspect. It is not the cause: the merge commit `7f2514b` and the PR branch head `cb50359a` have the identical tree `1b02f5dba09a128d51415124ba7f91f2aaac71fc`, and `e2e` passed on that exact tree three times on the branch. The only commit after it, `0883e69`, changes one line — the iOS `buildNumber` — which the Android job never reads.

I re-ran the failed job to check for a flake and it failed the same way, with the same launcher ANR dialog in the artifact. So it reproduces, but the cause is the emulator, not our code.

## Fix

Suppress system error dialogs on the emulator before installing, so a launcher ANR cannot cover the app under test:

```
adb shell settings put global hide_error_dialogs 1
```

This only hides crash/ANR dialogs belonging to *other* processes on a throwaway CI emulator. It does not mask failures in our app: if the app crashed, it would be absent from the hierarchy and the assertion would still fail.

## Testing

Verified by CI on this PR — the launch smoke is the thing being fixed, so the workflow run is the proof.

- `launch smoke (no backend)`: pass in 15m23s — https://github.com/antiwork/gumroad-mobile/actions/runs/30396724853/job/90401391901
- `test`: pass in 1m3s — https://github.com/antiwork/gumroad-mobile/actions/runs/30396727189/job/90401399647
- YAML parses and Prettier reports no changes.

No user-facing surface changes, so there are no screenshots: the diff is one line in a CI workflow and the app code is untouched.

Reviewed adversarially against the ways this could go wrong — the setting runs after the emulator is ready and before `adb install`, it is a global emulator setting supported by the API 34 google_apis image, and it cannot hide a failure in our own app (a crashed app is absent from the hierarchy, so the assertion still fails). Greptile also came back with no actionable defects and confirmed the setting applied (`adb` readback = 1).

---

## AI disclosure

Written by claude-opus-5 running as the Hermes agent. It was asked to find out why the Android `e2e` launch smoke was failing on `main`, to establish whether the preceding merge caused it, and to fix the real cause. It read the failed run's logcat and `maestro-smoke-results` view-hierarchy artifact, compared the trees of the merge commit and the PR branch head, re-ran the failed job to test for a flake, then made the one-line workflow change above and verified it against a full CI run on this branch.
