### PR TITLE
Enable podcast-style background video playback on iOS

### DIFF
--- a/.maestro/background-video-playback.yaml
+++ b/.maestro/background-video-playback.yaml
@@ -1,0 +1,45 @@
+appId: ${APP_ID}
+---
+# iOS-only: PR #345 restored background/lock-screen playback on iOS after PR #215's
+# blanket AppState pause (added for an Android-only media3 ANR) had killed it there too.
+# Android intentionally still pauses on background, so this flow only runs on iOS.
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - runFlow:
+          file: utils/sign-in.yaml
+          env:
+            EMAIL: mobile_buyer_do_not_edit@gumroad.com
+            PASSWORD: password
+      - tapOn: ".*Mobile Test Product 1.*"
+      - extendedWaitUntil:
+          visible: Mobile Test Video
+          timeout: 30000
+      - tapOn: "Watch|Watch again"
+      - extendedWaitUntil:
+          visible:
+            id: video-player
+          timeout: 20000
+      - assertNotVisible: This video failed to load
+      # Get past the earliest few seconds so the later "played through background" check
+      # can't be satisfied by a video that was already this far along before backgrounding.
+      - extendedWaitUntil:
+          visible: "Video playback started, 0:0[2-4] of 0:10"
+          timeout: 20000
+      # Background the app without stopping the process — pressKey: Home leaves audio
+      # session playback running, which is exactly the behavior this PR restored.
+      - pressKey: Home
+      - extendedWaitUntil:
+          visible: "Video playback started, 0:0[2-4] of 0:10"
+          timeout: 20000
+          notVisible: true
+      - launchApp:
+          stopApp: false
+      # If background playback had silently paused (the pre-#345 regression), the timer
+      # would still read the position from just before backgrounding. Assert it has moved
+      # forward instead of just being present, so a paused-but-rendered UI can't pass.
+      - extendedWaitUntil:
+          visible: "Video playback started, 0:0[5-9] of 0:10"
+          timeout: 20000
+      - assertNotVisible: This video failed to load

--- a/.maestro/background-video-playback.yaml
+++ b/.maestro/background-video-playback.yaml
@@ -22,30 +22,31 @@ appId: ${APP_ID}
             id: video-player
           timeout: 20000
       - assertNotVisible: This video failed to load
-      # Get past the earliest few seconds so the later "played through background" check
-      # can't be satisfied by a video that was already this far along before backgrounding.
+      # Narrow window so the margin below is computed against a known worst case,
+      # not a range that could itself eat into the post-relaunch wait budget.
       - extendedWaitUntil:
-          visible: "Video playback started, 0:0[2-4] of 0:10"
+          visible: "Video playback started, 0:0[1-2] of 0:10"
           timeout: 20000
       # Background the app without stopping the process — pressKey: Home leaves audio
       # session playback running, which is exactly the behavior this PR restored.
       - pressKey: Home
-      # Hold the background for a fixed ~5s (the tap-sleep idiom used elsewhere in this
-      # repo, e.g. audio-restart-resume.yaml) instead of just asserting the pre-background
-      # position disappeared — that only proves the app left foreground, not that playback
-      # kept running while it was gone.
+      # `tapOn` with `repeat: N` fires N taps separated by (N-1) `delay` waits — repeat: 2
+      # gives exactly ONE delay period, not repeat*delay. This hold is real ~6s (not the
+      # previous ~5s label, which the actual repeat:2/delay:2500 config only delivered ~2.5s
+      # of), matching the tap-sleep idiom in audio-restart-resume.yaml / flaky-network-recovery.yaml.
       - tapOn:
           point: "1%,1%"
           repeat: 2
-          delay: 2500
+          delay: 6000
       - launchApp:
           stopApp: false
-      # Assert the advance immediately, with a tight timeout. A player that paused on
-      # background and only resumed on reopen would still read ~0:02-0:04 here and need
-      # several more seconds of real playback to reach this range — a short timeout is
-      # what turns "resumed on reopen" and "kept playing while backgrounded" into two
-      # different, distinguishable outcomes instead of both passing this assertion.
+      # Assert the advance with a short, tight post-launch window. Worst case for a
+      # resume-on-reopen player: it paused at the top of the pre-background window (0:02)
+      # and only starts advancing again after relaunch, so in this 2s wait it can reach at
+      # most 0:04 — well short of the 0:08 (0:02 + ~6s real background) a genuinely
+      # continuous player lands at. That gap is what makes "resumed on reopen" and "kept
+      # playing while backgrounded" distinguishable instead of both passing.
       - extendedWaitUntil:
           visible: "Video playback started, 0:0[7-9] of 0:10"
-          timeout: 3000
+          timeout: 2000
       - assertNotVisible: This video failed to load

--- a/.maestro/background-video-playback.yaml
+++ b/.maestro/background-video-playback.yaml
@@ -30,16 +30,22 @@ appId: ${APP_ID}
       # Background the app without stopping the process — pressKey: Home leaves audio
       # session playback running, which is exactly the behavior this PR restored.
       - pressKey: Home
-      - extendedWaitUntil:
-          visible: "Video playback started, 0:0[2-4] of 0:10"
-          timeout: 20000
-          notVisible: true
+      # Hold the background for a fixed ~5s (the tap-sleep idiom used elsewhere in this
+      # repo, e.g. audio-restart-resume.yaml) instead of just asserting the pre-background
+      # position disappeared — that only proves the app left foreground, not that playback
+      # kept running while it was gone.
+      - tapOn:
+          point: "1%,1%"
+          repeat: 2
+          delay: 2500
       - launchApp:
           stopApp: false
-      # If background playback had silently paused (the pre-#345 regression), the timer
-      # would still read the position from just before backgrounding. Assert it has moved
-      # forward instead of just being present, so a paused-but-rendered UI can't pass.
+      # Assert the advance immediately, with a tight timeout. A player that paused on
+      # background and only resumed on reopen would still read ~0:02-0:04 here and need
+      # several more seconds of real playback to reach this range — a short timeout is
+      # what turns "resumed on reopen" and "kept playing while backgrounded" into two
+      # different, distinguishable outcomes instead of both passing this assertion.
       - extendedWaitUntil:
-          visible: "Video playback started, 0:0[5-9] of 0:10"
-          timeout: 20000
+          visible: "Video playback started, 0:0[7-9] of 0:10"
+          timeout: 3000
       - assertNotVisible: This video failed to load

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -290,8 +290,6 @@ export default function VideoPlayerScreen() {
   const player = useVideoPlayer(videoUrl, (player) => {
     player.loop = false;
     player.allowsExternalPlayback = true;
-    // The media3 background session caused an Android-only ANR (see the AppState pause
-    // effect below), so only iOS gets podcast-style playback with the screen locked/backgrounded.
     player.staysActiveInBackground = Platform.OS === "ios";
     player.timeUpdateEventInterval = 0.25;
     const pendingResume = pendingSourceResumeRef.current;
@@ -313,9 +311,8 @@ export default function VideoPlayerScreen() {
   const positionBeforeBackgroundRef = useRef<number | null>(null);
 
   useEffect(() => {
-    // iOS gets staysActiveInBackground = true above, so it keeps playing on lock/background
-    // (podcast-style) without this pause/resume dance. Android still forces a pause here because
-    // media3's background session ANRs (see PR #215) — expo-video has not shipped a fix.
+    // Scoped to Android: iOS already gets background playback via staysActiveInBackground
+    // above; the media3 background session ANRs on Android (see PR #215).
     if (Platform.OS !== "android") return;
 
     const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {

--- a/app/video-player.tsx
+++ b/app/video-player.tsx
@@ -290,7 +290,9 @@ export default function VideoPlayerScreen() {
   const player = useVideoPlayer(videoUrl, (player) => {
     player.loop = false;
     player.allowsExternalPlayback = true;
-    player.staysActiveInBackground = false;
+    // The media3 background session caused an Android-only ANR (see the AppState pause
+    // effect below), so only iOS gets podcast-style playback with the screen locked/backgrounded.
+    player.staysActiveInBackground = Platform.OS === "ios";
     player.timeUpdateEventInterval = 0.25;
     const pendingResume = pendingSourceResumeRef.current;
     pendingSourceResumeRef.current = null;
@@ -311,6 +313,11 @@ export default function VideoPlayerScreen() {
   const positionBeforeBackgroundRef = useRef<number | null>(null);
 
   useEffect(() => {
+    // iOS gets staysActiveInBackground = true above, so it keeps playing on lock/background
+    // (podcast-style) without this pause/resume dance. Android still forces a pause here because
+    // media3's background session ANRs (see PR #215) — expo-video has not shipped a fix.
+    if (Platform.OS !== "android") return;
+
     const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
       withReleasedPlayerGuard(() => {
         if (nextState === "background" || nextState === "inactive") {

--- a/tests/app/video-player.test.tsx
+++ b/tests/app/video-player.test.tsx
@@ -156,9 +156,15 @@ describe("VideoPlayerScreen", () => {
     jest.restoreAllMocks();
   });
 
-  it("sets staysActiveInBackground to false on player setup", () => {
-    renderScreen();
-    expect(mockPlayer.staysActiveInBackground).toBe(false);
+  it("sets staysActiveInBackground to false on player setup on Android", () => {
+    const originalPlatform = Platform.OS;
+    Object.defineProperty(Platform, "OS", { configurable: true, value: "android" });
+    try {
+      renderScreen();
+      expect(mockPlayer.staysActiveInBackground).toBe(false);
+    } finally {
+      Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatform });
+    }
   });
 
   it("exposes when playback advances", () => {
@@ -422,46 +428,139 @@ describe("VideoPlayerScreen", () => {
     });
   });
 
-  it("pauses the player when app goes to background", () => {
-    renderScreen();
+  // Backgrounding video is Android-only (see the platform split in app/video-player.tsx): iOS
+  // sets staysActiveInBackground = true and keeps playing, so it needs no pause/resume handling.
+  describe("app backgrounding (Android)", () => {
+    let originalPlatform: string;
 
-    act(() => {
-      appStateCallback!("background");
+    beforeEach(() => {
+      originalPlatform = Platform.OS;
+      Object.defineProperty(Platform, "OS", { configurable: true, value: "android" });
     });
 
-    expect(mockPlayer.pause).toHaveBeenCalled();
-  });
-
-  it("resumes the player when app returns to active if it was playing", () => {
-    renderScreen();
-    mockPlayer.playing = true;
-
-    act(() => {
-      appStateCallback!("background");
+    afterEach(() => {
+      Object.defineProperty(Platform, "OS", { configurable: true, value: originalPlatform });
     });
 
-    act(() => {
-      appStateCallback!("active");
+    it("pauses the player when app goes to background", () => {
+      renderScreen();
+
+      act(() => {
+        appStateCallback!("background");
+      });
+
+      expect(mockPlayer.pause).toHaveBeenCalled();
     });
 
-    expect(mockPlayer.play).toHaveBeenCalled();
-  });
+    it("resumes the player when app returns to active if it was playing", () => {
+      renderScreen();
+      mockPlayer.playing = true;
 
-  it("does not resume the player when app returns to active if it was not playing", () => {
-    renderScreen();
-    mockPlayer.playing = false;
+      act(() => {
+        appStateCallback!("background");
+      });
 
-    act(() => {
-      appStateCallback!("background");
+      act(() => {
+        appStateCallback!("active");
+      });
+
+      expect(mockPlayer.play).toHaveBeenCalled();
     });
 
-    mockPlayer.play.mockClear();
+    it("does not resume the player when app returns to active if it was not playing", () => {
+      renderScreen();
+      mockPlayer.playing = false;
 
-    act(() => {
-      appStateCallback!("active");
+      act(() => {
+        appStateCallback!("background");
+      });
+
+      mockPlayer.play.mockClear();
+
+      act(() => {
+        appStateCallback!("active");
+      });
+
+      expect(mockPlayer.play).not.toHaveBeenCalled();
     });
 
-    expect(mockPlayer.play).not.toHaveBeenCalled();
+    it("does not crash on background when the player has already been released", () => {
+      renderScreen();
+      mockPlayer.pause.mockImplementation(() => {
+        throw Object.assign(new Error("Cannot use shared object that was already released"), {
+          code: "ERR_USING_RELEASED_SHARED_OBJECT",
+        });
+      });
+
+      expect(() => act(() => appStateCallback!("background"))).not.toThrow();
+    });
+
+    it("does not crash on background when the player call fails with the iOS not-found exception", () => {
+      renderScreen();
+      mockPlayer.pause.mockImplementation(() => {
+        throw Object.assign(
+          new Error(
+            "Calling the 'pause' function has failed\n→ Caused by: Unable to find the native shared object associated with given JavaScript object",
+          ),
+          { code: "ERR_FUNCTION_CALL" },
+        );
+      });
+
+      expect(() => act(() => appStateCallback!("background"))).not.toThrow();
+    });
+
+    it("restores the playback position when returning from background", () => {
+      renderScreen();
+      mockPlayer.currentTime = 120;
+      mockPlayer.playing = true;
+
+      act(() => {
+        appStateCallback!("background");
+      });
+
+      mockPlayer.currentTime = 0;
+
+      act(() => {
+        appStateCallback!("active");
+      });
+
+      expect(mockPlayer.currentTime).toBe(120);
+    });
+
+    it("does not seek when the player has retained its position after returning from background", () => {
+      renderScreen();
+      mockPlayer.currentTime = 120;
+      mockPlayer.playing = true;
+
+      act(() => {
+        appStateCallback!("background");
+      });
+
+      mockPlayer.currentTime = 119.5;
+
+      act(() => {
+        appStateCallback!("active");
+      });
+
+      expect(mockPlayer.currentTime).toBe(119.5);
+    });
+
+    it("does not register an AppState listener on iOS, where the player stays active", () => {
+      Object.defineProperty(Platform, "OS", { configurable: true, value: "ios" });
+      jest.spyOn(AppState, "addEventListener").mockClear();
+
+      renderScreen();
+
+      expect(AppState.addEventListener).not.toHaveBeenCalled();
+    });
+
+    it("sets staysActiveInBackground to true on iOS", () => {
+      Object.defineProperty(Platform, "OS", { configurable: true, value: "ios" });
+
+      renderScreen();
+
+      expect(mockPlayer.staysActiveInBackground).toBe(true);
+    });
   });
 
   it("pauses the player on unmount", () => {
@@ -484,17 +583,6 @@ describe("VideoPlayerScreen", () => {
     expect(() => unmount()).not.toThrow();
   });
 
-  it("does not crash on background when the player has already been released", () => {
-    renderScreen();
-    mockPlayer.pause.mockImplementation(() => {
-      throw Object.assign(new Error("Cannot use shared object that was already released"), {
-        code: "ERR_USING_RELEASED_SHARED_OBJECT",
-      });
-    });
-
-    expect(() => act(() => appStateCallback!("background"))).not.toThrow();
-  });
-
   it("does not crash on unmount when the player call fails with the iOS not-found exception", () => {
     const { unmount } = renderScreen();
     mockPlayer.pause.mockImplementation(() => {
@@ -507,56 +595,6 @@ describe("VideoPlayerScreen", () => {
     });
 
     expect(() => unmount()).not.toThrow();
-  });
-
-  it("does not crash on background when the player call fails with the iOS not-found exception", () => {
-    renderScreen();
-    mockPlayer.pause.mockImplementation(() => {
-      throw Object.assign(
-        new Error(
-          "Calling the 'pause' function has failed\n→ Caused by: Unable to find the native shared object associated with given JavaScript object",
-        ),
-        { code: "ERR_FUNCTION_CALL" },
-      );
-    });
-
-    expect(() => act(() => appStateCallback!("background"))).not.toThrow();
-  });
-
-  it("restores the playback position when returning from background", () => {
-    renderScreen();
-    mockPlayer.currentTime = 120;
-    mockPlayer.playing = true;
-
-    act(() => {
-      appStateCallback!("background");
-    });
-
-    mockPlayer.currentTime = 0;
-
-    act(() => {
-      appStateCallback!("active");
-    });
-
-    expect(mockPlayer.currentTime).toBe(120);
-  });
-
-  it("does not seek when the player has retained its position after returning from background", () => {
-    renderScreen();
-    mockPlayer.currentTime = 120;
-    mockPlayer.playing = true;
-
-    act(() => {
-      appStateCallback!("background");
-    });
-
-    mockPlayer.currentTime = 119.5;
-
-    act(() => {
-      appStateCallback!("active");
-    });
-
-    expect(mockPlayer.currentTime).toBe(119.5);
   });
 
   it("renders an error message when the player reports an error status", () => {


### PR DESCRIPTION
## What

Enables podcast-style background/lock-screen video playback on iOS. Android is unchanged
(still pauses on background/inactive).

## Why

gumroad-private#1896: a buyer asked why the app pauses video the moment the screen locks or the
app is backgrounded, and wants "listen like a podcast" behavior back. PR #215 added a blanket
`AppState`-driven pause on both platforms to fix an Android-only media3 ANR
(`androidx.media3.common.util.Util.intToStringMaxRadix` in `ExpoVideoPlaybackService`,
Sentry 7445669840). That trade-off killed background video for iOS too, even though the ANR is
Android-specific — `expo-video`'s iOS `staysActiveInBackground` implementation is a separate
`AVAudioSession` path (`VideoManager.swift`) with no dependency on the Android `MediaSessionService`
that ANRs.

Root-causing the ANR itself (rather than avoiding it) would need an on-device Android repro I
can't run from this sandbox, and Sahil's "Fix" comment came in before a direction was picked — so
this ships the low-risk, reversible half of the two options the issue named: split the pause
behavior by platform instead of rewriting the Android media-session handling.

Audio-only background playback for video products (the issue's other named option) is a
separate, larger feature build — it needs a decision on the resume-to-video UX and whether it
hands off to the existing `track-player-service.ts` audio pipeline — and is not part of this PR.

## Before / After

- Before: locking the phone or backgrounding the app pauses video playback on **both** iOS and
  Android.
- After: **iOS** keeps playing through lock/background (matches the existing audio player's
  behavior). **Android** is unchanged — still pauses, since the ANR fix upstream hasn't shipped.

## Test Results

- `npx jest tests/app/video-player.test.tsx` — 62/62 passing (moved the background-pause specs
  under an Android-scoped `describe`, added two new specs for the iOS behavior: no `AppState`
  listener registered, `staysActiveInBackground` true).
- Mutation-checked the platform split by hand: reverting `staysActiveInBackground` to always
  `false` fails 1 spec; removing the Android guard in the `AppState` effect fails 1 spec (both
  killed cleanly, run in this session).
- `npx tsc --noEmit` — clean.
- `npx expo lint app/video-player.tsx tests/app/video-player.test.tsx` — same 6 pre-existing
  warnings as on `main` (verified diff against baseline), 0 new errors/warnings.

## QA steps

No rendered surface change beyond existing player controls — this is a background-lifecycle
behavior change, not a UI change. No on-device Android/iOS build was run in this sandbox (no
Android emulator/adb, no booted iOS lock-screen test); the unit-test mutation proof above is the
evidence this sandbox can produce. Real-device QA (lock the phone mid-video on an iOS build,
confirm playback continues and Now Playing controls work; confirm Android still pauses) is owed
before merge.

**2026-08-10 update (30d9862):** @nyomanjyotisa flagged that the Maestro flow could pass after
playback merely resumed on reopen instead of continuing through the background. Fixed: the flow
now holds the background for a fixed ~2.5s, then asserts the advance with a tight 3s timeout — a
resume-on-reopen player can't reach the later timestamp that fast, so only the real fix passes.
Not run on a device in this sandbox (same gap as above); real-device QA is still owed and unchanged
by this commit.

## Status

- [x] Scope — confirmed against code and PR #215.
- [x] Design — platform split, scoped to the low-risk half of the two options the issue named.
- [x] Build — pushed, tests/typecheck/lint green.
- [ ] QA — real-device lock-screen check owed (see QA steps).
- [ ] Shipped
- [ ] Market
- [ ] Sell

---
🤖 Generated with claude-sonnet-5



Premerge review: clean @ cf7c0779852bfeb9fcb3779fb64d021cf1df1a6a

---
**Ownership note (2026-08-08):** Marked awaiting-human — closes gp#1896 pending merge. Tests/typecheck/lint green; real-device lock-screen QA (see QA steps above) is still owed before merge and has NOT been performed — @nyomanjyotisa, needs a physical iOS device to confirm lock-screen playback continues and Android still pauses.


