### PR TITLE
Send proposal ids from mobile Agent confirms

### DIFF
--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -17,6 +17,7 @@ export interface ProposedAction {
   type: "api_write";
   params: Record<string, unknown>;
   summary: string;
+  proposal_message_id?: string;
   title?: string;
   fields?: ProposedActionField[];
 }
@@ -73,6 +74,7 @@ export const executeAgentAction = async ({
     data: {
       type: action.type,
       params: action.params,
+      ...(action.proposal_message_id ? { proposal_message_id: action.proposal_message_id } : {}),
       ...(conversationId ? { conversation_id: conversationId } : {}),
     },
     accessToken,
@@ -95,6 +97,7 @@ export interface AgentStreamResult {
 interface DoneEventData {
   reply: string;
   proposed_action: ProposedAction | null;
+  proposal_message_id?: string;
   conversation_id?: string;
 }
 
@@ -158,7 +161,12 @@ export const streamAgentMessage = async ({
           const data = raw as DoneEventData;
           return {
             reply: data.reply,
-            proposedAction: data.proposed_action,
+            proposedAction: data.proposed_action
+              ? {
+                  ...data.proposed_action,
+                  ...(data.proposal_message_id ? { proposal_message_id: data.proposal_message_id } : {}),
+                }
+              : null,
             conversationId: data.conversation_id ?? conversationId ?? null,
           };
         }

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -112,6 +112,7 @@ describe("AgentChat", () => {
         type: "api_write",
         params: { code: "LAUNCH", percent_off: 20 },
         summary: "Create a 20% off code called LAUNCH",
+        proposal_message_id: "msg-123",
       },
     });
     mockExecuteAgentAction.mockResolvedValue("Created discount LAUNCH.");
@@ -137,6 +138,7 @@ describe("AgentChat", () => {
         type: "api_write",
         params: { code: "LAUNCH", percent_off: 20 },
         summary: "Create a 20% off code called LAUNCH",
+        proposal_message_id: "msg-123",
       },
     });
   });

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -6,7 +6,7 @@ jest.mock("@/lib/env", () => ({
 const mockFetch = jest.fn();
 jest.mock("expo/fetch", () => ({ fetch: (...args: unknown[]) => mockFetch(...args) }));
 
-import { streamAgentMessage } from "@/lib/agent";
+import { executeAgentAction, streamAgentMessage } from "@/lib/agent";
 import { UnauthorizedError } from "@/lib/request";
 
 const encoder = new TextEncoder();
@@ -116,6 +116,26 @@ describe("streamAgentMessage", () => {
     expect(result.conversationId).toBe("conv-existing");
   });
 
+  it("attaches the proposal message id from the done frame to the proposed action", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse([
+        'event: done\ndata: {"reply":"Ready.","proposed_action":{"type":"api_write","params":{"endpoint":"create_product"},"summary":"Create product"},"proposal_message_id":"msg-123","conversation_id":"conv-3"}\n\n',
+      ]),
+    );
+
+    const result = await streamAgentMessage({
+      messages: [{ role: "user", content: "Create a product" }],
+      accessToken: "token",
+    });
+
+    expect(result.proposedAction).toEqual({
+      type: "api_write",
+      params: { endpoint: "create_product" },
+      summary: "Create product",
+      proposal_message_id: "msg-123",
+    });
+  });
+
   it("throws the server's message on an error event", async () => {
     const response = streamResponse(['event: error\ndata: {"message":"That conversation could not be found."}\n\n']);
     mockFetch.mockResolvedValue(response);
@@ -148,5 +168,50 @@ describe("streamAgentMessage", () => {
     await expect(
       streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
     ).rejects.toThrow("Agent stream ended without a done event");
+  });
+});
+
+describe("executeAgentAction", () => {
+  const mockRequestFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockRequestFetch as unknown as typeof fetch;
+  });
+
+  it("sends the proposal message id with the confirm payload", async () => {
+    mockRequestFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.example.com/mobile/agent/actions",
+      json: jest.fn().mockResolvedValue({ success: true, message: "Created product." }),
+    });
+
+    await expect(
+      executeAgentAction({
+        action: {
+          type: "api_write",
+          params: { endpoint: "create_product" },
+          summary: "Create product",
+          proposal_message_id: "msg-123",
+        },
+        conversationId: "conv-1",
+        accessToken: "token",
+      }),
+    ).resolves.toBe("Created product.");
+
+    expect(mockRequestFetch).toHaveBeenCalledWith(
+      "https://api.example.com/mobile/agent/actions?mobile_token=mobile-token",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          type: "api_write",
+          params: { endpoint: "create_product" },
+          proposal_message_id: "msg-123",
+          conversation_id: "conv-1",
+        }),
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+      }),
+    );
   });
 });

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -172,11 +172,16 @@ describe("streamAgentMessage", () => {
 });
 
 describe("executeAgentAction", () => {
+  const originalFetch = global.fetch;
   const mockRequestFetch = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = mockRequestFetch as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   it("sends the proposal message id with the confirm payload", async () => {
@@ -200,16 +205,17 @@ describe("executeAgentAction", () => {
       }),
     ).resolves.toBe("Created product.");
 
+    const requestBody = JSON.parse(String(mockRequestFetch.mock.calls[0][1]?.body));
+    expect(requestBody).toEqual({
+      type: "api_write",
+      params: { endpoint: "create_product" },
+      proposal_message_id: "msg-123",
+      conversation_id: "conv-1",
+    });
     expect(mockRequestFetch).toHaveBeenCalledWith(
       "https://api.example.com/mobile/agent/actions?mobile_token=mobile-token",
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({
-          type: "api_write",
-          params: { endpoint: "create_product" },
-          proposal_message_id: "msg-123",
-          conversation_id: "conv-1",
-        }),
         headers: expect.objectContaining({ Authorization: "Bearer token" }),
       }),
     );


### PR DESCRIPTION
## Status

- [x] Scope — gp#1727 identifies mobile confirms dropping `proposal_message_id`, forcing the server onto legacy fuzzy matching.
- [x] Design — carry the server's top-level `proposal_message_id` onto the mobile `ProposedAction`, then include it in the confirm payload alongside `conversation_id`.
- [x] Build — branch `gp1727-mobile-proposal-id`, head `a6a193b`.
- [ ] Ship — draft PR; CI is running and the mandatory PR video is still pending/not applicable for a non-visual data-layer fix.
- [x] Market — n/a; bug fix for mobile Agent confirm binding.
- [x] Sell — n/a; no pricing or sales collateral change.

## What

Mobile Agent confirms now send `proposal_message_id` back to `/mobile/agent/actions` when the stream provided one. The done-frame parser attaches the id to the proposed action, and the confirm mutation posts it back with the existing action payload.

## Why

Without the proposal id, every mobile confirm falls back to the server's legacy payload matcher. When a seller stages two near-identical product proposals, two separate “confirm” taps can match two different pending rows and create duplicate products. Web already sends this id; mobile should use the same binding.

Issue: antiwork/gumroad-private#1727

## Before/After

Before:
- The SSE `done` frame's `proposal_message_id` was ignored.
- `executeAgentAction` sent only `type`, `params`, and optional `conversation_id`.
- The server logged `Store agent confirmation omitted proposal message id` and used fuzzy matching.

After:
- `streamAgentMessage` preserves `proposal_message_id` on the proposed action.
- `executeAgentAction` includes `proposal_message_id` in the confirm POST.
- Existing confirms without an id still work through the compatibility path during deploy skew.

## Test Results

- `npm exec -- jest tests/lib/agent.test.ts tests/components/agent/agent-chat.test.tsx --silent --forceExit` — passed, 44 tests.
- `npm exec -- tsc --noEmit --pretty false` — passed.
- `npm exec -- eslint lib/agent.ts tests/lib/agent.test.ts tests/components/agent/agent-chat.test.tsx` — passed.
- `npm exec -- prettier --check lib/agent.ts tests/lib/agent.test.ts tests/components/agent/agent-chat.test.tsx` — passed.
- `claude-fable-5` adversarial review — clean for P1/P2. It noted two non-blocking test-hygiene points; both were fixed in `a6a193b`.

## QA steps

No UI change. The covered path is: mobile Agent stream receives a proposed action with `proposal_message_id`, the seller taps Confirm, and the confirm request sends that exact id back to the API. Verified through `tests/lib/agent.test.ts` and `tests/components/agent/agent-chat.test.tsx`.

Video: not included yet; this is a non-visual data-layer fix. If the repo requires a video for every PR despite no UI delta, the recording can show the Agent confirm flow once a dev app is running.

---

AI assistance: Gumclaw used claude-opus-5 to inspect the issue, edit the code, and update tests.