### PR TITLE
Add an e2e flow for inline video in content WebViews

### DIFF
--- a/.maestro/utils/launch.yaml
+++ b/.maestro/utils/launch.yaml
@@ -20,6 +20,13 @@ appId: ${APP_ID}
     commands:
       - openLink:
           link: "gumroadmobile://expo-development-client/?url=http%3A%2F%2F10.0.2.2%3A8082"
+# openLink returns before whichever system/app dialog it triggers has rendered, so every
+# `when: visible` check below it races the animation and can silently no-op. Wait for the
+# first of the known post-link states before checking any of them — this can land on the
+# iOS "Open" confirm OR skip straight to the dev-menu sheet depending on prior app state.
+- extendedWaitUntil:
+    visible: "Open|Never for This Website|Not Now|Cancel|Continue|Toggle performance monitor|Sign in with Gumroad|.*Library.*|Logout"
+    timeout: 15000
 # Disable password saving for the disposable localhost test account.
 - runFlow:
     when:
@@ -52,6 +59,11 @@ appId: ${APP_ID}
     commands:
       - waitForAnimationToEnd:
           timeout: 10000
+# The dev-menu ("Continue"/"Toggle performance monitor") sheet, when it appears, renders
+# asynchronously after the app boots — same openLink race as above, one layer deeper.
+- extendedWaitUntil:
+    visible: "Continue|Toggle performance monitor|Don.t allow|Sign in with Gumroad|.*Library.*|Logout"
+    timeout: 15000
 # Skip past the development-menu prompt when it appears.
 - runFlow:
     when:

--- a/.maestro/webview-inline-video.yaml
+++ b/.maestro/webview-inline-video.yaml
@@ -1,0 +1,20 @@
+appId: ${APP_ID}
+---
+# Verifies a third-party video embed plays INSIDE the purchase content page on iOS,
+# rather than iOS taking it over in a fullscreen player. Guards gumroad-mobile#337.
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_buyer_do_not_edit@gumroad.com
+      PASSWORD: password
+- extendedWaitUntil:
+    visible: ".*Mobile Embed Video Course.*"
+    timeout: 30000
+- tapOn: ".*Mobile Embed Video Course.*"
+- extendedWaitUntil:
+    visible: "Lesson 1"
+    timeout: 30000
+# The inline <video> renders inside the page. If iOS hijacks playback into its own
+# fullscreen player, the native player's Done/AirPlay chrome appears over the page.
+- assertNotVisible: "Done"
+- takeScreenshot: /tmp/maestro_inline_embed


### PR DESCRIPTION
## Status

- [x] Scope — cover #341 (inline-video-on-iOS) with a real device-level Maestro flow, not just jest
      prop assertions.
- [x] Design — reuse `utils/sign-in.yaml`/`utils/launch.yaml`; seed fixture lives in
      antiwork/gumroad#6914 (merged).
- [ ] Build — flow + seed fixture written; `launch.yaml` race bug found and fixed this session.
      Open gap (Greptile, 2026-08-04): the flow never starts playback before asserting fullscreen
      chrome is absent, so a regression that only triggers the takeover on play would still pass.
- [ ] QA — real simulator run advances to the OAuth login page (see below); not yet past a live
      backend outage to the target assertion.
- [ ] Shipped — pending a green run against a healthy backend.
- [ ] Market
- [ ] Sell

## Scope

Adds one Maestro flow, `.maestro/webview-inline-video.yaml`, covering the case #341 fixed: a
third-party video embed must play *inside* the purchase content page on iPhone rather than iOS
taking playback over in its own fullscreen player.

#341 shipped with jest assertions on the WebView props, which is the right regression guard for
"someone deletes the prop" but cannot see actual playback. This flow drives the real app.

## Why it's a draft — updated after a real simulator run

@nyomanjyotisa asked for a fix to the shared iOS launch/sign-in helper and a green run. Ran it live
(iPhone 17 Pro, iOS 26.4) this session and found the real bug, which was in `utils/launch.yaml`, not
`utils/sign-in.yaml` as this body previously guessed:

**Fixed and verified — `openLink` races the dialog that follows it.** `openLink` returns before the
system "Open in \"Gumroad\"?" confirm (or, on a warm install that skips that confirm, the dev-menu
sheet) has actually rendered, so the very next `when: visible` check can run against a still-empty
hierarchy and silently no-op. Added `extendedWaitUntil` gates in front of both checks, mirroring the
pattern already used further down this same file for the "Sign in with Gumroad" step. Reproduced the
original failure on a real simulator run (assertion failed with `Open` never tapped), applied the
fix, and re-ran: the flow now gets through the dev-client dialog, the dev-menu sheet, taps "Sign in
with Gumroad", and reaches the Gumroad OAuth login page inside the in-app browser — several steps
past where every previous run in this PR's history stopped.

**Not yet green end to end — a different, unrelated blocker.** The run currently stalls on the OAuth
login page itself: the local Rails backend it's pointed at (a shared instance from another task,
`qa6867` on port 3000) has a wedged Vite dev-server thread (`IOError: stream closed in another
thread` in its log, following a 120s `Rack::Timeout::RequestTimeoutException` on `/`) and is not
currently serving pages. That's an environment problem with a shared local backend, not a defect in
this flow or in `utils/launch.yaml`. Re-running against a healthy backend is the remaining step to a
genuine green run; the flow itself has not asserted anything further than the login page yet.

**Seed fixture: done.** antiwork/gumroad#6914 merged 2026-08-03T10:38Z and puts
`Mobile Embed Video Course` / permalink `embedvideocourse` on `main`; confirmed via
`bin/rails runner` against a local backend that the fixture and its seller
(`mobile_seller1_do_not_edit@gumroad.com`) exist.

**Open Build gap — Greptile review, 2026-08-04.** The flow opens the course, waits for `Lesson 1`,
and immediately asserts `Done` (native fullscreen chrome) is absent — but it never taps the embedded
player first. A regression that only routes playback to iOS's own fullscreen player *when playback
starts* (rather than on page load) would still pass this flow untouched. Fixing this needs a stable
selector for the embedded `mediaEmbed` player inside the WebView and a way to assert it's actually
playing inline, which I haven't verified live yet — the backend this flow drives against is still
down (see below), so I'm not pushing an unverified selector guess. Left open rather than closed
silently.

## Setup traps found (all now written into `references/maestro-e2e-flows.md`)

Each of these failed in a way that pointed at the wrong culprit, so they're worth having recorded:

- `MAESTRO_DRIVER_STARTUP_TIMEOUT=180000` is required on a first run — the XCUITest runner compiles
  on demand and blows the default timeout. Reads as a broken install.
- Run via `npm run e2e:ios -- <flow>`, never bare `maestro test`: without the script's
  `-e APP_ID=$IOS_BUNDLE_NAME`, nested `runFlow`s resolve `appId` to the literal string `undefined`
  and fail with `Failed to get app binary directory for bundle undefined`, which looks like the app
  isn't installed.
- `node_modules` must be a real install, not a symlink to another checkout — symlinked, Metro
  resolves into the other worktree and defaults to the **web** target, producing ~20 alarming
  `Importing native-only module` / `Unable to resolve module ../web` errors that are pure noise.
- Confirm Metro readiness by fetching a real bundle
  (`/index.bundle?platform=ios&dev=true` → 200, ~18MB); the root URL 500s even when it's healthy.
- `xcrun simctl erase` on a device that only has a dev-client build installed (no committed `.app`
  in the repo) wipes the install with no way back except a full `npx expo run:ios` native rebuild —
  costs ~12 minutes. Don't erase; `killApp`/`clearState` (what the flows already do) is enough.
- `openLink` races the dialog it triggers — see "Fixed and verified" above. Any new flow reusing
  `utils/launch.yaml` gets this fix for free.

## QA

- `npx prettier --check .maestro/webview-inline-video.yaml` — clean.
- Two-document YAML parse check — 6 steps, valid shape.
- **Real Maestro runs on iPhone 17 Pro (iOS 26.4), this session:** reproduced the original stall,
  applied the `launch.yaml` fix, re-ran and confirmed the flow advances through the dev-client
  dialog → dev-menu sheet → "Sign in with Gumroad" tap → Gumroad OAuth login page. Stopped there by
  the backend outage above, not by this flow or by `launch.yaml`.

## Test Results

- `npx prettier --check .maestro/webview-inline-video.yaml` — clean.
- Two-document YAML parse — 6 steps, valid shape.
- CI on head `8197f25`: pending at time of writing (just pushed).
- **Maestro run status, honestly stated:** not green end to end. The `launch.yaml` race that was
  blocking every previous run in this PR is fixed and verified live; the flow now reaches the OAuth
  login page. It stops there because the local backend it's pointed at is currently down (wedged
  Vite thread on a shared `qa6867` instance), not because of anything in this flow or in
  `launch.yaml`. No screenshot of the target assertion (`assertNotVisible: Done`) is attached because
  the run has not reached it yet.

## AI disclosure

Written by Hermes Agent (`claude-sonnet-5`) running as gumclaw's autonomous dev dispatcher.
Instructions given: respond to @nyomanjyotisa's review asking for a fix to the shared iOS
launch/sign-in helper and a green run. Found and fixed the real race in `utils/launch.yaml` (the
original body's diagnosis pointed at `sign-in.yaml`, which was wrong), verified the fix by running
Maestro live against a real iOS simulator this session, and reported the remaining blocker (an
unrelated backend outage) rather than papering over it with a fabricated green result.

