### PR TITLE
Let embedded video play inside the page on iPhone

### DIFF
--- a/app/post/[id].tsx
+++ b/app/post/[id].tsx
@@ -282,6 +282,7 @@ export default function PostScreen() {
                 style={{ height: bodyHeight, width: width - 32, backgroundColor: "transparent" }}
                 scrollEnabled={false}
                 showsVerticalScrollIndicator={false}
+                allowsInlineMediaPlayback
                 allowsFullscreenVideo
                 onMessage={handleHeightMessage}
                 injectedJavaScript={`

--- a/app/purchase/[token].tsx
+++ b/app/purchase/[token].tsx
@@ -253,6 +253,8 @@ export default function DownloadScreen() {
         pullToRefreshEnabled
         thirdPartyCookiesEnabled
         mediaPlaybackRequiresUserAction={false}
+        // On iPhone, WebKit refuses to play video inside the page unless this is on, and instead takes it over in a fullscreen player. Embedded players (like the Loom videos sellers put in course lessons) ask to stay inline and can stall when that takeover happens.
+        allowsInlineMediaPlayback
         // Android blocks the HTML5 fullscreen API in WebViews unless this is enabled, so videos playing inline (like embedded players in rich content) would have a fullscreen button that does nothing. iOS ignores this prop.
         allowsFullscreenVideo
         originWhitelist={["*"]}

--- a/tests/app/post-id.test.tsx
+++ b/tests/app/post-id.test.tsx
@@ -1,0 +1,79 @@
+/* eslint-disable import/first -- jest.mock must precede imports */
+import { render, screen } from "@testing-library/react-native";
+
+const mockUseInstallment = jest.fn();
+const mockUsePurchase = jest.fn();
+
+jest.mock("react-native-webview", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  return {
+    WebView: React.forwardRef(function MockWebView(props: Record<string, unknown>, ref: unknown) {
+      React.useImperativeHandle(ref, () => ({ postMessage: jest.fn() }));
+      return React.createElement(View, { testID: "post-webview", ...props });
+    }),
+  };
+});
+
+jest.mock("@/components/library/use-purchases", () => ({
+  useInstallment: () => mockUseInstallment(),
+  usePurchase: () => mockUsePurchase(),
+  fetchPurchaseDetail: jest.fn(),
+}));
+
+jest.mock("@/components/use-audio-player-sync", () => ({
+  useAudioPlayerSync: () => ({
+    playAudio: jest.fn(),
+    pauseAudio: jest.fn(),
+    activeResourceId: null,
+    isPlaying: false,
+  }),
+}));
+
+jest.mock("@/components/mini-audio-player", () => ({ MiniAudioPlayer: () => null }));
+
+jest.mock("@/lib/auth-context", () => ({ useAuth: () => ({ accessToken: "test-token" }) }));
+
+jest.mock("expo-router", () => ({
+  Stack: { Screen: () => null },
+  useLocalSearchParams: () => ({ id: "post-1", purchaseId: "purchase-1" }),
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("expo-file-system", () => ({
+  File: { downloadFileAsync: jest.fn() },
+  Paths: { cache: "/cache" },
+}));
+
+jest.mock("uniwind", () => ({
+  ...jest.requireActual("uniwind"),
+  useCSSVariable: () => ["#000000", "#ffffff", "Mabry Pro"],
+}));
+
+import PostScreen from "@/app/post/[id]";
+
+describe("PostScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseInstallment.mockReturnValue({
+      name: "Lesson 1",
+      message: "<p>Watch this</p>",
+      published_at: "2026-07-01T00:00:00Z",
+      creator_name: "Seller",
+      url_redirect_external_id: "redirect-1",
+      files_data: [],
+    });
+    mockUsePurchase.mockReturnValue({
+      purchase_id: "purchase-1",
+      url_redirect_token: "token-1",
+    });
+  });
+
+  it("lets video in a post body play inline and go fullscreen", () => {
+    render(<PostScreen />);
+
+    const webView = screen.getByTestId("post-webview");
+    expect(webView.props.allowsInlineMediaPlayback).toBe(true);
+    expect(webView.props.allowsFullscreenVideo).toBe(true);
+  });
+});

--- a/tests/app/purchase-token.test.tsx
+++ b/tests/app/purchase-token.test.tsx
@@ -130,11 +130,12 @@ describe("DownloadScreen", () => {
     expect(mockSafeOpenURL).toHaveBeenCalledWith("intent://pay#Intent;scheme=upi;end");
   });
 
-  it("allows fullscreen video for content playing inline in the WebView", () => {
+  it("lets video in the purchase content play inline and go fullscreen", () => {
     render(<DownloadScreen />);
 
     expect(screen.getByTestId("purchase-webview").props.incognito).toBe(true);
     expect(screen.getByTestId("purchase-webview").props.sharedCookiesEnabled).toBeUndefined();
+    expect(screen.getByTestId("purchase-webview").props.allowsInlineMediaPlayback).toBe(true);
     expect(screen.getByTestId("purchase-webview").props.allowsFullscreenVideo).toBe(true);
   });
 


### PR DESCRIPTION
## Issue

Fixes #337

## Scope

A buyer's course lessons start playing in the app and die after about 3 seconds. The same lessons play through in mobile Safari. The course is entirely video lessons, so in the app the product is effectively unusable.

The product hosts no Gumroad video at all — every `ProductFile` is a PDF or DOCX, and 13 of its 15 rich-content pages wrap a Loom share URL in an iframely iframe. So the failing player is a third-party embed inside the purchase WebView, not our own player and not the transcode path.

## Design

On iPhone, WebKit will not play video inside the page unless `allowsInlineMediaPlayback` is set — it instead hands the video to the native fullscreen controller. Embedded players like Loom set `playsinline` and expect to stay in the page, and that handoff is what kills playback a few seconds in.

The prop was never set anywhere in this repo, and it has **no default in the JS layer** — `WebView.ios.tsx` destructures `allowsInlineMediaPlayback` with no fallback (unlike its neighbour `allowsPictureInPictureMediaPlayback = true`), so the native `BOOL` zero-initialises to `NO` and inline playback was off for every WebView we render. It is also **iOS-only**: `grep` finds it in `apple/RNCWebViewImpl.m` and nowhere in the Android sources, so Android is unaffected by this change.

This is the same shape as #298/#303, which added `allowsFullscreenVideo` for the Android fullscreen button. That fix landed on both WebViews that can host video; the inline counterpart was simply missing. Both now travel together.

## Build

`allowsInlineMediaPlayback` added to the two WebViews that render seller content:

- `app/purchase/[token].tsx` — purchase/course content
- `app/post/[id].tsx` — post bodies, which embed video the same way

The other three (`settings/payments`, `settings/profile`, `sales-export`) are Stripe and form pages with zero media references, so they are deliberately left alone.

**I did not remove `incognito`,** which the issue floated as the other candidate. Reading the library source, `incognito` only swaps `WKWebsiteDataStore` for `nonPersistentDataStore` — storage still works normally within a session, so it does not explain playback dying mid-stream. It was also added deliberately in #119 to stop one buyer's session leaking into the next, and #245 depends on that behaviour for Cloudflare challenges. Dropping it to chase this bug would trade a video stall for a session-leak regression.

## QA

`npx jest` → **515 passed, 515 total, 53 suites.** `npx tsc --noEmit` → exit 0. `eslint` → 0 errors. `prettier --check` → clean.

Checks run:
- purchase-content WebView allows inline playback and fullscreen (extended the existing prop test rather than adding a parallel one)
- post-body WebView allows inline playback and fullscreen — `tests/app/post-id.test.tsx` is new; this screen had **no test file at all**, so its WebView props were previously unguarded

**Red-first, and narrowly.** Stripping only the new prop from both screens fails exactly the two new assertions and nothing else (2 failed / 9 passed); restoring makes all 11 pass. Done by copying the files aside rather than `git checkout`, so no shared-worktree history was touched.

One note on the suite, since it could otherwise look alarming in a log: the first full run reported 2 failures in `sales-export` and `pdf-navigation-sheet`, neither of which I touch. They pass on clean `main`, they pass in a clean full run on `main` (514/514), and they pass in the full run with this change (515/515) — they were cold-run timeouts on two already-slow suites (38s and 11s), not a regression. I verified rather than assumed, because "pre-existing failure" is the easy wrong answer here.

## Verification I have not done

**This is the load-bearing gap, and it is why I have left the PR as a draft: I could not test on a device or simulator, so the fix is unproven against the actual bug.** The reasoning is verified against the library's own source, and the prop is unambiguously required for inline playback on iOS — but "inline playback was off" being the cause of *this buyer's* 3-second stall is still an inference. What #337's checklist asks for and I could not do:

1. Reproduce on iOS with the Loom lesson (purchase `339095373`, `Link` 10572242) and confirm it dies at ~3s
2. Confirm this change makes that same lesson play through
3. Confirm on Android, which this change cannot affect — if Android fails too, the cause is something else and this fix is incomplete rather than wrong
4. Spot-check another embed provider (YouTube/Vimeo/Wistia), since if the inline prop is the cause they were all broken too and this is not a Loom-specific bug

No video is attached for the same reason. Per CONTRIBUTING that is a required item, so I am flagging it as outstanding rather than pretending otherwise — @nyomanjyotisa, you own this surface and the device QA is the real gate here.

Being explicit about what this does and does not settle: it removes a definite, source-verified misconfiguration on the exact code path the buyer hit, and it cannot regress Android. It does not yet prove the buyer's symptom is gone.
