### PR TITLE
Recover an interrupted agent turn instead of telling the seller it failed

### DIFF
--- a/.maestro/agent-turn-recovery.yaml
+++ b/.maestro/agent-turn-recovery.yaml
@@ -1,0 +1,35 @@
+appId: ${APP_ID}
+tags:
+  - ios-only
+  - proxy-only
+---
+- runFlow:
+    file: utils/sign-in.yaml
+    env:
+      EMAIL: mobile_seller1_do_not_edit@gumroad.com
+      PASSWORD: password
+
+- tapOn: ".*Agent.*"
+- extendedWaitUntil:
+    visible:
+      id: "agent-message-input-ready"
+    timeout: 15000
+- evalScript: ${output.recoveryProduct = "RECOVERY_E2E_" + Date.now()}
+- tapOn:
+    id: "agent-message-input-ready"
+- inputText: ${"Create a product proposal named " + output.recoveryProduct + " priced at 1 dollar. Do not ask follow-up questions."}
+- tapOn:
+    text: "Send"
+    enabled: true
+    waitToSettleTimeoutMs: 100
+- extendedWaitUntil:
+    visible:
+      id: "agent-message-input-sending"
+    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: "agent-message-input-ready"
+    timeout: 240000
+- assertNotVisible: "Sorry, I ran into a problem. Please try again."
+- assertVisible: ".*${output.recoveryProduct}.*"
+- assertVisible: "Confirm"

--- a/.maestro/utils/login-with-password.yaml
+++ b/.maestro/utils/login-with-password.yaml
@@ -4,40 +4,22 @@ appId: ${APP_ID}
     element: Login
 - tapOn: Email
 - inputText: ${EMAIL}
-- pressKey: enter # The form moves focus to the password field.
-# The password field rerenders after each character in Safari on iOS 26,
-# so refocus it before entering each character of the seeded test password.
 - runFlow:
     when:
       platform: iOS
     commands:
-      - tapOn: Show password
-      - tapOn: Password
-      - inputText: p
+      - tapOn: Next
+      - inputText: ${PASSWORD}
       - tapOn:
           text: Never for This Website
           optional: true
-      - tapOn: Password
-      - inputText: a
-      - tapOn: Password
-      - inputText: s
-      - tapOn: Password
-      - inputText: s
-      - tapOn: Password
-      - inputText: w
-      - tapOn: Password
-      - inputText: o
-      - tapOn: Password
-      - inputText: r
-      - tapOn: Password
-      - inputText: d
 - runFlow:
     when:
       platform: Android
     commands:
+      - pressKey: enter
       - inputText: ${PASSWORD}
 - hideKeyboard
-# The password prompt may appear as soon as the form auto-submits.
 - runFlow:
     when:
       platform: iOS
@@ -47,10 +29,18 @@ appId: ${APP_ID}
           optional: true
 - runFlow:
     when:
+      platform: iOS
+      visible: Password
+    commands:
+      - scrollUntilVisible:
+          element: "^Login$"
+      - tapOn: "^Login$"
+- runFlow:
+    when:
+      platform: Android
       visible: Login
     commands:
       - tapOn: Login
-# Or it may appear after an explicit submit.
 - runFlow:
     when:
       platform: iOS

--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -4,23 +4,78 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Text } from "@/components/ui/text";
 import {
   type ChatMessage,
+  type AgentStreamResult,
+  type AgentTurnStatus,
   type ProposedAction,
+  AgentStreamInterruptedError,
   executeAgentAction,
+  fetchAgentTurnStatus,
   fetchLatestAgentConversation,
   streamAgentMessage,
 } from "@/lib/agent";
 import { useAuthedRequest } from "@/lib/authed-request";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useMutation } from "@tanstack/react-query";
+import { randomUUID } from "expo-crypto";
 import { useEffect, useRef, useState } from "react";
 import { FlatList, KeyboardAvoidingView, type NativeScrollEvent, Platform, TextInput, View } from "react-native";
 import { useCSSVariable } from "uniwind";
 
 const IOS_KEYBOARD_VERTICAL_OFFSET = 88;
 const AUTOSCROLL_BOTTOM_THRESHOLD = 24;
+// After a stream breaks, how long to keep asking the server what became of the turn. The server
+// tolerates up to 120 seconds of model silence across as many as 25 tool iterations, so recovery
+// keeps polling for as long as it reports "in_progress"; the cap only guards a marker that never
+// resolves.
+const TURN_RECOVERY_POLL_INTERVAL_MS = 3000;
+const TURN_RECOVERY_MAX_POLLS = 60;
+// "unknown" means neither a stored turn nor a liveness marker, which is normally conclusive — but a
+// Redis blip can produce one spuriously, so take a couple of confirming looks before giving up.
+const TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS = 2;
 
 const isNearBottom = ({ contentOffset, contentSize, layoutMeasurement }: NativeScrollEvent) =>
   contentSize.height - contentOffset.y - layoutMeasurement.height <= AUTOSCROLL_BOTTOM_THRESHOLD;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Ask the server what became of a turn whose stream broke, identified by the id the app generated
+// before sending. Without this, an interruption is indistinguishable from a failure, so a turn the
+// server went on to persist is shown as an error and re-sending it duplicates the whole exchange.
+const recoverTurn = async (
+  clientTurnId: string,
+  authedRequest: <T>(request: (token: string) => Promise<T>) => Promise<T>,
+): Promise<AgentStreamResult> => {
+  let consecutiveUnknowns = 0;
+  for (let poll = 0; poll < TURN_RECOVERY_MAX_POLLS; poll++) {
+    await sleep(TURN_RECOVERY_POLL_INTERVAL_MS);
+    let turn: AgentTurnStatus;
+    try {
+      turn = await authedRequest((token) => fetchAgentTurnStatus(clientTurnId, token));
+    } catch {
+      // The same flaky network that broke the stream may still be down, so keep asking.
+      continue;
+    }
+    switch (turn.status) {
+      case "persisted":
+        return {
+          reply: turn.message.content,
+          proposedAction: turn.message.proposed_action ?? null,
+          proposalMessageId: turn.message.proposal_message_id ?? null,
+          conversationId: turn.conversationId,
+        };
+      case "failed":
+        throw new Error("Agent turn failed");
+      case "in_progress":
+        consecutiveUnknowns = 0;
+        continue;
+      case "unknown":
+        consecutiveUnknowns += 1;
+        if (consecutiveUnknowns >= TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS) throw new Error("Agent turn was lost");
+        continue;
+    }
+  }
+  throw new Error("Agent turn recovery timed out");
+};
 
 interface DisplayMessage extends ChatMessage {
   proposedAction?: ProposedAction;
@@ -195,18 +250,26 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   }, []);
 
   const sendMutation = useMutation({
-    mutationFn: (history: ChatMessage[]) =>
-      authedRequest((token) =>
-        streamAgentMessage({
-          messages: history,
-          conversationId: conversationIdRef.current,
-          accessToken: token,
-          handlers: {
-            onToken: (text) => setStreamingReply((prev) => (prev ?? "") + text),
-            onReset: () => setStreamingReply(null),
-          },
-        }),
-      ),
+    mutationFn: async (history: ChatMessage[]) => {
+      const clientTurnId = randomUUID();
+      try {
+        return await authedRequest((token) =>
+          streamAgentMessage({
+            messages: history,
+            conversationId: conversationIdRef.current,
+            clientTurnId,
+            accessToken: token,
+            handlers: {
+              onToken: (text) => setStreamingReply((prev) => (prev ?? "") + text),
+              onReset: () => setStreamingReply(null),
+            },
+          }),
+        );
+      } catch (error) {
+        if (!(error instanceof AgentStreamInterruptedError)) throw error;
+        return await recoverTurn(clientTurnId, authedRequest);
+      }
+    },
     onSuccess: ({ reply, proposedAction, proposalMessageId, conversationId }) => {
       conversationIdRef.current = conversationId;
       setMessages((prev) => [

--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -16,7 +16,6 @@ import {
 import { useAuthedRequest } from "@/lib/authed-request";
 import { useHeaderHeight } from "@react-navigation/elements";
 import { useMutation } from "@tanstack/react-query";
-import { randomUUID } from "expo-crypto";
 import { useEffect, useRef, useState } from "react";
 import { FlatList, KeyboardAvoidingView, type NativeScrollEvent, Platform, TextInput, View } from "react-native";
 import { useCSSVariable } from "uniwind";
@@ -37,6 +36,19 @@ const isNearBottom = ({ contentOffset, contentSize, layoutMeasurement }: NativeS
   contentSize.height - contentOffset.y - layoutMeasurement.height <= AUTOSCROLL_BOTTOM_THRESHOLD;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// The id only has to distinguish this turn from the seller's other turns, so a timestamp plus
+// randomness is enough — the server accepts any hex-and-dash string up to 64 characters.
+const TURN_ID_RANDOM_SEGMENTS = 4;
+const generateTurnId = () =>
+  [
+    Date.now().toString(16),
+    ...Array.from({ length: TURN_ID_RANDOM_SEGMENTS }, () =>
+      Math.floor(Math.random() * 0x10000)
+        .toString(16)
+        .padStart(4, "0"),
+    ),
+  ].join("-");
 
 // Ask the server what became of a turn whose stream broke, identified by the id the app generated
 // before sending. Without this, an interruption is indistinguishable from a failure, so a turn the
@@ -251,7 +263,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
 
   const sendMutation = useMutation({
     mutationFn: async (history: ChatMessage[]) => {
-      const clientTurnId = randomUUID();
+      const clientTurnId = generateTurnId();
       try {
         return await authedRequest((token) =>
           streamAgentMessage({

--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -24,10 +24,12 @@ const IOS_KEYBOARD_VERTICAL_OFFSET = 88;
 const AUTOSCROLL_BOTTOM_THRESHOLD = 24;
 // After a stream breaks, how long to keep asking the server what became of the turn. The server
 // tolerates up to 120 seconds of model silence across as many as 25 tool iterations, so recovery
-// keeps polling for as long as it reports "in_progress"; the cap only guards a marker that never
-// resolves.
+// keeps polling for as long as it reports "in_progress"; the deadline only guards a marker that
+// never resolves. It is wall-clock rather than a poll count because a status request can itself
+// hang for the request timeout, which would stretch a counted budget by an order of magnitude
+// while the composer stays disabled.
 const TURN_RECOVERY_POLL_INTERVAL_MS = 3000;
-const TURN_RECOVERY_MAX_POLLS = 60;
+const TURN_RECOVERY_DEADLINE_MS = 180_000;
 // "unknown" means neither a stored turn nor a liveness marker, which is normally conclusive — but a
 // Redis blip can produce one spuriously, so take a couple of confirming looks before giving up.
 const TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS = 2;
@@ -58,7 +60,8 @@ const recoverTurn = async (
   authedRequest: <T>(request: (token: string) => Promise<T>) => Promise<T>,
 ): Promise<AgentStreamResult> => {
   let consecutiveUnknowns = 0;
-  for (let poll = 0; poll < TURN_RECOVERY_MAX_POLLS; poll++) {
+  const deadline = Date.now() + TURN_RECOVERY_DEADLINE_MS;
+  while (Date.now() < deadline) {
     await sleep(TURN_RECOVERY_POLL_INTERVAL_MS);
     let turn: AgentTurnStatus;
     try {

--- a/components/agent/agent-chat.tsx
+++ b/components/agent/agent-chat.tsx
@@ -4,13 +4,12 @@ import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { Text } from "@/components/ui/text";
 import {
   type ChatMessage,
-  type AgentStreamResult,
-  type AgentTurnStatus,
   type ProposedAction,
   AgentStreamInterruptedError,
   executeAgentAction,
   fetchAgentTurnStatus,
   fetchLatestAgentConversation,
+  recoverAgentTurn,
   streamAgentMessage,
 } from "@/lib/agent";
 import { useAuthedRequest } from "@/lib/authed-request";
@@ -22,22 +21,9 @@ import { useCSSVariable } from "uniwind";
 
 const IOS_KEYBOARD_VERTICAL_OFFSET = 88;
 const AUTOSCROLL_BOTTOM_THRESHOLD = 24;
-// After a stream breaks, how long to keep asking the server what became of the turn. The server
-// tolerates up to 120 seconds of model silence across as many as 25 tool iterations, so recovery
-// keeps polling for as long as it reports "in_progress"; the deadline only guards a marker that
-// never resolves. It is wall-clock rather than a poll count because a status request can itself
-// hang for the request timeout, which would stretch a counted budget by an order of magnitude
-// while the composer stays disabled.
-const TURN_RECOVERY_POLL_INTERVAL_MS = 3000;
-const TURN_RECOVERY_DEADLINE_MS = 180_000;
-// "unknown" means neither a stored turn nor a liveness marker, which is normally conclusive — but a
-// Redis blip can produce one spuriously, so take a couple of confirming looks before giving up.
-const TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS = 2;
 
 const isNearBottom = ({ contentOffset, contentSize, layoutMeasurement }: NativeScrollEvent) =>
   contentSize.height - contentOffset.y - layoutMeasurement.height <= AUTOSCROLL_BOTTOM_THRESHOLD;
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // The id only has to distinguish this turn from the seller's other turns, so a timestamp plus
 // randomness is enough — the server accepts any hex-and-dash string up to 64 characters.
@@ -51,46 +37,6 @@ const generateTurnId = () =>
         .padStart(4, "0"),
     ),
   ].join("-");
-
-// Ask the server what became of a turn whose stream broke, identified by the id the app generated
-// before sending. Without this, an interruption is indistinguishable from a failure, so a turn the
-// server went on to persist is shown as an error and re-sending it duplicates the whole exchange.
-const recoverTurn = async (
-  clientTurnId: string,
-  authedRequest: <T>(request: (token: string) => Promise<T>) => Promise<T>,
-): Promise<AgentStreamResult> => {
-  let consecutiveUnknowns = 0;
-  const deadline = Date.now() + TURN_RECOVERY_DEADLINE_MS;
-  while (Date.now() < deadline) {
-    await sleep(TURN_RECOVERY_POLL_INTERVAL_MS);
-    let turn: AgentTurnStatus;
-    try {
-      turn = await authedRequest((token) => fetchAgentTurnStatus(clientTurnId, token));
-    } catch {
-      // The same flaky network that broke the stream may still be down, so keep asking.
-      continue;
-    }
-    switch (turn.status) {
-      case "persisted":
-        return {
-          reply: turn.message.content,
-          proposedAction: turn.message.proposed_action ?? null,
-          proposalMessageId: turn.message.proposal_message_id ?? null,
-          conversationId: turn.conversationId,
-        };
-      case "failed":
-        throw new Error("Agent turn failed");
-      case "in_progress":
-        consecutiveUnknowns = 0;
-        continue;
-      case "unknown":
-        consecutiveUnknowns += 1;
-        if (consecutiveUnknowns >= TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS) throw new Error("Agent turn was lost");
-        continue;
-    }
-  }
-  throw new Error("Agent turn recovery timed out");
-};
 
 interface DisplayMessage extends ChatMessage {
   proposedAction?: ProposedAction;
@@ -217,6 +163,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const [hasContentGrownSinceReaderScroll, setHasContentGrownSinceReaderScroll] = useState(false);
   const conversationIdRef = useRef<string | null>(null);
   const hasSentMessageRef = useRef(false);
+  const turnControllerRef = useRef<AbortController | null>(null);
   const mutedColor = useCSSVariable("--color-muted") as string;
   const listRef = useRef<FlatList<DisplayMessage>>(null);
   const isAtBottomRef = useRef(true);
@@ -260,6 +207,7 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
       .catch(() => {});
     return () => {
       cancelled = true;
+      turnControllerRef.current?.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- resume runs once, on mount
   }, []);
@@ -267,22 +215,34 @@ export const AgentChat = ({ greeting, suggestions }: Props) => {
   const sendMutation = useMutation({
     mutationFn: async (history: ChatMessage[]) => {
       const clientTurnId = generateTurnId();
+      const turnController = new AbortController();
+      turnControllerRef.current = turnController;
       try {
-        return await authedRequest((token) =>
-          streamAgentMessage({
-            messages: history,
-            conversationId: conversationIdRef.current,
+        try {
+          return await authedRequest((token) =>
+            streamAgentMessage({
+              messages: history,
+              conversationId: conversationIdRef.current,
+              clientTurnId,
+              accessToken: token,
+              signal: turnController.signal,
+              handlers: {
+                onToken: (text) => setStreamingReply((prev) => (prev ?? "") + text),
+                onReset: () => setStreamingReply(null),
+              },
+            }),
+          );
+        } catch (error) {
+          if (!(error instanceof AgentStreamInterruptedError) || turnController.signal.aborted) throw error;
+          setStreamingReply(null);
+          return await recoverAgentTurn(
             clientTurnId,
-            accessToken: token,
-            handlers: {
-              onToken: (text) => setStreamingReply((prev) => (prev ?? "") + text),
-              onReset: () => setStreamingReply(null),
-            },
-          }),
-        );
-      } catch (error) {
-        if (!(error instanceof AgentStreamInterruptedError)) throw error;
-        return await recoverTurn(clientTurnId, authedRequest);
+            (turnId, signal) => authedRequest((token) => fetchAgentTurnStatus(turnId, token, signal)),
+            { interruptionPhase: error.phase, signal: turnController.signal },
+          );
+        }
+      } finally {
+        if (turnControllerRef.current === turnController) turnControllerRef.current = null;
       }
     },
     onSuccess: ({ reply, proposedAction, proposalMessageId, conversationId }) => {

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -104,14 +104,46 @@ interface DoneEventData {
   conversation_id?: string;
 }
 
+// Thrown when the stream ends without a `done` event: the connection broke, but the server may
+// still be generating the turn and may yet persist it. The caller recovers by asking the
+// turn-status endpoint what became of this exact turn, rather than assuming the turn was lost.
+export class AgentStreamInterruptedError extends Error {
+  constructor() {
+    super("Agent stream interrupted");
+    this.name = "AgentStreamInterruptedError";
+  }
+}
+
+export type AgentTurnStatus =
+  | { status: "persisted"; conversationId: string; message: ConversationMessage }
+  | { status: "in_progress" | "failed" | "unknown" };
+
+type AgentTurnStatusResponse =
+  | { success: true; status: "persisted"; conversation_id: string; message: ConversationMessage }
+  | { success: true; status: "in_progress" | "failed" | "unknown" }
+  | { success: false; error: string };
+
+export const fetchAgentTurnStatus = async (clientTurnId: string, accessToken: string): Promise<AgentTurnStatus> => {
+  const json = await requestAPI<AgentTurnStatusResponse>(`mobile/agent/turns/${encodeURIComponent(clientTurnId)}`, {
+    method: "GET",
+    accessToken,
+  });
+  if (!json.success) throw new Error(json.error);
+  return json.status === "persisted"
+    ? { status: json.status, conversationId: json.conversation_id, message: json.message }
+    : { status: json.status };
+};
+
 export const streamAgentMessage = async ({
   messages,
   conversationId,
+  clientTurnId,
   accessToken,
   handlers = {},
 }: {
   messages: ChatMessage[];
   conversationId?: string | null;
+  clientTurnId?: string | null;
   accessToken: string;
   handlers?: AgentStreamHandlers;
 }): Promise<AgentStreamResult> => {
@@ -128,7 +160,11 @@ export const streamAgentMessage = async ({
     const response = await streamingFetch(buildApiUrl("mobile/agent/messages/stream"), {
       method: "POST",
       headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
-      body: JSON.stringify({ messages, ...(conversationId ? { conversation_id: conversationId } : {}) }),
+      body: JSON.stringify({
+        messages,
+        ...(conversationId ? { conversation_id: conversationId } : {}),
+        ...(clientTurnId ? { client_turn_id: clientTurnId } : {}),
+      }),
       signal: controller.signal,
     });
 
@@ -209,7 +245,7 @@ export const streamAgentMessage = async ({
       }
     }
 
-    if (!done) throw new Error("Agent stream ended without a done event");
+    if (!done) throw new AgentStreamInterruptedError();
     return done;
   } finally {
     clearTimeout(timeoutId);

--- a/lib/agent.ts
+++ b/lib/agent.ts
@@ -1,4 +1,4 @@
-import { buildApiUrl, REQUEST_TIMEOUT_MS, requestAPI, UnauthorizedError } from "@/lib/request";
+import { buildApiUrl, REQUEST_TIMEOUT_MS, requestAPI, RequestError, UnauthorizedError } from "@/lib/request";
 import { fetch as streamingFetch } from "expo/fetch";
 
 export type ChatRole = "user" | "assistant";
@@ -107,10 +107,17 @@ interface DoneEventData {
 // Thrown when the stream ends without a `done` event: the connection broke, but the server may
 // still be generating the turn and may yet persist it. The caller recovers by asking the
 // turn-status endpoint what became of this exact turn, rather than assuming the turn was lost.
+export type AgentStreamInterruptionPhase = "request" | "stream";
+
 export class AgentStreamInterruptedError extends Error {
-  constructor() {
+  readonly cause?: unknown;
+  readonly phase: AgentStreamInterruptionPhase;
+
+  constructor({ cause, phase = "stream" }: { cause?: unknown; phase?: AgentStreamInterruptionPhase } = {}) {
     super("Agent stream interrupted");
     this.name = "AgentStreamInterruptedError";
+    this.cause = cause;
+    this.phase = phase;
   }
 }
 
@@ -118,20 +125,171 @@ export type AgentTurnStatus =
   | { status: "persisted"; conversationId: string; message: ConversationMessage }
   | { status: "in_progress" | "failed" | "unknown" };
 
+export class AgentTurnStatusError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentTurnStatusError";
+  }
+}
+
+const TURN_RECOVERY_POLL_INTERVAL_MS = 3000;
+const TURN_RECOVERY_DEADLINE_MS = 180_000;
+const TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS = 2;
+const INITIAL_REQUEST_MAX_CONSECUTIVE_FAILURES = 2;
+
+const recoveryAbortedError = () => {
+  const error = new Error("Agent turn recovery cancelled");
+  error.name = "AbortError";
+  return error;
+};
+
+const throwIfAborted = (signal?: AbortSignal) => {
+  if (signal?.aborted) throw recoveryAbortedError();
+};
+
+const sleep = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    throwIfAborted(signal);
+    const timeoutId = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, ms);
+    const handleAbort = () => {
+      clearTimeout(timeoutId);
+      reject(recoveryAbortedError());
+    };
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+
+const runBeforeDeadline = async <T>(
+  deadline: number,
+  run: (signal: AbortSignal) => Promise<T>,
+  externalSignal?: AbortSignal,
+): Promise<T> => {
+  throwIfAborted(externalSignal);
+  const remainingTime = deadline - Date.now();
+  if (remainingTime <= 0) throw new Error("Agent turn recovery timed out");
+
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error("Agent turn recovery timed out"));
+    }, remainingTime);
+  });
+  let handleExternalAbort: (() => void) | undefined;
+  const externalAbort = new Promise<never>((_, reject) => {
+    if (!externalSignal) return;
+    handleExternalAbort = () => {
+      controller.abort();
+      reject(recoveryAbortedError());
+    };
+    externalSignal.addEventListener("abort", handleExternalAbort, { once: true });
+  });
+
+  try {
+    const attempt = run(controller.signal);
+    // Promise.race observes losing rejections, but keep an explicit handler on the aborted request
+    // as well so React Native error tooling never treats its late AbortError as unhandled.
+    void attempt.catch(() => {});
+    return await Promise.race([attempt, timeout, externalAbort]);
+  } finally {
+    clearTimeout(timeoutId);
+    if (handleExternalAbort) externalSignal?.removeEventListener("abort", handleExternalAbort);
+  }
+};
+
 type AgentTurnStatusResponse =
   | { success: true; status: "persisted"; conversation_id: string; message: ConversationMessage }
   | { success: true; status: "in_progress" | "failed" | "unknown" }
   | { success: false; error: string };
 
-export const fetchAgentTurnStatus = async (clientTurnId: string, accessToken: string): Promise<AgentTurnStatus> => {
+export const fetchAgentTurnStatus = async (
+  clientTurnId: string,
+  accessToken: string,
+  signal?: AbortSignal,
+): Promise<AgentTurnStatus> => {
   const json = await requestAPI<AgentTurnStatusResponse>(`mobile/agent/turns/${encodeURIComponent(clientTurnId)}`, {
     method: "GET",
     accessToken,
+    signal,
   });
-  if (!json.success) throw new Error(json.error);
+  if (!json.success) throw new AgentTurnStatusError(json.error);
   return json.status === "persisted"
     ? { status: json.status, conversationId: json.conversation_id, message: json.message }
     : { status: json.status };
+};
+
+export const recoverAgentTurn = async (
+  clientTurnId: string,
+  fetchStatus: (clientTurnId: string, signal: AbortSignal) => Promise<AgentTurnStatus>,
+  {
+    pollIntervalMs = TURN_RECOVERY_POLL_INTERVAL_MS,
+    interruptionPhase = "stream",
+    signal,
+  }: { pollIntervalMs?: number; interruptionPhase?: AgentStreamInterruptionPhase; signal?: AbortSignal } = {},
+): Promise<AgentStreamResult> => {
+  let consecutiveUnknowns = 0;
+  let consecutiveFailures = 0;
+  const deadline = Date.now() + TURN_RECOVERY_DEADLINE_MS;
+
+  while (Date.now() < deadline) {
+    const remainingTime = deadline - Date.now();
+    const pollDelay = Math.min(pollIntervalMs, remainingTime);
+    if (pollDelay > 0) await sleep(pollDelay, signal);
+    throwIfAborted(signal);
+    if (Date.now() >= deadline) break;
+
+    let turn: AgentTurnStatus;
+    try {
+      turn = await runBeforeDeadline(deadline, (requestSignal) => fetchStatus(clientTurnId, requestSignal), signal);
+    } catch (error) {
+      if (
+        error instanceof UnauthorizedError ||
+        error instanceof RequestError ||
+        error instanceof AgentTurnStatusError
+      ) {
+        throw error;
+      }
+      consecutiveFailures += 1;
+      // A mid-stream break proves that the server accepted the request, so tolerate an outage until
+      // the deadline. Before headers, two failed status reads instead indicate a fully offline device;
+      // fail promptly rather than locking its composer for the full recovery window.
+      if (interruptionPhase === "request" && consecutiveFailures >= INITIAL_REQUEST_MAX_CONSECUTIVE_FAILURES) {
+        throw error;
+      }
+      continue;
+    }
+    consecutiveFailures = 0;
+
+    switch (turn.status) {
+      case "persisted":
+        return {
+          reply: turn.message.content,
+          proposedAction: turn.message.proposed_action ?? null,
+          proposalMessageId: turn.message.proposal_message_id ?? null,
+          conversationId: turn.conversationId,
+        };
+      case "failed":
+        throw new Error("Agent turn failed");
+      case "in_progress":
+        consecutiveUnknowns = 0;
+        continue;
+      case "unknown":
+        // Once the response stream began, the server contract defines unknown as terminal: one
+        // retry covers the short gap between committing the response and arming its marker. Before
+        // headers, however, the POST may still be queued or running, so only the hard deadline can
+        // safely declare it lost without inviting a duplicate turn.
+        consecutiveUnknowns += 1;
+        if (interruptionPhase === "stream" && consecutiveUnknowns >= TURN_RECOVERY_MAX_CONSECUTIVE_UNKNOWNS) {
+          throw new Error("Agent turn was lost");
+        }
+        continue;
+    }
+  }
+
+  throw new Error("Agent turn recovery timed out");
 };
 
 export const streamAgentMessage = async ({
@@ -139,17 +297,22 @@ export const streamAgentMessage = async ({
   conversationId,
   clientTurnId,
   accessToken,
+  signal,
   handlers = {},
 }: {
   messages: ChatMessage[];
   conversationId?: string | null;
   clientTurnId?: string | null;
   accessToken: string;
+  signal?: AbortSignal;
   handlers?: AgentStreamHandlers;
 }): Promise<AgentStreamResult> => {
   // Abort the request if the server goes quiet for too long. The timer restarts on every
   // received chunk, so a long reply streams fine — only a stalled connection gets cut off.
   const controller = new AbortController();
+  const handleExternalAbort = () => controller.abort();
+  if (signal?.aborted) handleExternalAbort();
+  else signal?.addEventListener("abort", handleExternalAbort, { once: true });
   let timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
   const resetIdleTimeout = () => {
     clearTimeout(timeoutId);
@@ -166,6 +329,12 @@ export const streamAgentMessage = async ({
         ...(clientTurnId ? { client_turn_id: clientTurnId } : {}),
       }),
       signal: controller.signal,
+    }).catch((error: unknown) => {
+      if (signal?.aborted) throw error;
+      // A transport failure before response headers does not tell us whether the server received
+      // the POST. If this request has a stable identity, recover it instead of risking a duplicate.
+      if (clientTurnId) throw new AgentStreamInterruptedError({ cause: error, phase: "request" });
+      throw error;
     });
 
     if (response.status === 401) throw new UnauthorizedError("Unauthorized");
@@ -219,7 +388,13 @@ export const streamAgentMessage = async ({
 
     try {
       for (;;) {
-        const { value, done: streamDone } = await reader.read();
+        let chunk: ReadableStreamReadResult<Uint8Array>;
+        try {
+          chunk = await reader.read();
+        } catch (error) {
+          throw new AgentStreamInterruptedError({ cause: error });
+        }
+        const { value, done: streamDone } = chunk;
         if (streamDone) break;
         resetIdleTimeout();
         buffer += decoder.decode(value, { stream: true });
@@ -230,6 +405,7 @@ export const streamAgentMessage = async ({
           if (frame.trim().length > 0) done = handleFrame(frame) ?? done;
           separator = buffer.indexOf("\n\n");
         }
+        if (done) return done;
       }
     } finally {
       reader.cancel().catch(() => {});
@@ -240,7 +416,7 @@ export const streamAgentMessage = async ({
       } catch (error) {
         // Data left in the buffer after the stream closes means the last frame was cut off
         // mid-transmission, so failing to parse it as JSON is expected — we fall through to
-        // the "ended without a done event" error below. Anything else is a real error.
+        // the interruption error below. Anything else is a real error.
         if (!(error instanceof SyntaxError)) throw error;
       }
     }
@@ -249,5 +425,6 @@ export const streamAgentMessage = async ({
     return done;
   } finally {
     clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", handleExternalAbort);
   }
 };

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "e2e:ios": "dotenv-flow -- npm run e2e:ios:run",
-    "e2e:ios:run": "maestro test -p ios --exclude-tags=android-only -e APP_ID=$IOS_BUNDLE_NAME",
+    "e2e:ios:run": "maestro test -p ios --exclude-tags=android-only,proxy-only -e APP_ID=$IOS_BUNDLE_NAME",
+    "e2e:agent-turn-recovery:ios": "dotenv-flow -- node scripts/run-agent-turn-recovery-e2e.mjs",
     "e2e:android": "dotenv-flow -- npm run e2e:android:run",
-    "e2e:android:run": "maestro test -p android -e APP_ID=$ANDROID_BUNDLE_NAME",
+    "e2e:android:run": "maestro test -p android --exclude-tags=ios-only,proxy-only -e APP_ID=$ANDROID_BUNDLE_NAME",
     "eas": "dotenv-flow eas --",
     "postinstall": "npx patch-package"
   },

--- a/scripts/run-agent-turn-recovery-e2e.mjs
+++ b/scripts/run-agent-turn-recovery-e2e.mjs
@@ -1,0 +1,225 @@
+import { spawn, execFileSync } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+
+const PROXY_PORT = Number(process.env.AGENT_RECOVERY_PROXY_PORT ?? 8787);
+const METRO_PORT = Number(process.env.AGENT_RECOVERY_METRO_PORT ?? 8082);
+const UPSTREAM_API_URL = process.env.EXPO_PUBLIC_GUMROAD_API_URL;
+const APP_ID = process.env.IOS_BUNDLE_NAME;
+const HOP_BY_HOP_HEADERS = new Set(["connection", "content-encoding", "content-length", "host", "transfer-encoding"]);
+
+if (!UPSTREAM_API_URL) throw new Error("EXPO_PUBLIC_GUMROAD_API_URL is required");
+if (!APP_ID) throw new Error("IOS_BUNDLE_NAME is required");
+
+const state = { streamCut: false, turnId: undefined, statuses: [] };
+
+const readBody = async (request) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return Buffer.concat(chunks);
+};
+
+const requestHeaders = (request) => {
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(request.headers)) {
+    if (!value || HOP_BY_HOP_HEADERS.has(name)) continue;
+    headers.set(name, Array.isArray(value) ? value.join(", ") : value);
+  }
+  headers.set("accept-encoding", "identity");
+  return headers;
+};
+
+const applyResponse = (source, destination) => {
+  destination.statusCode = source.status;
+  for (const [name, value] of source.headers) {
+    if (!HOP_BY_HOP_HEADERS.has(name)) destination.setHeader(name, value);
+  }
+};
+
+const sendBufferedResponse = async (upstreamResponse, response, pathname) => {
+  const body = Buffer.from(await upstreamResponse.arrayBuffer());
+  const match = pathname.match(/^\/mobile\/agent\/turns\/([^/]+)$/);
+  if (match && decodeURIComponent(match[1]) === state.turnId) {
+    const payload = JSON.parse(body.toString("utf8"));
+    if (payload.status) {
+      state.statuses.push(payload.status);
+      process.stdout.write(`turn status: ${payload.status}\n`);
+    }
+  }
+  applyResponse(upstreamResponse, response);
+  response.end(body);
+};
+
+const relayInterruptedStream = async (upstreamResponse, response, turnId) => {
+  if (!upstreamResponse.body) {
+    await sendBufferedResponse(upstreamResponse, response, "");
+    return;
+  }
+
+  applyResponse(upstreamResponse, response);
+  response.flushHeaders();
+  const reader = upstreamResponse.body.getReader();
+  const decoder = new TextDecoder();
+  const interruptThisStream = !state.streamCut;
+  let buffer = "";
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let separator = buffer.indexOf("\n\n");
+    while (separator !== -1) {
+      const frame = buffer.slice(0, separator);
+      buffer = buffer.slice(separator + 2);
+      if (!interruptThisStream) {
+        await new Promise((resolve) => response.write(`${frame}\n\n`, resolve));
+      } else if (!state.streamCut) {
+        await new Promise((resolve) => response.write(`${frame}\n\n`, resolve));
+        if (/^event:\s*token$/m.test(frame)) {
+          state.streamCut = true;
+          state.turnId = turnId;
+          process.stdout.write(`stream interrupted: ${turnId}\n`);
+          response.destroy();
+        }
+      }
+      separator = buffer.indexOf("\n\n");
+    }
+  }
+
+  if (!response.destroyed) response.end(buffer);
+};
+
+const proxy = http.createServer((request, response) => {
+  void (async () => {
+    const body = await readBody(request);
+    const url = new URL(request.url ?? "/", UPSTREAM_API_URL);
+    const upstreamResponse = await fetch(url, {
+      method: request.method,
+      headers: requestHeaders(request),
+      body: body.length > 0 ? body : undefined,
+      redirect: "follow",
+    });
+
+    if (request.method === "POST" && url.pathname === "/mobile/agent/messages/stream") {
+      const turnId = JSON.parse(body.toString("utf8")).client_turn_id;
+      await relayInterruptedStream(upstreamResponse, response, turnId);
+      return;
+    }
+
+    await sendBufferedResponse(upstreamResponse, response, url.pathname);
+  })().catch((error) => {
+    if (!response.destroyed) {
+      response.statusCode = 502;
+      response.end("Proxy request failed");
+    }
+    process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  });
+});
+
+const isPortOpen = (port) =>
+  new Promise((resolve) => {
+    const socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve(true);
+    });
+    socket.once("error", () => resolve(false));
+  });
+
+const waitForPort = async (port) => {
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    if (await isPortOpen(port)) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for port ${port}`);
+};
+
+const run = (command, args, options = {}) => {
+  const child = spawn(command, args, options);
+  return {
+    child,
+    completion: new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+    }),
+  };
+};
+
+const stop = async (child) => {
+  if (!child || child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) =>
+      setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve();
+      }, 5000),
+    ),
+  ]);
+};
+
+const bootedDevices = JSON.parse(
+  execFileSync("xcrun", ["simctl", "list", "devices", "booted", "-j"], { encoding: "utf8" }),
+);
+const iPhone = Object.values(bootedDevices.devices)
+  .flat()
+  .find((device) => device.name.startsWith("iPhone"));
+if (!iPhone) throw new Error("A booted iPhone Simulator is required");
+
+if (await isPortOpen(METRO_PORT)) throw new Error(`Port ${METRO_PORT} is already in use`);
+
+await new Promise((resolve, reject) => {
+  proxy.once("error", reject);
+  proxy.listen(PROXY_PORT, "127.0.0.1", resolve);
+});
+
+const artifacts = await mkdtemp(path.join(os.tmpdir(), "gumroad-agent-recovery-"));
+const metro = run(
+  path.join(process.cwd(), "node_modules", ".bin", "expo"),
+  ["start", "--dev-client", "--clear", "--port", String(METRO_PORT)],
+  {
+    env: {
+      ...process.env,
+      CI: "1",
+      EXPO_PUBLIC_GUMROAD_API_URL: `http://127.0.0.1:${PROXY_PORT}`,
+    },
+    stdio: "inherit",
+  },
+);
+
+try {
+  await waitForPort(METRO_PORT);
+  process.stdout.write(`artifacts: ${artifacts}\n`);
+  const maestro = run(
+    process.env.MAESTRO_BIN ?? "maestro",
+    [
+      "test",
+      "--no-ansi",
+      "-p",
+      "ios",
+      "--udid",
+      iPhone.udid,
+      "--test-output-dir",
+      artifacts,
+      "-e",
+      `APP_ID=${APP_ID}`,
+      ".maestro/agent-turn-recovery.yaml",
+    ],
+    { stdio: "inherit" },
+  );
+  const result = await maestro.completion;
+  if (result.code !== 0) throw new Error(`Maestro failed with exit code ${result.code}`);
+  if (!state.streamCut) throw new Error("The proxy did not interrupt an agent stream");
+  if (!state.statuses.includes("persisted"))
+    throw new Error(`Turn recovery never reached persisted: ${state.statuses.join(", ")}`);
+  process.stdout.write("agent turn recovery e2e passed\n");
+} finally {
+  await stop(metro.child);
+  proxy.closeAllConnections();
+  await new Promise((resolve) => proxy.close(resolve));
+}

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -1,5 +1,6 @@
 import { AgentChat } from "@/components/agent/agent-chat";
 import { LineIcon } from "@/components/icon";
+import { AgentStreamInterruptedError } from "@/lib/agent";
 import { fireEvent, screen, waitFor } from "@testing-library/react-native";
 import { act } from "react";
 import { FlatList, KeyboardAvoidingView, Platform } from "react-native";
@@ -19,11 +20,13 @@ jest.mock("expo/fetch", () => ({ fetch: jest.fn() }));
 const mockStreamAgentMessage = jest.fn();
 const mockExecuteAgentAction = jest.fn();
 const mockFetchLatestAgentConversation = jest.fn();
+const mockFetchAgentTurnStatus = jest.fn();
 jest.mock("@/lib/agent", () => ({
   ...jest.requireActual("@/lib/agent"),
   streamAgentMessage: (...args: unknown[]) => mockStreamAgentMessage(...args),
   executeAgentAction: (...args: unknown[]) => mockExecuteAgentAction(...args),
   fetchLatestAgentConversation: (...args: unknown[]) => mockFetchLatestAgentConversation(...args),
+  fetchAgentTurnStatus: (...args: unknown[]) => mockFetchAgentTurnStatus(...args),
 }));
 
 const GREETING = "Hi! I'm your store assistant.";
@@ -241,6 +244,66 @@ describe("AgentChat", () => {
     });
 
     await waitFor(() => expect(screen.getByText("Sorry, I ran into a problem. Please try again.")).toBeTruthy());
+  });
+
+  it("adopts a turn the server persisted after the stream broke", async () => {
+    mockStreamAgentMessage.mockRejectedValue(new AgentStreamInterruptedError());
+    mockFetchAgentTurnStatus.mockResolvedValue({
+      status: "persisted",
+      conversationId: "conv-recovered",
+      message: { role: "assistant", content: "Your discount is ready.", proposal_message_id: "msg-7" },
+    });
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "Create a launch discount");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Your discount is ready.")).toBeTruthy(), { timeout: 10000 });
+    expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
+    expect(mockStreamAgentMessage).toHaveBeenCalledTimes(1);
+    expect(mockStreamAgentMessage.mock.calls[0][0].clientTurnId).toEqual(expect.any(String));
+    expect(mockFetchAgentTurnStatus.mock.calls[0][0]).toBe(mockStreamAgentMessage.mock.calls[0][0].clientTurnId);
+  });
+
+  it("keeps waiting while the server reports the interrupted turn is still generating", async () => {
+    mockStreamAgentMessage.mockRejectedValue(new AgentStreamInterruptedError());
+    mockFetchAgentTurnStatus
+      .mockResolvedValueOnce({ status: "in_progress" })
+      .mockResolvedValueOnce({ status: "in_progress" })
+      .mockResolvedValue({
+        status: "persisted",
+        conversationId: "conv-recovered",
+        message: { role: "assistant", content: "Here are your sales." },
+      });
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Here are your sales.")).toBeTruthy(), { timeout: 20000 });
+    expect(mockFetchAgentTurnStatus).toHaveBeenCalledTimes(3);
+  }, 30000);
+
+  it("shows the fallback message when the server says the interrupted turn never persisted", async () => {
+    mockStreamAgentMessage.mockRejectedValue(new AgentStreamInterruptedError());
+    mockFetchAgentTurnStatus.mockResolvedValue({ status: "failed" });
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Sorry, I ran into a problem. Please try again.")).toBeTruthy(), {
+      timeout: 10000,
+    });
   });
 
   it("shows an error message when applying a confirmed action fails", async () => {

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -87,6 +87,7 @@ describe("AgentChat", () => {
     expect(mockStreamAgentMessage).toHaveBeenCalledWith({
       accessToken: "test-token",
       conversationId: null,
+      clientTurnId: expect.stringMatching(/^[0-9a-f-]{1,64}$/),
       handlers: { onToken: expect.any(Function), onReset: expect.any(Function) },
       messages: [
         { role: "assistant", content: GREETING },
@@ -264,7 +265,7 @@ describe("AgentChat", () => {
     await waitFor(() => expect(screen.getByText("Your discount is ready.")).toBeTruthy(), { timeout: 10000 });
     expect(screen.queryByText("Sorry, I ran into a problem. Please try again.")).toBeNull();
     expect(mockStreamAgentMessage).toHaveBeenCalledTimes(1);
-    expect(mockStreamAgentMessage.mock.calls[0][0].clientTurnId).toEqual(expect.any(String));
+    expect(mockStreamAgentMessage.mock.calls[0][0].clientTurnId).toMatch(/^[0-9a-f-]{1,64}$/);
     expect(mockFetchAgentTurnStatus.mock.calls[0][0]).toBe(mockStreamAgentMessage.mock.calls[0][0].clientTurnId);
   });
 

--- a/tests/components/agent/agent-chat.test.tsx
+++ b/tests/components/agent/agent-chat.test.tsx
@@ -23,6 +23,15 @@ const mockFetchLatestAgentConversation = jest.fn();
 const mockFetchAgentTurnStatus = jest.fn();
 jest.mock("@/lib/agent", () => ({
   ...jest.requireActual("@/lib/agent"),
+  recoverAgentTurn: (
+    clientTurnId: string,
+    fetchStatus: (turnId: string, signal: AbortSignal) => Promise<unknown>,
+    options: { interruptionPhase?: "request" | "stream"; signal?: AbortSignal } = {},
+  ) =>
+    jest.requireActual("@/lib/agent").recoverAgentTurn(clientTurnId, fetchStatus, {
+      ...options,
+      pollIntervalMs: 0,
+    }),
   streamAgentMessage: (...args: unknown[]) => mockStreamAgentMessage(...args),
   executeAgentAction: (...args: unknown[]) => mockExecuteAgentAction(...args),
   fetchLatestAgentConversation: (...args: unknown[]) => mockFetchLatestAgentConversation(...args),
@@ -88,6 +97,7 @@ describe("AgentChat", () => {
       accessToken: "test-token",
       conversationId: null,
       clientTurnId: expect.stringMatching(/^[0-9a-f-]{1,64}$/),
+      signal: expect.any(AbortSignal),
       handlers: { onToken: expect.any(Function), onReset: expect.any(Function) },
       messages: [
         { role: "assistant", content: GREETING },
@@ -267,6 +277,104 @@ describe("AgentChat", () => {
     expect(mockStreamAgentMessage).toHaveBeenCalledTimes(1);
     expect(mockStreamAgentMessage.mock.calls[0][0].clientTurnId).toMatch(/^[0-9a-f-]{1,64}$/);
     expect(mockFetchAgentTurnStatus.mock.calls[0][0]).toBe(mockStreamAgentMessage.mock.calls[0][0].clientTurnId);
+  });
+
+  it("replaces a frozen partial reply with the activity indicator while recovering", async () => {
+    let resolveStatus!: (status: {
+      status: "persisted";
+      conversationId: string;
+      message: { role: "assistant"; content: string };
+    }) => void;
+    mockStreamAgentMessage.mockImplementation(({ handlers }: { handlers: { onToken: (text: string) => void } }) => {
+      handlers.onToken("A partial reply");
+      return Promise.reject(new AgentStreamInterruptedError());
+    });
+    mockFetchAgentTurnStatus.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveStatus = resolve;
+        }),
+    );
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Working on it...")).toBeTruthy());
+    expect(screen.queryByText("A partial reply")).toBeNull();
+
+    await act(async () => {
+      resolveStatus({
+        status: "persisted",
+        conversationId: "conv-recovered",
+        message: { role: "assistant", content: "The complete reply" },
+      });
+    });
+    await waitFor(() => expect(screen.getByText("The complete reply")).toBeTruthy());
+  });
+
+  it("aborts turn recovery when the chat unmounts", async () => {
+    let requestSignal: AbortSignal | undefined;
+    mockStreamAgentMessage.mockRejectedValue(new AgentStreamInterruptedError());
+    mockFetchAgentTurnStatus.mockImplementation((_turnId: string, _token: string, signal: AbortSignal) => {
+      requestSignal = signal;
+      return new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+      });
+    });
+
+    const { unmount } = renderChat();
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+    await waitFor(() => expect(mockFetchAgentTurnStatus).toHaveBeenCalledTimes(1));
+
+    unmount();
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(mockFetchAgentTurnStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not start recovery when the chat unmounts before its stream breaks", async () => {
+    let streamSignal: AbortSignal | undefined;
+    mockStreamAgentMessage.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      streamSignal = signal;
+      return new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => reject(new AgentStreamInterruptedError()), { once: true });
+      });
+    });
+
+    const { unmount } = renderChat();
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+    await waitFor(() => expect(mockStreamAgentMessage).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await act(async () => {});
+
+    expect(streamSignal?.aborted).toBe(true);
+    expect(mockFetchAgentTurnStatus).not.toHaveBeenCalled();
+  });
+
+  it("fails promptly when the request and recovery checks both find the device offline", async () => {
+    mockStreamAgentMessage.mockRejectedValue(new AgentStreamInterruptedError({ phase: "request" }));
+    mockFetchAgentTurnStatus.mockRejectedValue(new TypeError("Network request failed"));
+
+    renderChat();
+
+    fireEvent.changeText(screen.getByLabelText("Message"), "How are sales?");
+    await act(async () => {
+      fireEvent.press(screen.getByLabelText("Send"));
+    });
+
+    await waitFor(() => expect(screen.getByText("Sorry, I ran into a problem. Please try again.")).toBeTruthy());
+    expect(mockFetchAgentTurnStatus).toHaveBeenCalledTimes(2);
   });
 
   it("keeps waiting while the server reports the interrupted turn is still generating", async () => {

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -6,7 +6,7 @@ jest.mock("@/lib/env", () => ({
 const mockFetch = jest.fn();
 jest.mock("expo/fetch", () => ({ fetch: (...args: unknown[]) => mockFetch(...args) }));
 
-import { streamAgentMessage } from "@/lib/agent";
+import { AgentStreamInterruptedError, fetchAgentTurnStatus, streamAgentMessage } from "@/lib/agent";
 import { UnauthorizedError } from "@/lib/request";
 
 const encoder = new TextEncoder();
@@ -147,11 +147,92 @@ describe("streamAgentMessage", () => {
     ).rejects.toThrow("Agent stream request failed");
   });
 
-  it("throws when the stream ends without a done event", async () => {
+  it("throws AgentStreamInterruptedError when the stream ends without a done event", async () => {
     mockFetch.mockResolvedValue(streamResponse(['event: token\ndata: {"text":"Half a re']));
 
     await expect(
       streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
-    ).rejects.toThrow("Agent stream ended without a done event");
+    ).rejects.toThrow(AgentStreamInterruptedError);
+  });
+
+  it("sends the client turn id so a broken stream can be recovered by exact identity", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: done\ndata: {"reply":"Hi","proposed_action":null,"conversation_id":"conv-1"}\n\n']),
+    );
+
+    await streamAgentMessage({
+      messages: [{ role: "user", content: "Hi" }],
+      clientTurnId: "turn-abc",
+      accessToken: "token",
+    });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchObject({ client_turn_id: "turn-abc" });
+  });
+
+  it("omits the client turn id when none is given", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: done\ndata: {"reply":"Hi","proposed_action":null,"conversation_id":"conv-1"}\n\n']),
+    );
+
+    await streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" });
+
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).not.toHaveProperty("client_turn_id");
+  });
+});
+
+describe("fetchAgentTurnStatus", () => {
+  const mockGlobalFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockGlobalFetch as unknown as typeof global.fetch;
+  });
+
+  const jsonResponse = (payload: unknown) => ({
+    ok: true,
+    status: 200,
+    url: "https://api.example.com/mobile/agent/turns/turn-abc",
+    headers: { get: () => "application/json" },
+    json: () => Promise.resolve(payload),
+  });
+
+  it("returns the stored turn when the server persisted it", async () => {
+    mockGlobalFetch.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        status: "persisted",
+        conversation_id: "conv-9",
+        message: {
+          role: "assistant",
+          content: "Your product is ready to publish.",
+          proposed_action: { type: "api_write", params: { name: "Guide" }, summary: "Create Guide" },
+          proposal_message_id: "msg-7",
+        },
+      }),
+    );
+
+    await expect(fetchAgentTurnStatus("turn-abc", "token")).resolves.toEqual({
+      status: "persisted",
+      conversationId: "conv-9",
+      message: {
+        role: "assistant",
+        content: "Your product is ready to publish.",
+        proposed_action: { type: "api_write", params: { name: "Guide" }, summary: "Create Guide" },
+        proposal_message_id: "msg-7",
+      },
+    });
+    expect(mockGlobalFetch.mock.calls[0][0]).toContain("mobile/agent/turns/turn-abc");
+  });
+
+  it("reports a turn the server is still generating", async () => {
+    mockGlobalFetch.mockResolvedValue(jsonResponse({ success: true, status: "in_progress" }));
+
+    await expect(fetchAgentTurnStatus("turn-abc", "token")).resolves.toEqual({ status: "in_progress" });
+  });
+
+  it("throws the server's error when the turn id is rejected", async () => {
+    mockGlobalFetch.mockResolvedValue(jsonResponse({ success: false, error: "Invalid turn id." }));
+
+    await expect(fetchAgentTurnStatus("bad id", "token")).rejects.toThrow("Invalid turn id.");
   });
 });

--- a/tests/lib/agent.test.ts
+++ b/tests/lib/agent.test.ts
@@ -6,8 +6,14 @@ jest.mock("@/lib/env", () => ({
 const mockFetch = jest.fn();
 jest.mock("expo/fetch", () => ({ fetch: (...args: unknown[]) => mockFetch(...args) }));
 
-import { AgentStreamInterruptedError, fetchAgentTurnStatus, streamAgentMessage } from "@/lib/agent";
-import { UnauthorizedError } from "@/lib/request";
+import {
+  AgentStreamInterruptedError,
+  AgentTurnStatusError,
+  fetchAgentTurnStatus,
+  recoverAgentTurn,
+  streamAgentMessage,
+} from "@/lib/agent";
+import { RequestError, UnauthorizedError } from "@/lib/request";
 
 const encoder = new TextEncoder();
 
@@ -17,7 +23,8 @@ const streamResponse = (
     ok = true,
     status,
     contentType = "text/event-stream",
-  }: { ok?: boolean; status?: number; contentType?: string } = {},
+    readError,
+  }: { ok?: boolean; status?: number; contentType?: string; readError?: Error } = {},
 ) => {
   let index = 0;
   const cancel = jest.fn().mockResolvedValue(undefined);
@@ -30,7 +37,9 @@ const streamResponse = (
         read: () =>
           index < frames.length
             ? Promise.resolve({ value: encoder.encode(frames[index++]), done: false })
-            : Promise.resolve({ value: undefined, done: true }),
+            : readError
+              ? Promise.reject(readError)
+              : Promise.resolve({ value: undefined, done: true }),
         cancel,
       }),
     },
@@ -155,6 +164,96 @@ describe("streamAgentMessage", () => {
     ).rejects.toThrow(AgentStreamInterruptedError);
   });
 
+  it("preserves an initial stream request error when the request has no recoverable identity", async () => {
+    mockFetch.mockRejectedValue(new Error("The network connection was lost."));
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow("The network connection was lost.");
+  });
+
+  it("recovers an identified turn when the connection fails before response headers arrive", async () => {
+    const transportError = new Error("The network connection was lost.");
+    mockFetch.mockRejectedValue(transportError);
+
+    const stream = streamAgentMessage({
+      messages: [{ role: "user", content: "Hi" }],
+      clientTurnId: "turn-abc",
+      accessToken: "token",
+    });
+
+    await expect(stream).rejects.toMatchObject({
+      name: "AgentStreamInterruptedError",
+      cause: transportError,
+      phase: "request",
+    });
+  });
+
+  it("aborts the stream request when its caller leaves", async () => {
+    let requestSignal: AbortSignal | undefined;
+    mockFetch.mockImplementation((_url: string, options: { signal: AbortSignal }) => {
+      requestSignal = options.signal;
+      return new Promise<never>((_, reject) => {
+        options.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), {
+          once: true,
+        });
+      });
+    });
+    const controller = new AbortController();
+    const stream = streamAgentMessage({
+      messages: [{ role: "user", content: "Hi" }],
+      clientTurnId: "turn-abc",
+      accessToken: "token",
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expect(stream).rejects.toMatchObject({ name: "AbortError" });
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("preserves the reader error that interrupted an identified turn", async () => {
+    const transportError = new Error("The network connection was lost.");
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: token\ndata: {"text":"Half"}\n\n'], {
+        readError: transportError,
+      }),
+    );
+
+    await expect(
+      streamAgentMessage({
+        messages: [{ role: "user", content: "Hi" }],
+        clientTurnId: "turn-abc",
+        accessToken: "token",
+      }),
+    ).rejects.toMatchObject({ name: "AgentStreamInterruptedError", cause: transportError });
+  });
+
+  it("throws AgentStreamInterruptedError when the body reader rejects mid-stream", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: token\ndata: {"text":"Half"}\n\n'], {
+        readError: new Error("The network connection was lost."),
+      }),
+    );
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).rejects.toThrow(AgentStreamInterruptedError);
+  });
+
+  it("returns a completed turn without waiting for the stream to close", async () => {
+    mockFetch.mockResolvedValue(
+      streamResponse(['event: done\ndata: {"reply":"Hi","proposed_action":null,"conversation_id":"conv-1"}\n\n'], {
+        readError: new Error("The network connection was lost."),
+      }),
+    );
+
+    await expect(
+      streamAgentMessage({ messages: [{ role: "user", content: "Hi" }], accessToken: "token" }),
+    ).resolves.toMatchObject({ reply: "Hi", conversationId: "conv-1" });
+  });
+
   it("sends the client turn id so a broken stream can be recovered by exact identity", async () => {
     mockFetch.mockResolvedValue(
       streamResponse(['event: done\ndata: {"reply":"Hi","proposed_action":null,"conversation_id":"conv-1"}\n\n']),
@@ -180,12 +279,187 @@ describe("streamAgentMessage", () => {
   });
 });
 
+describe("recoverAgentTurn", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("adopts the persisted turn returned by the status endpoint", async () => {
+    const fetchStatus = jest.fn().mockResolvedValue({
+      status: "persisted",
+      conversationId: "conv-recovered",
+      message: {
+        role: "assistant",
+        content: "Recovered reply",
+        proposed_action: { type: "api_write", params: { name: "Guide" }, summary: "Create Guide" },
+        proposal_message_id: "msg-7",
+      },
+    });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    await expect(recovery).resolves.toEqual({
+      reply: "Recovered reply",
+      proposedAction: { type: "api_write", params: { name: "Guide" }, summary: "Create Guide" },
+      proposalMessageId: "msg-7",
+      conversationId: "conv-recovered",
+    });
+  });
+
+  it("aborts an in-flight status request at the recovery deadline", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const fetchStatus = jest.fn((_turnId: string, signal: AbortSignal) => {
+      requestSignal = signal;
+      return new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+      });
+    });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+    const rejection = expect(recovery).rejects.toThrow("Agent turn recovery timed out");
+
+    await jest.advanceTimersByTimeAsync(180_000);
+
+    await rejection;
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("aborts an in-flight status request and stops polling when the caller leaves", async () => {
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    const fetchStatus = jest.fn((_turnId: string, signal: AbortSignal) => {
+      requestSignal = signal;
+      return new Promise<never>((_, reject) => {
+        signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")), { once: true });
+      });
+    });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus, { signal: controller.signal });
+    const rejection = expect(recovery).rejects.toMatchObject({ name: "AbortError" });
+
+    await jest.advanceTimersByTimeAsync(3_000);
+    controller.abort();
+    await rejection;
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(requestSignal?.aborted).toBe(true);
+  });
+
+  it("does not start another status request when the poll delay reaches the deadline", async () => {
+    const fetchStatus = jest.fn(
+      () =>
+        new Promise<{ status: "in_progress" }>((resolve) => {
+          setTimeout(() => resolve({ status: "in_progress" }), 176_500);
+        }),
+    );
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+    const rejection = expect(recovery).rejects.toThrow("Agent turn recovery timed out");
+
+    await jest.advanceTimersByTimeAsync(180_000);
+
+    await rejection;
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps polling after consecutive network errors until the status endpoint recovers", async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockRejectedValueOnce(new TypeError("Network request failed"))
+      .mockResolvedValue({
+        status: "persisted",
+        conversationId: "conv-recovered",
+        message: { role: "assistant", content: "Recovered after reconnecting" },
+      });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+
+    await jest.advanceTimersByTimeAsync(9_000);
+
+    await expect(recovery).resolves.toMatchObject({
+      reply: "Recovered after reconnecting",
+      conversationId: "conv-recovered",
+    });
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("fails promptly when both an initial request and its status checks show the device is offline", async () => {
+    const fetchStatus = jest.fn().mockRejectedValue(new TypeError("Network request failed"));
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus, { interruptionPhase: "request" });
+    const rejection = expect(recovery).rejects.toThrow("Network request failed");
+
+    await jest.advanceTimersByTimeAsync(6_000);
+
+    await rejection;
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("declares a turn lost after two consecutive unknown statuses and resets that count on progress", async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "unknown" })
+      .mockResolvedValueOnce({ status: "in_progress" })
+      .mockResolvedValue({ status: "unknown" });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+    const rejection = expect(recovery).rejects.toThrow("Agent turn was lost");
+
+    await jest.advanceTimersByTimeAsync(12_000);
+
+    await rejection;
+    expect(fetchStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps checking an unknown request-phase turn because the server may not have armed its marker yet", async () => {
+    const fetchStatus = jest
+      .fn()
+      .mockResolvedValueOnce({ status: "unknown" })
+      .mockResolvedValueOnce({ status: "unknown" })
+      .mockResolvedValueOnce({ status: "unknown" })
+      .mockResolvedValue({
+        status: "persisted",
+        conversationId: "conv-recovered",
+        message: { role: "assistant", content: "Recovered slow request" },
+      });
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus, { interruptionPhase: "request" });
+
+    await jest.advanceTimersByTimeAsync(12_000);
+
+    await expect(recovery).resolves.toMatchObject({ reply: "Recovered slow request" });
+    expect(fetchStatus).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    new UnauthorizedError("Unauthorized"),
+    new RequestError(422, "Invalid turn id"),
+    new AgentTurnStatusError("Feature unavailable"),
+  ])("does not retry a non-retryable status error", async (error) => {
+    const fetchStatus = jest.fn().mockRejectedValue(error);
+    const recovery = recoverAgentTurn("turn-abc", fetchStatus);
+    const rejection = expect(recovery).rejects.toBe(error);
+
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    await rejection;
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("fetchAgentTurnStatus", () => {
   const mockGlobalFetch = jest.fn();
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     jest.clearAllMocks();
     global.fetch = mockGlobalFetch as unknown as typeof global.fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
   });
 
   const jsonResponse = (payload: unknown) => ({
@@ -226,13 +500,24 @@ describe("fetchAgentTurnStatus", () => {
 
   it("reports a turn the server is still generating", async () => {
     mockGlobalFetch.mockResolvedValue(jsonResponse({ success: true, status: "in_progress" }));
+    const controller = new AbortController();
 
-    await expect(fetchAgentTurnStatus("turn-abc", "token")).resolves.toEqual({ status: "in_progress" });
+    await expect(fetchAgentTurnStatus("turn-abc", "token", controller.signal)).resolves.toEqual({
+      status: "in_progress",
+    });
+    const requestSignal = mockGlobalFetch.mock.calls[0][1].signal as AbortSignal;
+    expect(requestSignal.aborted).toBe(false);
+
+    controller.abort();
+
+    expect(requestSignal.aborted).toBe(true);
   });
 
   it("throws the server's error when the turn id is rejected", async () => {
     mockGlobalFetch.mockResolvedValue(jsonResponse({ success: false, error: "Invalid turn id." }));
 
-    await expect(fetchAgentTurnStatus("bad id", "token")).rejects.toThrow("Invalid turn id.");
+    await expect(fetchAgentTurnStatus("bad id", "token")).rejects.toEqual(
+      expect.objectContaining({ name: "AgentTurnStatusError", message: "Invalid turn id." }),
+    );
   });
 });


### PR DESCRIPTION
Ref antiwork/gumroad-private#1727

## What

The mobile Agent chat now recovers a turn when its response stream breaks instead of treating the turn as failed.

Each send gets a stable `client_turn_id`. If the request or stream ends before the terminal event, the app asks the existing turn-status endpoint what happened to that exact turn. A persisted reply replaces the interrupted response, including its proposal and `proposal_message_id`; a failed or lost turn still shows the existing error.

Recovery has a hard three-minute wall-clock deadline. The deadline covers poll delays and in-flight status requests, so a slow request cannot keep the composer disabled past the budget. Leaving the screen cancels the stream, polling, and pending delays.

A proxy-driven Maestro flow now cuts the stream after its first token and verifies that the app adopts the persisted proposal without confirming it.

## Why

Before this change, a connection drop could show “Sorry, I ran into a problem” even after the server had accepted and persisted the turn. Retrying could then start a second turn for work the server had already completed.

The stream cannot resume, and sending the prompt again would create a new turn. Polling by `client_turn_id` is the only safe way to learn whether the original turn persisted without risking a duplicate proposal.

## Before/After

https://github.com/user-attachments/assets/da6ff2e1-5fa3-4e0c-88a1-381336df100e

Before: a mid-stream disconnect discards the partial response and ends with the generic failure message.

After: the partial response clears, the app shows “Working on it…” while it checks the original turn, then renders the recovered reply and proposal when the server reports `persisted`.

The recording uses an iPhone 17 Simulator on iOS 26.4. The app, authentication, and ordinary API requests point to production. The Agent stream and turn-status responses use a deterministic proxy fixture because the available production accounts receive `403` from the Agent endpoints. The fixture sends one token, cuts the socket, reports `in_progress`, then returns the persisted proposal. It validates the client recovery flow, not production Agent access or model output.

## Test Results

- Full Jest suite: 53 suites and 544 tests passed.
- Focused Agent suites: 72 tests passed.
- TypeScript: passed.
- Lint: passed with two pre-existing warnings outside this change.
- iOS Simulator recovery flow: passed; the fallback message stayed hidden and the recovered proposal rendered with Confirm enabled.
- CI `test`, `launch smoke (no backend)`, and Greptile Review: passed at `7bd5f16`.
- Claude Fable 5 autoreview with high reasoning: no findings.

---

The initial implementation used Hermes Agent with Claude Opus 5. Follow-up fixes, tests, and Simulator validation used Codex with GPT-5.6 Sol. Claude Fable 5 performed the final autoreview.
