### PR TITLE
Add explicit QA checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,6 +29,7 @@ Issue: #
 - [ ] I have watched [Gumroad PR review livestreams](https://www.youtube.com/@anti-work)
 - [ ] I have performed a self-review and left review comments on my PR
 - [ ] I have added/updated tests for my changes
+- [ ] QA — I have exercised this change (click-path, console transcript, or API call) and confirmed the described behavior
 
 ---
 


### PR DESCRIPTION
## What
Adds a `- [ ] QA` line to the PR template's Checklist section.

## Why
Sahil asked for QA to be one of the checkbox items on every PR so the QA state is trackable at a glance, alongside the other checklist items (contributing guidelines read, self-review, tests added).

## Before / after
- Before: checklist had no explicit QA item — QA state, if mentioned, lived only in free-text.
- After: checklist has `- [ ] QA — I have exercised this change (click-path, console transcript, or API call) and confirmed the described behavior`.

## Tests
Docs-only change to `.github/PULL_REQUEST_TEMPLATE.md`; no code path affected.

## QA
Rendered the template locally as markdown — new checkbox line displays correctly alongside the existing checklist.

Premerge review: exempt (docs-only PR-template text edit, no code path)

---
AI disclosure: claude-sonnet-5 (Anthropic). Instructions: add a QA checkbox to PR templates so PR state is easy to track, per Sahil's direct request.