### PR TITLE
Fix walkthrough script leaving generated caller test on interrupted runs

### DIFF
--- a/qa-media/pr-mobile-proposal-message-id-walkthrough.sh
+++ b/qa-media/pr-mobile-proposal-message-id-walkthrough.sh
@@ -20,10 +20,17 @@ REL_HARNESS="tests/components/agent/proposal-id-walkthrough.test.tsx"
 HARNESS_SRC="$(mktemp -t pmid-harness.XXXXXX)"
 BEFORE_WT="$(mktemp -d -t pmid-before-worktree.XXXXXX)"
 
+HARNESS_INSTALLED=0
+
 cleanup() {
   git worktree remove --force "$BEFORE_WT" 2>/dev/null || rm -rf "$BEFORE_WT"
   rm -f "$HARNESS_SRC"
-  rm -f "$ROOT/$REL_HARNESS"
+  # Only remove the caller-checkout copy if THIS run actually wrote it. Removing
+  # it unconditionally deletes a pre-existing, untracked file the caller owns
+  # when the script exits before it ever copies its own harness in.
+  if [ "$HARNESS_INSTALLED" = 1 ]; then
+    rm -f "$ROOT/$REL_HARNESS"
+  fi
 }
 trap cleanup EXIT
 
@@ -132,6 +139,7 @@ cp "$HARNESS_SRC" "$BEFORE_WT/$REL_HARNESS"
 # over or restored, so an interrupted run leaves this checkout exactly as the caller had it.
 mkdir -p "$ROOT/$(dirname "$REL_HARNESS")"
 cp "$HARNESS_SRC" "$ROOT/$REL_HARNESS"
+HARNESS_INSTALLED=1
 {
   echo "=== $BRANCH (after) ==="
   report_in "$ROOT"

--- a/qa-media/pr-mobile-proposal-message-id-walkthrough.sh
+++ b/qa-media/pr-mobile-proposal-message-id-walkthrough.sh
@@ -23,6 +23,7 @@ BEFORE_WT="$(mktemp -d -t pmid-before-worktree.XXXXXX)"
 cleanup() {
   git worktree remove --force "$BEFORE_WT" 2>/dev/null || rm -rf "$BEFORE_WT"
   rm -f "$HARNESS_SRC"
+  rm -f "$ROOT/$REL_HARNESS"
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## What

Follow-up to the merged #344: fixes the remaining Greptile P1 it left open — an
interrupted run of `qa-media/pr-mobile-proposal-message-id-walkthrough.sh`
still left the generated caller-side Jest test
(`tests/components/agent/proposal-id-walkthrough.test.tsx`) untracked in the
caller's checkout.

## Why

`cleanup()` only removed the detached "before" worktree and the temp harness
source; it never removed the copy the script makes into the caller's own
tree at `$ROOT/$REL_HARNESS`. A SIGTERM after that copy (but before the
normal-path `rm` near the end of the script) leaves the file behind.

Greptile then flagged the fix itself: the EXIT trap removed
`$ROOT/$REL_HARNESS` unconditionally, so a run that exits *before* copying its
own harness in (e.g. the detached-worktree setup fails first) deletes a
pre-existing, untracked file of the same name that the caller already owned.

## Before / after

Round 1: one line added to `cleanup()`: `rm -f "$ROOT/$REL_HARNESS"`.

Round 2 (this push): track whether this invocation actually installed the
harness (`HARNESS_INSTALLED` flag, set right after the `cp` into `$ROOT`) and
gate the EXIT trap's removal on that flag. The unconditional `rm` at the end
of a successful normal run is unchanged — only the trap needed the
ownership check.

## Tests

No unit tests apply — shell QA harness, not product code.

## QA

Reproduced against pre-fix code, then confirmed both rounds of the fix on a
fresh checkout of this branch:

1. Pre-fix (merged #344 code), normal run: script completes, caller test
   cleaned up.
2. Pre-fix, `timeout`/early interruption: caller test left behind,
   untracked — reproduces the original P1.
3. Round-1 fix, Greptile's scenario: seeded a pre-existing untracked
   `tests/components/agent/proposal-id-walkthrough.test.tsx` sentinel, then
   forced the script to exit (bad `git worktree add` ref) *before* it copies
   its own harness in. Confirmed the sentinel was deleted anyway —
   reproduced Greptile's P1 exactly.
4. Round-2 fix (`f406781`), same seeded-sentinel + early-exit scenario on a
   fresh clone of the shipped commit: sentinel survives untouched.
5. Round-2 fix, full normal run: completes, own harness cleaned up, no
   leftover worktree.

No rendered UI surface — dev-tooling script, no screenshot/video applies.

## Status

- [x] Scope — remove the generated caller-side Jest test in `cleanup()` (Greptile P1 on #344); then make that removal ownership-aware (Greptile P1 on this PR)
- [x] Design — track installation with a flag, gate the EXIT trap's removal on it
- [x] Build — pushed (`f406781`)
- [x] QA — reproduced both P1s pre-fix, verified both fixes post-fix (above)
- [x] Shipped — pushed to `fix/gp344-walkthrough-cleanup-caller-test`
- [ ] Market — n/a, internal dev tooling
- [ ] Sell — n/a, internal dev tooling

---

Premerge review: clean @ f406781f79177f5b8bfd19bb58ad157d51ffe7ec (autoreview --engine codex, no accepted findings)

AI disclosure: this PR was authored autonomously by an AI agent (claude-sonnet-5) responding to Greptile review findings, including one left open on the merged #344 and one on this PR's own first commit.

